### PR TITLE
Add the Cloudstack updateVmNicIp call

### DIFF
--- a/cmd/privnet.go
+++ b/cmd/privnet.go
@@ -69,7 +69,7 @@ func dhcpRange(startIP, endIP, netmask net.IP) string {
 }
 
 // dhcpRange returns the string representation for a DHCP
-func nicIP(nic *egoscale.Nic) string {
+func nicIP(nic egoscale.Nic) string {
 	ip := nic.IPAddress
 	if ip != nil {
 		return ip.String()

--- a/cmd/privnet_associate.go
+++ b/cmd/privnet_associate.go
@@ -47,7 +47,7 @@ var privnetAssociateCmd = &cobra.Command{
 					}
 					table.Append([]string{
 						vm.DisplayName,
-						nicIP(nic)})
+						nicIP(*nic)})
 					i = i + 1
 					continue
 				}
@@ -58,7 +58,7 @@ var privnetAssociateCmd = &cobra.Command{
 			}
 			table.Append([]string{
 				vm.DisplayName,
-				nicIP(nic)})
+				nicIP(*nic)})
 		}
 		w.Flush() // nolint: errcheck
 		table.Render()

--- a/cmd/privnet_show.go
+++ b/cmd/privnet_show.go
@@ -50,7 +50,7 @@ var privnetShowCmd = &cobra.Command{
 					vm.ID.String(),
 					vm.Name,
 					vm.IP().String(),
-					nicIP(privateNic),
+					nicIP(*privateNic),
 				})
 			}
 			table.Render()

--- a/cmd/vm_update_ip.go
+++ b/cmd/vm_update_ip.go
@@ -61,17 +61,17 @@ func updateNicIP(nicID *egoscale.UUID, newIP string) (*egoscale.VirtualMachine, 
 
 func showVMWithNics(vm *egoscale.VirtualMachine) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.TabIndent)
-	fmt.Fprintf(w, "\nInstance ID\t%s\n", vm.ID) // nolint: errcheck
-	fmt.Fprintf(w, "Name\t%s\n", vm.DisplayName) // nolint: errcheck
+	fmt.Fprintf(w, "\nInstance ID:\t%s\n", vm.ID) // nolint: errcheck
+	fmt.Fprintf(w, "Name:\t%s\n", vm.DisplayName) // nolint: errcheck
 	if vm.DisplayName != vm.Name {
-		fmt.Fprintf(w, "Hostname\t%s\n", vm.Name) // nolint: errcheck
+		fmt.Fprintf(w, "Hostname:\t%s\n", vm.Name) // nolint: errcheck
 	}
 
-	fmt.Fprintf(w, "Network Interfaces\n") // nolint: errcheck
+	fmt.Fprintf(w, "Network Interfaces:\n") // nolint: errcheck
 	defaultNic := vm.DefaultNic()
 	if defaultNic != nil {
-		fmt.Fprintf(w, "-\tNetwork\tPublic\n")                           // nolint: errcheck
-		fmt.Fprintf(w, " \tPublic\t%s\n", defaultNic.IPAddress.String()) // nolint: errcheck
+		fmt.Fprintf(w, "-\tNetwork:\tPublic\n")                               // nolint: errcheck
+		fmt.Fprintf(w, " \tIP Address:\t%s\n", defaultNic.IPAddress.String()) // nolint: errcheck
 	}
 	for _, nic := range vm.Nic {
 		if nic.IsDefault {
@@ -86,12 +86,12 @@ func showVMWithNics(vm *egoscale.VirtualMachine) error {
 				networkName = network.ID.String()
 			}
 
-			fmt.Fprintf(w, "-\tNetwork\t%s\n", networkName)
+			fmt.Fprintf(w, "-\tNetwork:\t%s\n", networkName)
 			if network.Name == "" {
-				fmt.Fprintf(w, " \tID\t%s\n", network.ID.String())
+				fmt.Fprintf(w, " \tID:\t%s\n", network.ID.String())
 			}
 
-			fmt.Fprintf(w, " \tIP\t%s\n", nicIP(nic))
+			fmt.Fprintf(w, " \tIP Address:\t%s\n", nicIP(nic))
 		}
 	}
 
@@ -100,5 +100,5 @@ func showVMWithNics(vm *egoscale.VirtualMachine) error {
 }
 
 func init() {
-	vmCmd.AddCommand(vmUpdateNicIPCmd)
+	vmCmd.AddCommand(vmUpdateIPCmd)
 }

--- a/cmd/vm_update_nic_ip.go
+++ b/cmd/vm_update_nic_ip.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"text/tabwriter"
+
+	"github.com/exoscale/egoscale"
+	"github.com/spf13/cobra"
+)
+
+var vmUpdateIPCmd = &cobra.Command{
+	Use:   "updateip <vm name|id> <network name|id> <ip address>",
+	Short: "Update the static DHCP lease of an instance",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 3 {
+			return cmd.Usage()
+		}
+		vm, err := getVMWithNameOrID(args[0])
+		if err != nil {
+			return err
+		}
+		network, err := getNetworkByName(args[1])
+		if err != nil {
+			return err
+		}
+		nic := vm.NicByNetworkID(*network.ID)
+		if nic == nil {
+			return fmt.Errorf("the virtual machine %s is not associated to the network %s", vm.DisplayName, network.Name)
+		}
+
+		newVm, err := updateNicIP(nic.ID, args[2])
+		if err != nil {
+			return err
+		}
+
+		return showVMWithNics(newVm)
+	},
+}
+
+func updateNicIP(nicID *egoscale.UUID, newIP string) (*egoscale.VirtualMachine, error) {
+	IP := net.ParseIP(newIP)
+	if IP == nil {
+		return nil, errors.New("invalid IP address")
+	}
+
+	req := &egoscale.UpdateVMNicIP{
+		IPAddress: IP,
+		NicID:     nicID,
+	}
+
+	resp, err := asyncRequest(req, fmt.Sprintf("updating the static lease of NIC %q", nicID))
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*egoscale.VirtualMachine), nil
+}
+
+func showVMWithNics(vm *egoscale.VirtualMachine) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.TabIndent)
+	fmt.Fprintf(w, "\nInstance ID\t%s\n", vm.ID) // nolint: errcheck
+	fmt.Fprintf(w, "Name\t%s\n", vm.DisplayName) // nolint: errcheck
+	if vm.DisplayName != vm.Name {
+		fmt.Fprintf(w, "Hostname\t%s\n", vm.Name) // nolint: errcheck
+	}
+
+	fmt.Fprintf(w, "Network Interfaces\n") // nolint: errcheck
+	defaultNic := vm.DefaultNic()
+	if defaultNic != nil {
+		fmt.Fprintf(w, "-\tNetwork\tPublic\n")                           // nolint: errcheck
+		fmt.Fprintf(w, " \tPublic\t%s\n", defaultNic.IPAddress.String()) // nolint: errcheck
+	}
+	for _, nic := range vm.Nic {
+		if nic.IsDefault {
+		} else {
+			network := &egoscale.Network{ID: nic.NetworkID}
+			if err := cs.GetWithContext(gContext, network); err != nil {
+				return err
+			}
+
+			networkName := network.Name
+			if networkName == "" {
+				networkName = network.ID.String()
+			}
+
+			fmt.Fprintf(w, "-\tNetwork\t%s\n", networkName)
+			if network.Name == "" {
+				fmt.Fprintf(w, " \tID\t%s\n", network.ID.String())
+			}
+
+			fmt.Fprintf(w, " \tIP\t%s\n", nicIP(nic))
+		}
+	}
+
+	fmt.Fprintln(w) // nolint: errcheck
+	return w.Flush()
+}
+
+func init() {
+	vmCmd.AddCommand(vmUpdateNicIPCmd)
+}


### PR DESCRIPTION
This call allows to modify the static ip associated to a nic.

```
$ ./exo vm updatenicip 2269764c-39ef-43a4-9a97-dc17a155bb2e 10.0.0.5
Updating the nic "2269764c-39ef-43a4-9a97-dc17a155bb2e" . success.
Instance ID:           8f0d4701-dce1-432c-87bd-5548c0860a43
Isntance Hostname:     test-vm
Instance Display name: test-vm
┼──────────────────────────────────────┼──────────────────────────────────────┼────────────┼
│                NIC ID                │              NETWORK ID              │ IP ADDRESS │
┼──────────────────────────────────────┼──────────────────────────────────────┼────────────┼
│ 2269764c-39ef-43a4-9a97-dc17a155bb2e │ 932e1e8e-9a07-4449-8894-b0ad52fcec6d │ 10.0.0.5   │
┼──────────────────────────────────────┼──────────────────────────────────────┼────────────┼
```