### PR TITLE
config: store data next to config

### DIFF
--- a/cmd/config_list.go
+++ b/cmd/config_list.go
@@ -15,7 +15,9 @@ var configListCmd = &cobra.Command{
 		if gAllAccount == nil {
 			return fmt.Errorf("no accounts defined")
 		}
-		listAccounts()
+		for _, account := range listAccounts() {
+			fmt.Println(account)
+		}
 		return nil
 	},
 }

--- a/cmd/config_show.go
+++ b/cmd/config_show.go
@@ -7,7 +7,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // showCmd represents the show command
@@ -62,9 +61,9 @@ var showCmd = &cobra.Command{
 			fmt.Fprintf(w, "SOS Endpoint:\t%s\n", acc.SosEndpoint) // nolint: errcheck
 		}
 
-		fmt.Fprintf(w, "\t\n")                                         // nolink: errcheck
-		fmt.Fprintf(w, "Configuration:\t%s\n", viper.ConfigFileUsed()) // nolink: errcheck
-		fmt.Fprintf(w, "Storage:\t%s\n", gConfigFolder)                // nolint: errcheck
+		fmt.Fprintf(w, "\t\n")                                  // nolink: errcheck
+		fmt.Fprintf(w, "Configuration:\t%s\n", gConfigFilePath) // nolink: errcheck
+		fmt.Fprintf(w, "Storage:\t%s\n", gConfigFolder)         // nolint: errcheck
 
 		return w.Flush()
 	},

--- a/cmd/config_show.go
+++ b/cmd/config_show.go
@@ -7,6 +7,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // showCmd represents the show command
@@ -40,21 +41,31 @@ var showCmd = &cobra.Command{
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.TabIndent)
-		fmt.Fprintf(w, "Name:\t%s\n", acc.Name)                // nolint: errcheck
+		fmt.Fprintf(w, " \t%s\n", acc.Name)                    // nolint: errcheck
+		fmt.Fprintf(w, "\t\n")                                 // nolink: errcheck
+		fmt.Fprintf(w, "Account:\t%s\n", acc.Account)          // nolint: errcheck
 		fmt.Fprintf(w, "API Key:\t%s\n", acc.Key)              // nolint: errcheck
 		fmt.Fprintf(w, "API Secret:\t%s\n", secret)            // nolint: errcheck
-		fmt.Fprintf(w, "Account:\t%s\n", acc.Account)          // nolint: errcheck
+		fmt.Fprintf(w, "\t\n")                                 // nolink: errcheck
 		fmt.Fprintf(w, "Default zone:\t%s\n", acc.DefaultZone) // nolint: errcheck
+
 		if acc.DefaultTemplate != "" {
-			println("Default template:", acc.DefaultTemplate) // nolint: errcheck
+			fmt.Fprintf(w, "Default template:\t%s\n", acc.DefaultTemplate) // nolint: errcheck
 		}
+
 		if acc.Endpoint != defaultEndpoint {
 			fmt.Fprintf(w, "Endpoint:\t%s\n", acc.Endpoint)        // nolint: errcheck
 			fmt.Fprintf(w, "DNS Endpoint:\t%s\n", acc.DNSEndpoint) // nolint: errcheck
 		}
+
 		if acc.SosEndpoint != defaultSosEndpoint {
 			fmt.Fprintf(w, "SOS Endpoint:\t%s\n", acc.SosEndpoint) // nolint: errcheck
 		}
+
+		fmt.Fprintf(w, "\t\n")                                         // nolink: errcheck
+		fmt.Fprintf(w, "Configuration:\t%s\n", viper.ConfigFileUsed()) // nolink: errcheck
+		fmt.Fprintf(w, "Storage:\t%s\n", gConfigFolder)                // nolint: errcheck
+
 		return w.Flush()
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -182,7 +182,6 @@ func initConfig() {
 		// Use config file from the flag.
 		viper.SetConfigFile(gConfigFilePath)
 	} else {
-		// Search config in home directory with name ".cobra_test" (without extension).
 		viper.SetConfigName("exoscale")
 		viper.AddConfigPath(gConfigFolder)
 		// Retain backwards compatibility
@@ -201,6 +200,9 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err != nil {
 		log.Fatal(err)
 	}
+
+	// All the stored data (e.g. ssh keys) will be put next to the config file.
+	gConfigFolder = path.Dir(viper.ConfigFileUsed())
 
 	if err := viper.Unmarshal(config); err != nil {
 		log.Fatal(fmt.Errorf("couldn't read config: %s", err))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -202,7 +202,8 @@ func initConfig() {
 	}
 
 	// All the stored data (e.g. ssh keys) will be put next to the config file.
-	gConfigFolder = path.Dir(viper.ConfigFileUsed())
+	gConfigFilePath = viper.ConfigFileUsed()
+	gConfigFolder = path.Dir(gConfigFilePath)
 
 	if err := viper.Unmarshal(config); err != nil {
 		log.Fatal(fmt.Errorf("couldn't read config: %s", err))


### PR DESCRIPTION
#62 moves the default config folder, let's make it visible.

```console
% exo config show
                  ppyoan

Account:          yoan.blanc@exoscale.ch
API Key:          EXOc94bc655ff901b7218a5c3cd
API Secret:       secret-tool lookup Exoscale EXOc94bc655ff901b7218a5c3cd

Default zone:     ch-gva-2
Default template: Linux Ubuntu 18.04 LTS 64-bit
Endpoint:         https://api.exoscale.ch/compute
DNS Endpoint:     https://api.exoscale.ch/dns

Configuration:    /home/u/.exoscale/exoscale.toml
Storage:          /home/u/.exoscale
```