### PR TITLE
Fix (#68) Api raw args not allowed

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -79,7 +79,7 @@ func buildCommands(methods []category) {
 			runCMD := func(cmd *cobra.Command, args []string) error {
 
 				if len(args) > 0 {
-					fmt.Fprintf(os.Stderr, "Raw arg(s) not allowed %q\n", strings.Join(args, ", ")) // nolint: errcheck
+					fmt.Fprintf(os.Stderr, "Raw arg(s) are not supported. Did you mean --%s ?\n", strings.Join(args, " --")) // nolint: errcheck
 					return cmd.Usage()
 				}
 

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -79,7 +79,7 @@ func buildCommands(methods []category) {
 			runCMD := func(cmd *cobra.Command, args []string) error {
 
 				if len(args) > 0 {
-					return fmt.Errorf("Raw arguments are not supported. Did you mean?\n\n%s --%s", cmd.CommandPath(), strings.Join(args, " --"))
+					return fmt.Errorf("raw arguments are not supported. Did you mean?\n\n%s --%s", cmd.CommandPath(), strings.Join(args, " --"))
 				}
 
 				// Show request and quit DEBUG

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -79,8 +79,7 @@ func buildCommands(methods []category) {
 			runCMD := func(cmd *cobra.Command, args []string) error {
 
 				if len(args) > 0 {
-					fmt.Fprintf(os.Stderr, "Raw arg(s) are not supported. Did you mean --%s ?\n", strings.Join(args, " --")) // nolint: errcheck
-					return cmd.Usage()
+					return fmt.Errorf("Raw arguments are not supported. Did you mean?\n\n%s --%s", cmd.CommandPath(), strings.Join(args, " --"))
 				}
 
 				// Show request and quit DEBUG

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -78,6 +78,11 @@ func buildCommands(methods []category) {
 
 			runCMD := func(cmd *cobra.Command, args []string) error {
 
+				if len(args) > 0 {
+					fmt.Fprintf(os.Stderr, "Raw arg(s) not allowed %q\n", strings.Join(args, ", ")) // nolint: errcheck
+					return cmd.Usage()
+				}
+
 				// Show request and quit DEBUG
 				if apiDebug {
 					payload, err := cs.Payload(s.command)


### PR DESCRIPTION
go run main.go api zone list keyword=bar tags=tag
```
Raw arg(s) not allowed "keyword=bar, tags=tag"
Usage:
  exo api zone list [flags]

Aliases:
  list, ls, listZones

Flags:
      --available        true if you want to retrieve all available Zones. False if you only want to return the Zones from which you have at least one VM. Default is false. (default nil)
      --id UUID          the ID of the zone (default nil)
      --keyword string   List by keyword
      --name string      the name of the zone
      --page int
      --pagesize int
      --showcapacities   flag to display the capacity of the zones (default nil)
      --tags tag         List zones by resource tags (key/value pairs)
  -h, --help             help for list

Global Flags:
  -C, --config string        Specify an alternate config file [env EXOSCALE_CONFIG]
  -d, --debug                debug mode on
  -A, --use-account string   Account to use in config file [env EXOSCALE_ACCOUNT]
```
Fix #68 