### PR TITLE
config: unpanic when exoscale.toml is empty

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -67,7 +67,7 @@ var configCmd = &cobra.Command{
 }
 
 func configCmdRun(cmd *cobra.Command, args []string) error {
-	if viper.ConfigFileUsed() != "" {
+	if viper.ConfigFileUsed() != "" && gAccountName != "" {
 		fmt.Println("Good day! exo is already configured with accounts:")
 		accounts := listAccounts()
 		prompt := promptui.Select{
@@ -277,7 +277,6 @@ func addAccount(filePath string, newAccounts *config) error {
 		accounts[i]["name"] = acc.Name
 		accounts[i]["endpoint"] = acc.Endpoint
 		accounts[i]["key"] = acc.Key
-		accounts[i]["secret"] = acc.Secret
 		accounts[i]["defaultZone"] = acc.DefaultZone
 		if acc.DefaultSSHKey != "" {
 			accounts[i]["defaultSSHKey"] = acc.DefaultSSHKey
@@ -287,6 +286,8 @@ func addAccount(filePath string, newAccounts *config) error {
 		}
 		if len(acc.SecretCommand) != 0 {
 			accounts[i]["secretCommand"] = acc.SecretCommand
+		} else {
+			accounts[i]["secret"] = acc.secret
 		}
 		accounts[i]["account"] = acc.Account
 
@@ -302,7 +303,7 @@ func addAccount(filePath string, newAccounts *config) error {
 			accounts[accountsSize+i]["name"] = acc.Name
 			accounts[accountsSize+i]["endpoint"] = acc.Endpoint
 			accounts[accountsSize+i]["key"] = acc.Key
-			accounts[accountsSize+i]["secret"] = acc.Secret
+			accounts[accountsSize+i]["secret"] = acc.Secret()
 			accounts[accountsSize+i]["defaultZone"] = acc.DefaultZone
 			if acc.DefaultSSHKey != "" {
 				accounts[accountsSize+i]["defaultSSHKey"] = acc.DefaultSSHKey

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -68,7 +68,7 @@ var configCmd = &cobra.Command{
 
 func configCmdRun(cmd *cobra.Command, args []string) error {
 	if viper.ConfigFileUsed() != "" && gAccountName != "" {
-		fmt.Println("Good day! exo is already configured with accounts:")
+		fmt.Println("Good day! exo is already configured:")
 		accounts := listAccounts()
 		prompt := promptui.Select{
 			Label: "Select an account",
@@ -222,7 +222,7 @@ Let's start over.
 		}
 	}
 
-	name, err := readInput(reader, "Account name", account.Name)
+	name, err := readInput(reader, "Name", account.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -231,8 +231,8 @@ Let's start over.
 	}
 
 	for isAccountExist(account.Name) {
-		fmt.Printf("Account name [%s] already exist\n", name)
-		name, err = readInput(reader, "Account name", account.Name)
+		fmt.Printf("Name [%s] already exist\n", name)
+		name, err = readInput(reader, "Name", account.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -287,7 +287,7 @@ func addAccount(filePath string, newAccounts *config) error {
 		if len(acc.SecretCommand) != 0 {
 			accounts[i]["secretCommand"] = acc.SecretCommand
 		} else {
-			accounts[i]["secret"] = acc.secret
+			accounts[i]["secret"] = acc.Secret
 		}
 		accounts[i]["account"] = acc.Account
 
@@ -303,7 +303,7 @@ func addAccount(filePath string, newAccounts *config) error {
 			accounts[accountsSize+i]["name"] = acc.Name
 			accounts[accountsSize+i]["endpoint"] = acc.Endpoint
 			accounts[accountsSize+i]["key"] = acc.Key
-			accounts[accountsSize+i]["secret"] = acc.Secret()
+			accounts[accountsSize+i]["secret"] = acc.Secret
 			accounts[accountsSize+i]["defaultZone"] = acc.DefaultZone
 			if acc.DefaultSSHKey != "" {
 				accounts[accountsSize+i]["defaultSSHKey"] = acc.DefaultSSHKey
@@ -428,22 +428,21 @@ func importCloudstackINI(option, csPath, cfgPath string) error {
 
 		csClient := egoscale.NewClient(csAccount.Endpoint, csAccount.Key, csAccount.Secret)
 
-		fmt.Printf("Checking the credentials of %q...", csAccount.Key)
+		fmt.Printf("Checking the credentials of %q (%s)...", csAccount.Key, csAccount.Endpoint)
 		a := &egoscale.Account{}
 		err := csClient.GetWithContext(gContext, a)
 		if err != nil {
 			fmt.Println(" failure.")
-			if !askQuestion(fmt.Sprintf("Do you want to keep %s?", acc.Name())) {
+			if !askQuestion(fmt.Sprintf("Do you want to keep %s?", csAccount.Name)) {
 				continue
 			}
 		} else {
 			fmt.Println(" success!")
-			csAccount.Name = a.Name
 			csAccount.Account = a.Name
 		}
 		fmt.Println("")
 
-		name, err := readInput(reader, "Account name", csAccount.Name)
+		name, err := readInput(reader, fmt.Sprintf("Name (org: %q)", a.Name), csAccount.Name)
 		if err != nil {
 			return err
 		}
@@ -453,7 +452,7 @@ func importCloudstackINI(option, csPath, cfgPath string) error {
 
 		for isAccountExist(csAccount.Name) {
 			fmt.Printf("Account name [%s] already exist\n", csAccount.Name)
-			name, err = readInput(reader, "Account name", csAccount.Name)
+			name, err = readInput(reader, fmt.Sprintf("Name (org: %q)", a.Name), csAccount.Name)
 			if err != nil {
 				return err
 			}
@@ -509,8 +508,10 @@ func createConfigFile(fileName string) (string, error) {
 
 	filepath := path.Join(gConfigFolder, fileName+".toml")
 
-	if _, err := os.Stat(filepath); !os.IsNotExist(err) {
-		return "", fmt.Errorf("%q exists already", filepath)
+	if viper.ConfigFileUsed() == "" {
+		if _, err := os.Stat(filepath); !os.IsNotExist(err) {
+			return "", fmt.Errorf("%q exists already", filepath)
+		}
 	}
 
 	fp, err := os.OpenFile(filepath, os.O_RDONLY|os.O_CREATE, 0600)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -206,6 +206,11 @@ func initConfig() {
 		log.Fatal(fmt.Errorf("couldn't read config: %s", err))
 	}
 
+	if len(config.Accounts) == 0 {
+		ignoreClientBuild = true
+		return
+	}
+
 	if config.DefaultAccount == "" && gAccountName == "" {
 		log.Fatalf("default account not defined")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -182,7 +182,6 @@ func initConfig() {
 		// Use config file from the flag.
 		viper.SetConfigFile(gConfigFilePath)
 	} else {
-		// Search config in home directory with name ".cobra_test" (without extension).
 		viper.SetConfigName("exoscale")
 		viper.AddConfigPath(gConfigFolder)
 		// Retain backwards compatibility
@@ -207,7 +206,12 @@ func initConfig() {
 	}
 
 	if len(config.Accounts) == 0 {
-		ignoreClientBuild = true
+		if isNonCredentialCmd(nonCredentialCmd...) {
+			ignoreClientBuild = true
+			return
+		}
+
+		log.Fatalf("no accounts we found into %q", viper.ConfigFileUsed())
 		return
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -211,7 +211,7 @@ func initConfig() {
 			return
 		}
 
-		log.Fatalf("no accounts we found into %q", viper.ConfigFileUsed())
+		log.Fatalf("no accounts were found into %q", viper.ConfigFileUsed())
 		return
 	}
 


### PR DESCRIPTION
:warning: master truncates the `~/.exoscale/exoscale.toml` file :warning:

**now**

```console
% truncate -s 0 ~/.exoscale/exoscale.toml
% exo config
default account not defined
```

**then**

```console
% truncate -s 0 ~/.exoscale/exoscale.toml
% exo config                 
We've found a "cloudstack.ini" configuration file with the following configurations:
...
```