### PR TITLE
config: allow secret to come from an external command

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -191,7 +191,7 @@ func getAccount() (*account, error) {
 
 		secret := account.Secret()
 		secretShow := account.Secret()
-		if secret != "" && len(secret) > 11 {
+		if secret != "" && len(secret) > 10 {
 			secretShow = secret[0:7] + "..."
 		}
 		secretKey, err := readInput(reader, "Secret Key", secretShow)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -42,6 +42,7 @@ func (a account) Secret() string {
 	if len(a.SecretCommand) != 0 {
 		cmd := exec.Command(a.SecretCommand[0], a.SecretCommand[1:]...)
 		cmd.Stdin = os.Stdin
+		cmd.Stderr = os.Stderr
 		out, err := cmd.Output()
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"os/user"
 	"path"
 	"path/filepath"
@@ -16,6 +17,40 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+type config struct {
+	DefaultAccount string
+	Accounts       []account
+}
+
+type account struct {
+	Name            string
+	Account         string
+	Endpoint        string
+	ComputeEndpoint string // legacy config.
+	DNSEndpoint     string
+	SosEndpoint     string
+	Key             string
+	secret          string
+	SecretCommand   []string
+	DefaultZone     string
+	DefaultSSHKey   string
+	DefaultTemplate string
+}
+
+func (a account) Secret() string {
+	if len(a.SecretCommand) != 0 {
+		cmd := exec.Command(a.SecretCommand[0], a.SecretCommand[1:]...)
+		cmd.Stdin = os.Stdin
+		out, err := cmd.Output()
+		if err != nil {
+			log.Fatal(err)
+		}
+		return strings.TrimRight(string(out), "\n")
+	}
+
+	return a.secret
+}
 
 const (
 	defaultConfigFileName = "exoscale"
@@ -132,7 +167,7 @@ func getAccount() (*account, error) {
 	account := &account{
 		Endpoint: defaultEndpoint,
 		Key:      "",
-		Secret:   "",
+		secret:   "",
 	}
 
 	for i := 0; ; i++ {
@@ -154,19 +189,20 @@ func getAccount() (*account, error) {
 			account.Key = apiKey
 		}
 
-		secret := ""
-		if account.Secret != "" && len(account.Secret) > 10 {
-			secret = account.Secret[0:7] + "..."
+		secret := account.Secret()
+		secretShow := account.Secret()
+		if secret != "" && len(secret) > 11 {
+			secretShow = secret[0:7] + "..."
 		}
-		secretKey, err := readInput(reader, "Secret Key", secret)
+		secretKey, err := readInput(reader, "Secret Key", secretShow)
 		if err != nil {
 			return nil, err
 		}
-		if secretKey != account.Secret && secretKey != secret {
-			account.Secret = secretKey
+		if secretKey != secret && secretKey != secretShow {
+			account.secret = secretKey
 		}
 
-		client = egoscale.NewClient(account.Endpoint, account.Key, account.Secret)
+		client = egoscale.NewClient(account.Endpoint, account.Key, account.secret)
 
 		fmt.Printf("Checking the credentials of %q...", account.Key)
 		acc := &egoscale.Account{}
@@ -229,21 +265,28 @@ func addAccount(filePath string, newAccounts *config) error {
 		newAccountsSize = len(newAccounts.Accounts)
 	}
 
-	accounts := make([]map[string]string, accountsSize+newAccountsSize)
+	accounts := make([]map[string]interface{}, accountsSize+newAccountsSize)
 
 	conf := &config{}
 
 	for i, acc := range currentAccounts {
 
-		accounts[i] = map[string]string{}
+		accounts[i] = map[string]interface{}{}
 
 		accounts[i]["name"] = acc.Name
 		accounts[i]["endpoint"] = acc.Endpoint
 		accounts[i]["key"] = acc.Key
 		accounts[i]["secret"] = acc.Secret
 		accounts[i]["defaultZone"] = acc.DefaultZone
-		accounts[i]["defaultSSHKey"] = acc.DefaultSSHKey
-		accounts[i]["defaultTemplate"] = defaultTemplate
+		if acc.DefaultSSHKey != "" {
+			accounts[i]["defaultSSHKey"] = acc.DefaultSSHKey
+		}
+		if acc.DefaultTemplate != "" {
+			accounts[i]["defaultTemplate"] = acc.DefaultTemplate
+		}
+		if len(acc.SecretCommand) != 0 {
+			accounts[i]["secretCommand"] = acc.SecretCommand
+		}
 		accounts[i]["account"] = acc.Account
 
 		conf.Accounts = append(conf.Accounts, acc)
@@ -253,15 +296,16 @@ func addAccount(filePath string, newAccounts *config) error {
 
 		for i, acc := range newAccounts.Accounts {
 
-			accounts[accountsSize+i] = map[string]string{}
+			accounts[accountsSize+i] = map[string]interface{}{}
 
 			accounts[accountsSize+i]["name"] = acc.Name
 			accounts[accountsSize+i]["endpoint"] = acc.Endpoint
 			accounts[accountsSize+i]["key"] = acc.Key
 			accounts[accountsSize+i]["secret"] = acc.Secret
 			accounts[accountsSize+i]["defaultZone"] = acc.DefaultZone
-			accounts[accountsSize+i]["defaultSSHKey"] = acc.DefaultSSHKey
-			accounts[accountsSize+i]["defaultTemplate"] = defaultTemplate
+			if acc.DefaultSSHKey != "" {
+				accounts[accountsSize+i]["defaultSSHKey"] = acc.DefaultSSHKey
+			}
 			accounts[accountsSize+i]["account"] = acc.Account
 			conf.Accounts = append(conf.Accounts, acc)
 		}
@@ -377,10 +421,10 @@ func importCloudstackINI(option, csPath, cfgPath string) error {
 			Name:     acc.Name(),
 			Endpoint: acc.Key("endpoint").String(),
 			Key:      acc.Key("key").String(),
-			Secret:   acc.Key("secret").String(),
+			secret:   acc.Key("secret").String(),
 		}
 
-		csClient := egoscale.NewClient(csAccount.Endpoint, csAccount.Key, csAccount.Secret)
+		csClient := egoscale.NewClient(csAccount.Endpoint, csAccount.Key, csAccount.secret)
 
 		fmt.Printf("Checking the credentials of %q...", csAccount.Key)
 		a := &egoscale.Account{}

--- a/cmd/config_show.go
+++ b/cmd/config_show.go
@@ -33,7 +33,11 @@ var showCmd = &cobra.Command{
 			return fmt.Errorf("account %q was not found", account)
 		}
 
-		secret := strings.Repeat("×", len(acc.Secret)/4)
+		secret := strings.Repeat("×", len(acc.secret)/4)
+
+		if len(acc.SecretCommand) > 0 {
+			secret = strings.Join(acc.SecretCommand, " ")
+		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.TabIndent)
 		fmt.Fprintf(w, "Name:\t%s\n", acc.Name)                // nolint: errcheck

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,25 +40,6 @@ var gUploadAlias = []string{"up"}
 var gDissociateAlias = []string{"disassociate", "dissoc"}
 var gAssociateAlias = []string{"assoc"}
 
-type account struct {
-	Name            string
-	Account         string
-	Endpoint        string
-	ComputeEndpoint string // legacy config.
-	DNSEndpoint     string
-	SosEndpoint     string
-	Key             string
-	Secret          string
-	DefaultZone     string
-	DefaultSSHKey   string
-	DefaultTemplate string
-}
-
-type config struct {
-	DefaultAccount string
-	Accounts       []account
-}
-
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:           "exo",
@@ -127,8 +108,8 @@ func buildClient() {
 		return
 	}
 
-	csDNS = egoscale.NewClient(gCurrentAccount.DNSEndpoint, gCurrentAccount.Key, gCurrentAccount.Secret)
-	cs = egoscale.NewClient(gCurrentAccount.Endpoint, gCurrentAccount.Key, gCurrentAccount.Secret)
+	csDNS = egoscale.NewClient(gCurrentAccount.DNSEndpoint, gCurrentAccount.Key, gCurrentAccount.Secret())
+	cs = egoscale.NewClient(gCurrentAccount.Endpoint, gCurrentAccount.Key, gCurrentAccount.Secret())
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/sos.go
+++ b/cmd/sos.go
@@ -20,7 +20,7 @@ var sosCmd = &cobra.Command{
 func newMinioClient(zone string) (*minio.Client, error) {
 	endpoint := strings.Replace(gCurrentAccount.SosEndpoint, "https://", "", -1)
 	endpoint = strings.Replace(endpoint, "{zone}", zone, -1)
-	return minio.NewV4(endpoint, gCurrentAccount.Key, gCurrentAccount.Secret, true)
+	return minio.NewV4(endpoint, gCurrentAccount.Key, gCurrentAccount.Secret(), true)
 }
 
 func init() {


### PR DESCRIPTION
Fixes #18 

```toml
[[accounts]]
  key = "EXOc94bc655ff901b7218a5c3cd"
  secretCommand = ["secret-tool", "lookup", "Exoscale", "EXOc94bc655ff901b7218a5c3cd"]
```

```console
% exo config show
Default template: Linux Ubuntu 18.04 LTS 64-bit
Name:         yoan.blanc@exoscale.ch
API Key:      EXOc94bc655ff901b7218a5c3cd
API Secret:   secret-tool lookup Exoscale EXOc94bc655ff901b7218a5c3cd
Account:      yoan.blanc@exoscale.ch
Default zone: ch-gva-2

% exo zone list
```
|   NAME   |                  ID                  |
|----------|--------------------------------------|
| ch-gva-2 | 1747ef5e-5451-41fd-9f1a-58913bae9702 |
| ch-dk-2  | 381d0a95-ed4a-4ad9-b41c-b97073c1a433 |
| at-vie-1 | b0fcd72f-47ad-4779-a64f-fe4de007ec72 |
| de-fra-1 | de88c980-78f6-467c-a431-71bcc88e437f |
