### PR TITLE
goreleaser: change project name to exoscale-cli

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+project_name: exoscale-cli
+
 builds:
   - binary: exo
     env:
@@ -46,18 +48,11 @@ nfpm:
     - deb
     - rpm
 
-  overrides:
-    deb:
-      files:
-        "./manpage/exo*.1.gz": "/usr/share/man/man1"
-        "./bash_completion": "/etc/bash_completion.d/exo"
-    rpm:
-      files:
-        "./manpage/exo*.1.gz": "/usr/share/man/man1"
-        "./bash_completion": "/etc/bash_completion.d/exo"
+  files:
+    "./manpage/exo*.1.gz": "/usr/share/man/man1"
+    "./bash_completion": "/etc/bash_completion.d/exo"
 
 brew:
-  name: "exo"
   github:
     owner: exoscale
     name: homebrew-tap

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -179,7 +179,14 @@ func initConfig() {
 
 	usr, err := user.Current()
 	if err != nil {
-		log.Fatal(err)
+		log.Println(`current user cannot be read, using "root"`)
+		usr = &user.User{
+			Uid:      "0",
+			Gid:      "0",
+			Username: "root",
+			Name:     "root",
+			HomeDir:  "/root",
+		}
 	}
 
 	gConfigFolder = path.Join(usr.HomeDir, ".exoscale")


### PR DESCRIPTION
Fixes #55

```console
% docker run --rm -it ubuntu:cosmic sh
# dpkg -i dist/exoscale-cli_..._linux_amd64.deb
Selecting previously unselected package exoscale-cli.
(Reading database ... 4032 files and directories currently installed.)
Preparing to unpack .../exoscale-cli_..._linux_amd64.deb ...
Unpacking exoscale-cli (1.0.3) ...
Setting up exoscale-cli (1.0.3) ...
# exo version
exo ... 0d80d1e61b241bef498af5f1f1f908560d5f0c1d (egoscale 0.12.2)
# exit
```

**NB** it will also change its name for our macOS users.