### PR TITLE
Add default sshkey pair

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -8,7 +8,6 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/exoscale/egoscale"
@@ -190,14 +189,6 @@ Let's start over.
 	}
 
 	account.DefaultZone = defaultZone
-
-	defaultSSHKey, err := chooseSSHKey(account.Name, client)
-	if err != nil {
-		return nil, err
-	}
-
-	account.DefaultSSHKey = defaultSSHKey
-
 	account.DNSEndpoint = strings.Replace(account.Endpoint, "/compute", "/dns", 1)
 
 	return account, nil
@@ -408,15 +399,7 @@ func importCloudstackINI(option, csPath, cfgPath string) error {
 		if err != nil {
 			return err
 		}
-
 		csAccount.DefaultZone = defaultZone
-
-		defaultSSHKey, err := chooseSSHKey(csAccount.Name, csClient)
-		if err != nil {
-			return err
-		}
-
-		csAccount.DefaultSSHKey = defaultSSHKey
 
 		isDefault := false
 		if askQuestion(fmt.Sprintf("Is %q your default profile?", csAccount.Name)) {
@@ -587,57 +570,6 @@ func chooseZone(accountName string, cs *egoscale.Client) (string, error) {
 		}
 	}
 	return defaultZone, nil
-}
-
-func chooseSSHKey(accountName string, cs *egoscale.Client) (string, error) {
-
-	reader := bufio.NewReader(os.Stdin)
-
-	sshKeys, err := getSSHKeys(cs)
-	if err != nil {
-		return "", err
-	}
-
-	if len(sshKeys) == 0 {
-		return "", nil
-	}
-
-	fmt.Printf("Choose %q default sshkey pair:\n", accountName)
-
-	for i, sshkey := range sshKeys {
-		fmt.Printf("%d: %s\n", i+1, sshkey.Name)
-	}
-
-	sshkeyIndex, err := readInput(reader, "Select", "none")
-	if err != nil {
-		return "", err
-	}
-
-	if sshkeyIndex == "none" {
-		return "", nil
-	}
-
-	defaultKeyPair, ok := getSelectedKeyPair(sshkeyIndex, sshKeys)
-	for !ok {
-		fmt.Println("Error: Invalid sshkey pair number")
-		defaultKeyPair, err = chooseSSHKey(accountName, cs)
-		if err == nil {
-			break
-		}
-	}
-	return defaultKeyPair, nil
-}
-
-func getSelectedKeyPair(index string, sshKeys []egoscale.SSHKeyPair) (string, bool) {
-	i, err := strconv.ParseInt(index, 10, 64)
-	if err != nil {
-		return "", false
-	}
-	if i <= 0 || i > int64(len(sshKeys)) {
-		return "", false
-	}
-
-	return sshKeys[i-1].Name, true
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,6 +49,7 @@ type account struct {
 	Key             string
 	Secret          string
 	DefaultZone     string
+	DefaultSSHKey   string
 	DefaultTemplate string
 }
 

--- a/cmd/sshkey_list.go
+++ b/cmd/sshkey_list.go
@@ -76,11 +76,11 @@ func getSSHKeys(cs *egoscale.Client) ([]egoscale.SSHKeyPair, error) {
 		return nil, err
 	}
 
-	res := make([]egoscale.SSHKeyPair, 0, len(sshKeys))
+	res := make([]egoscale.SSHKeyPair, len(sshKeys))
 
-	for _, key := range sshKeys {
+	for i, key := range sshKeys {
 		k := key.(*egoscale.SSHKeyPair)
-		res = append(res, *k)
+		res[i] = *k
 	}
 
 	return res, nil

--- a/cmd/sshkey_list.go
+++ b/cmd/sshkey_list.go
@@ -27,17 +27,14 @@ var listCmd = &cobra.Command{
 }
 
 func listSSHKey(t *table.Table, filters []string) error {
-	sshKey := &egoscale.SSHKeyPair{}
-	sshKeys, err := cs.ListWithContext(gContext, sshKey)
+	sshKeys, err := getSSHKeys(cs)
 	if err != nil {
 		return err
 	}
 
 	data := make([][]string, 0)
 
-	for _, key := range sshKeys {
-		k := key.(*egoscale.SSHKeyPair)
-
+	for _, k := range sshKeys {
 		keep := true
 		if len(filters) > 0 {
 			keep = false
@@ -71,6 +68,22 @@ func listSSHKey(t *table.Table, filters []string) error {
 	t.AppendBulk(data)
 
 	return nil
+}
+
+func getSSHKeys(cs *egoscale.Client) ([]egoscale.SSHKeyPair, error) {
+	sshKeys, err := cs.ListWithContext(gContext, &egoscale.SSHKeyPair{})
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]egoscale.SSHKeyPair, 0, len(sshKeys))
+
+	for _, key := range sshKeys {
+		k := key.(*egoscale.SSHKeyPair)
+		res = append(res, *k)
+	}
+
+	return res, nil
 }
 
 func init() {

--- a/cmd/vm_create.go
+++ b/cmd/vm_create.go
@@ -76,6 +76,10 @@ var vmCreateCmd = &cobra.Command{
 			return err
 		}
 
+		if keypair == "" && gCurrentAccount.DefaultSSHKey != "" {
+			keypair = gCurrentAccount.DefaultSSHKey
+		}
+
 		sg, err := cmd.Flags().GetString("security-group")
 		if err != nil {
 			return err

--- a/cmd/vm_create.go
+++ b/cmd/vm_create.go
@@ -76,7 +76,7 @@ var vmCreateCmd = &cobra.Command{
 			return err
 		}
 
-		if keypair == "" && gCurrentAccount.DefaultSSHKey != "" {
+		if keypair == "" {
 			keypair = gCurrentAccount.DefaultSSHKey
 		}
 


### PR DESCRIPTION
Example

you can choose a default sshkey pair
```
[[accounts]]
  account = "exoscale-1"
  computeEndpoint = "https://api.exoscale.ch/compute"
  defaultSSHKey = ""
  defaultTemplate = "Linux Ubuntu 18.04 LTS 64-bit"
  defaultZone = "ch-gva-2"
  key = "XXXXXXX"
  name = "account-test"
  secret = "XXXXX"
```
or you can leave it blank if you don't want default sshkey pair.

https://github.com/exoscale/cli/issues/15
It's used when you want to deploy a virtual machine if you have a default sshkey pair exo will use this key