### PR TITLE
vm: show breaks on non-UUID content

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/exoscale/cli
 require (
 	github.com/VividCortex/ewma v1.1.1 // indirect
 	github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d
-	github.com/exoscale/egoscale v0.12.1
+	github.com/exoscale/egoscale v0.12.2
 	github.com/fatih/camelcase v1.0.0
 	github.com/go-ini/ini v1.38.3
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.12.2
+------
+
+- fix: `ListNics` has no virtualmachineid limitations anymore
+- fix: `PCIDevice` ids are not UUIDs
+
 0.12.1
 ------
 

--- a/vendor/github.com/exoscale/egoscale/README.md
+++ b/vendor/github.com/exoscale/egoscale/README.md
@@ -9,7 +9,15 @@ description: the Go library for Exoscale
 
 A wrapper for the [Exoscale public cloud](https://www.exoscale.com) API.
 
-This project also provides an executable CLI client. See [the documentation](http://exoscale.github.io/egoscale/cli/) for installation instructions.
+## Known users
+
+- [Exoscale CLI](https://github.com/exoscale/cli)
+- [Exoscale terraform provider](https://github.com/exoscale/terraform-provider-exoscale)
+- [ExoIP](https://github.com/exoscale/exoip): IP Watchdog
+- [Lego](https://github.com/xenolf/lego): Let's Encrypt and ACME library
+- Kubernetes Incubator: [External DNS](https://github.com/kubernetes-incubator/external-dns)
+- [Docker machine](https://docs.docker.com/machine/drivers/exoscale/)
+- [etc.](https://godoc.org/github.com/exoscale/egoscale?importers)
 
 ## License
 

--- a/vendor/github.com/exoscale/egoscale/nics.go
+++ b/vendor/github.com/exoscale/egoscale/nics.go
@@ -1,7 +1,6 @@
 package egoscale
 
 import (
-	"errors"
 	"net"
 )
 
@@ -32,10 +31,6 @@ type Nic struct {
 
 // ListRequest build a ListNics request from the given Nic
 func (nic Nic) ListRequest() (ListCommand, error) {
-	if nic.VirtualMachineID == nil {
-		return nil, errors.New("command ListNics requires the VirtualMachineID field to be set")
-	}
-
 	req := &ListNics{
 		VirtualMachineID: nic.VirtualMachineID,
 		NicID:            nic.ID,

--- a/vendor/github.com/exoscale/egoscale/version.go
+++ b/vendor/github.com/exoscale/egoscale/version.go
@@ -1,4 +1,4 @@
 package egoscale
 
 // Version of the library
-const Version = "0.12.1"
+const Version = "0.12.2"

--- a/vendor/github.com/exoscale/egoscale/virtual_machines.go
+++ b/vendor/github.com/exoscale/egoscale/virtual_machines.go
@@ -215,10 +215,10 @@ type IPToNetwork struct {
 // PCIDevice represents a PCI card present in the host
 type PCIDevice struct {
 	PCIVendorName     string `json:"pcivendorname,omitempty" doc:"Device vendor name of pci card"`
-	DeviceID          *UUID  `json:"deviceid,omitempty" doc:"Device model ID of pci card"`
+	DeviceID          string `json:"deviceid,omitempty" doc:"Device model ID of pci card"`
 	RemainingCapacity int    `json:"remainingcapacity,omitempty" doc:"Remaining capacity in terms of no. of more VMs that can be deployped with this vGPU type"`
 	MaxCapacity       int    `json:"maxcapacity,omitempty" doc:"Maximum vgpu can be created with this vgpu type on the given pci group"`
-	PCIVendorID       *UUID  `json:"pcivendorid,omitempty" doc:"Device vendor ID of pci card"`
+	PCIVendorID       string `json:"pcivendorid,omitempty" doc:"Device vendor ID of pci card"`
 	PCIDeviceName     string `json:"pcidevicename,omitempty" doc:"Device model name of pci card"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2,7 +2,7 @@
 github.com/VividCortex/ewma
 # github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.12.1
+# github.com/exoscale/egoscale v0.12.2
 github.com/exoscale/egoscale
 # github.com/fatih/camelcase v1.0.0
 github.com/fatih/camelcase


### PR DESCRIPTION
https://github.com/exoscale/egoscale/pull/352

bumping egoscale to v0.12.2 fixes that.