### PR TITLE
api: add missing vm-group calls

### DIFF
--- a/cmd/api_layout.go
+++ b/cmd/api_layout.go
@@ -154,7 +154,9 @@ var methods = []category{
 		"VM group management",
 		[]cmd{
 			{&egoscale.CreateInstanceGroup{}, "create", gCreateAlias},
+			{&egoscale.DeleteInstanceGroup{}, "delete", gDeleteAlias},
 			{&egoscale.ListInstanceGroups{}, "list", gListAlias},
+			{&egoscale.UpdateInstanceGroup{}, "update", nil},
 		},
 	},
 	{


### PR DESCRIPTION
delete and update were missing.

```console
% exo api vm-group                                                                                                          
VM group management                                                                                                                          
                                                                                                                                             
Usage:                                                                                                                                       
  exo api vm-group [command]                                                                                                                 
                  
Aliases:  
  vm-group, vg
                                    
Available Commands:
  create      Creates a vm group
  delete      Deletes a vm group                                                                                                             
  list        Lists vm groups        
  update      Updates a vm group
```