### PR TITLE
PR #57 broke credential reading from configuration

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -38,7 +38,7 @@ type account struct {
 	DefaultTemplate string
 }
 
-func (a account) GetSecret() string {
+func (a account) APISecret() string {
 	if len(a.SecretCommand) != 0 {
 		cmd := exec.Command(a.SecretCommand[0], a.SecretCommand[1:]...)
 		cmd.Stdin = os.Stdin
@@ -190,8 +190,8 @@ func getAccount() (*account, error) {
 			account.Key = apiKey
 		}
 
-		secret := account.GetSecret()
-		secretShow := account.GetSecret()
+		secret := account.APISecret()
+		secretShow := account.APISecret()
 		if secret != "" && len(secret) > 10 {
 			secretShow = secret[0:7] + "..."
 		}
@@ -203,7 +203,7 @@ func getAccount() (*account, error) {
 			account.Secret = secretKey
 		}
 
-		client = egoscale.NewClient(account.Endpoint, account.Key, account.GetSecret())
+		client = egoscale.NewClient(account.Endpoint, account.Key, account.APISecret())
 
 		fmt.Printf("Checking the credentials of %q...", account.Key)
 		acc := &egoscale.Account{}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -31,14 +31,14 @@ type account struct {
 	DNSEndpoint     string
 	SosEndpoint     string
 	Key             string
-	secret          string
+	Secret          string
 	SecretCommand   []string
 	DefaultZone     string
 	DefaultSSHKey   string
 	DefaultTemplate string
 }
 
-func (a account) Secret() string {
+func (a account) GetSecret() string {
 	if len(a.SecretCommand) != 0 {
 		cmd := exec.Command(a.SecretCommand[0], a.SecretCommand[1:]...)
 		cmd.Stdin = os.Stdin
@@ -50,8 +50,9 @@ func (a account) Secret() string {
 		return strings.TrimRight(string(out), "\n")
 	}
 
-	return a.secret
+	return a.Secret
 }
+
 
 const (
 	defaultConfigFileName = "exoscale"
@@ -168,7 +169,7 @@ func getAccount() (*account, error) {
 	account := &account{
 		Endpoint: defaultEndpoint,
 		Key:      "",
-		secret:   "",
+		Secret:   "",
 	}
 
 	for i := 0; ; i++ {
@@ -190,8 +191,8 @@ func getAccount() (*account, error) {
 			account.Key = apiKey
 		}
 
-		secret := account.Secret()
-		secretShow := account.Secret()
+		secret := account.GetSecret()
+		secretShow := account.GetSecret()
 		if secret != "" && len(secret) > 10 {
 			secretShow = secret[0:7] + "..."
 		}
@@ -200,10 +201,10 @@ func getAccount() (*account, error) {
 			return nil, err
 		}
 		if secretKey != secret && secretKey != secretShow {
-			account.secret = secretKey
+			account.Secret = secretKey
 		}
 
-		client = egoscale.NewClient(account.Endpoint, account.Key, account.secret)
+		client = egoscale.NewClient(account.Endpoint, account.Key, account.GetSecret())
 
 		fmt.Printf("Checking the credentials of %q...", account.Key)
 		acc := &egoscale.Account{}
@@ -422,10 +423,10 @@ func importCloudstackINI(option, csPath, cfgPath string) error {
 			Name:     acc.Name(),
 			Endpoint: acc.Key("endpoint").String(),
 			Key:      acc.Key("key").String(),
-			secret:   acc.Key("secret").String(),
+			Secret:   acc.Key("secret").String(),
 		}
 
-		csClient := egoscale.NewClient(csAccount.Endpoint, csAccount.Key, csAccount.secret)
+		csClient := egoscale.NewClient(csAccount.Endpoint, csAccount.Key, csAccount.Secret)
 
 		fmt.Printf("Checking the credentials of %q...", csAccount.Key)
 		a := &egoscale.Account{}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -53,7 +53,6 @@ func (a account) GetSecret() string {
 	return a.Secret
 }
 
-
 const (
 	defaultConfigFileName = "exoscale"
 	defaultEndpoint       = "https://api.exoscale.ch/compute"

--- a/cmd/config_show.go
+++ b/cmd/config_show.go
@@ -33,7 +33,7 @@ var showCmd = &cobra.Command{
 			return fmt.Errorf("account %q was not found", account)
 		}
 
-		secret := strings.Repeat("×", len(acc.secret)/4)
+		secret := strings.Repeat("×", len(acc.Secret)/4)
 
 		if len(acc.SecretCommand) > 0 {
 			secret = strings.Join(acc.SecretCommand, " ")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,8 +108,8 @@ func buildClient() {
 		return
 	}
 
-	csDNS = egoscale.NewClient(gCurrentAccount.DNSEndpoint, gCurrentAccount.Key, gCurrentAccount.GetSecret())
-	cs = egoscale.NewClient(gCurrentAccount.Endpoint, gCurrentAccount.Key, gCurrentAccount.GetSecret())
+	csDNS = egoscale.NewClient(gCurrentAccount.DNSEndpoint, gCurrentAccount.Key, gCurrentAccount.APISecret())
+	cs = egoscale.NewClient(gCurrentAccount.Endpoint, gCurrentAccount.Key, gCurrentAccount.APISecret())
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,8 +108,8 @@ func buildClient() {
 		return
 	}
 
-	csDNS = egoscale.NewClient(gCurrentAccount.DNSEndpoint, gCurrentAccount.Key, gCurrentAccount.Secret())
-	cs = egoscale.NewClient(gCurrentAccount.Endpoint, gCurrentAccount.Key, gCurrentAccount.Secret())
+	csDNS = egoscale.NewClient(gCurrentAccount.DNSEndpoint, gCurrentAccount.Key, gCurrentAccount.GetSecret())
+	cs = egoscale.NewClient(gCurrentAccount.Endpoint, gCurrentAccount.Key, gCurrentAccount.GetSecret())
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/sos.go
+++ b/cmd/sos.go
@@ -20,7 +20,7 @@ var sosCmd = &cobra.Command{
 func newMinioClient(zone string) (*minio.Client, error) {
 	endpoint := strings.Replace(gCurrentAccount.SosEndpoint, "https://", "", -1)
 	endpoint = strings.Replace(endpoint, "{zone}", zone, -1)
-	return minio.NewV4(endpoint, gCurrentAccount.Key, gCurrentAccount.GetSecret(), true)
+	return minio.NewV4(endpoint, gCurrentAccount.Key, gCurrentAccount.APISecret(), true)
 }
 
 func init() {

--- a/cmd/sos.go
+++ b/cmd/sos.go
@@ -20,7 +20,7 @@ var sosCmd = &cobra.Command{
 func newMinioClient(zone string) (*minio.Client, error) {
 	endpoint := strings.Replace(gCurrentAccount.SosEndpoint, "https://", "", -1)
 	endpoint = strings.Replace(endpoint, "{zone}", zone, -1)
-	return minio.NewV4(endpoint, gCurrentAccount.Key, gCurrentAccount.Secret(), true)
+	return minio.NewV4(endpoint, gCurrentAccount.Key, gCurrentAccount.GetSecret(), true)
 }
 
 func init() {


### PR DESCRIPTION
This restores the functionality.
As an added bonus, this also restores `exo config` functionality, which also got broken in #57 (marshaling of configs failed both ways)