### PR TITLE
Add EXOSCALE_TRACE= on SOS

### DIFF
--- a/cmd/sos.go
+++ b/cmd/sos.go
@@ -22,12 +22,15 @@ func newMinioClient(zone string) (*minio.Client, error) {
 	endpoint := strings.Replace(gCurrentAccount.SosEndpoint, "https://", "", -1)
 	endpoint = strings.Replace(endpoint, "{zone}", zone, -1)
 	client, err := minio.NewV4(endpoint, gCurrentAccount.Key, gCurrentAccount.APISecret(), true)
+	if err != nil {
+		return nil, err
+	}
 
 	if _, ok := os.LookupEnv("EXOSCALE_TRACE"); ok {
 		client.TraceOn(os.Stderr)
 	}
 
-	return client, err
+	return client, nil
 }
 
 func init() {

--- a/cmd/sos.go
+++ b/cmd/sos.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"strings"
 
 	minio "github.com/minio/minio-go"
@@ -20,7 +21,13 @@ var sosCmd = &cobra.Command{
 func newMinioClient(zone string) (*minio.Client, error) {
 	endpoint := strings.Replace(gCurrentAccount.SosEndpoint, "https://", "", -1)
 	endpoint = strings.Replace(endpoint, "{zone}", zone, -1)
-	return minio.NewV4(endpoint, gCurrentAccount.Key, gCurrentAccount.APISecret(), true)
+	client, err := minio.NewV4(endpoint, gCurrentAccount.Key, gCurrentAccount.APISecret(), true)
+
+	if _, ok := os.LookupEnv("EXOSCALE_TRACE"); ok {
+		client.TraceOn(os.Stderr)
+	}
+
+	return client, err
 }
 
 func init() {


### PR DESCRIPTION
SOS with `EXOSCAL_TRACE=`:
```
---------START-HTTP---------
GET /bucket-example/?location= HTTP/1.1
Host: sos-ch-dk-2.exo.io
User-Agent: Minio (darwin; amd64) minio-go/v6.0.6
Authorization: AWS4-HMAC-SHA256 Credential=XXXXXXXXXXXXXXXX/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=**REDACTED**
X-Amz-Content-Sha256: UNSIGNED-PAYLOAD
X-Amz-Date: 20181130T141747Z
Accept-Encoding: gzip

HTTP/2.0 200 OK
Content-Length: 134
Content-Type: application/xml
Date: Fri, 30 Nov 2018 14:17:53 GMT
Server: nginx
X-Amz-Bucket-Region: ch-dk-2
X-Amz-Id-2: eeaab1bd-1932-4d4e-bdbd-b1e72d04bae9
X-Amz-Request-Id: eeaab1bd-1932-4d4e-bdbd-b1e72d04bae9
X-Amzn-Requestid: eeaab1bd-1932-4d4e-bdbd-b1e72d04bae9
---------END-HTTP---------
```