### PR TITLE
ssh: name can be ambiguous...

### DIFF
--- a/cmd/eip_associate.go
+++ b/cmd/eip_associate.go
@@ -36,7 +36,7 @@ func associateIP(ipAddr, instance string) (*egoscale.UUID, error) {
 		return nil, fmt.Errorf("invalid IP address %q", ipAddr)
 	}
 
-	vm, err := getVMWithNameOrID(instance)
+	vm, err := getVirtualMachineByNameOrID(instance)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/eip_dissociate.go
+++ b/cmd/eip_dissociate.go
@@ -32,7 +32,7 @@ func dissociateIP(ipAddr, instance string) error {
 		return fmt.Errorf("invalid IP address %q", ipAddr)
 	}
 
-	vm, err := getVMWithNameOrID(instance)
+	vm, err := getVirtualMachineByNameOrID(instance)
 	if err != nil {
 		return err
 	}

--- a/cmd/privnet_associate.go
+++ b/cmd/privnet_associate.go
@@ -67,7 +67,7 @@ var privnetAssociateCmd = &cobra.Command{
 }
 
 func associatePrivNet(privnet *egoscale.Network, vmName string, ip net.IP) (*egoscale.Nic, *egoscale.VirtualMachine, error) {
-	vm, err := getVMWithNameOrID(vmName)
+	vm, err := getVirtualMachineByNameOrID(vmName)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/privnet_dissociate.go
+++ b/cmd/privnet_dissociate.go
@@ -34,7 +34,7 @@ var dissociateCmd = &cobra.Command{
 }
 
 func dissociatePrivNet(privnet *egoscale.Network, vmName string) (*egoscale.UUID, error) {
-	vm, err := getVMWithNameOrID(vmName)
+	vm, err := getVirtualMachineByNameOrID(vmName)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/snapshot_create.go
+++ b/cmd/snapshot_create.go
@@ -18,7 +18,7 @@ var snapshotCreateCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 
-		vm, err := getVMWithNameOrID(args[0])
+		vm, err := getVirtualMachineByNameOrID(args[0])
 		if err != nil {
 			return err
 		}

--- a/cmd/snapshot_list.go
+++ b/cmd/snapshot_list.go
@@ -49,7 +49,7 @@ var snapshotListCmd = &cobra.Command{
 		table.SetHeader([]string{"VM", "State", "Created On", "Size", "ID"})
 
 		for _, arg := range args {
-			vm, err := getVMWithNameOrID(arg)
+			vm, err := getVirtualMachineByNameOrID(arg)
 			if err != nil {
 				return err
 			}

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -63,9 +63,46 @@ type sshInfo struct {
 }
 
 func getSSHInfo(name string, isIpv6 bool) (*sshInfo, error) {
-	vm, err := getVMWithNameOrID(name)
+	vmQuery := egoscale.VirtualMachine{}
+	id, err := egoscale.ParseUUID(name)
+	if err != nil {
+		vmQuery.Name = name
+	} else {
+		vmQuery.ID = id
+	}
+
+	vms, err := cs.ListWithContext(gContext, vmQuery)
 	if err != nil {
 		return nil, err
+	}
+
+	var vm *egoscale.VirtualMachine
+	switch len(vms) {
+	case 0:
+		return nil, fmt.Errorf("no VMs has been found")
+	case 1:
+		vm = vms[0].(*egoscale.VirtualMachine)
+	default:
+		names := []string{}
+		for _, i := range vms {
+			v := i.(*egoscale.VirtualMachine)
+			if v.Name != vmQuery.Name {
+				continue
+			}
+
+			vm = v
+			names = append(names, fmt.Sprintf("\t%s\t%s\t%s", v.ID.String(), v.ZoneName, v.IP()))
+		}
+
+		if len(names) == 1 {
+			break
+		}
+
+		fmt.Println("More than one VM has been found, use the ID instead:")
+		for _, name := range names {
+			fmt.Println(name)
+		}
+		return nil, fmt.Errorf("abort vm name %q is ambiguous", vmQuery.Name)
 	}
 
 	sshKeyPath := path.Join(gConfigFolder, "instances", vm.ID.String(), "id_rsa")

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -63,7 +63,7 @@ type sshInfo struct {
 }
 
 func getSSHInfo(name string, isIpv6 bool) (*sshInfo, error) {
-	vm, err := getVMWithNameOrID(name)
+	vm, err := getVirtualMachineByNameOrID(name)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -63,46 +63,9 @@ type sshInfo struct {
 }
 
 func getSSHInfo(name string, isIpv6 bool) (*sshInfo, error) {
-	vmQuery := egoscale.VirtualMachine{}
-	id, err := egoscale.ParseUUID(name)
-	if err != nil {
-		vmQuery.Name = name
-	} else {
-		vmQuery.ID = id
-	}
-
-	vms, err := cs.ListWithContext(gContext, vmQuery)
+	vm, err := getVMWithNameOrID(name)
 	if err != nil {
 		return nil, err
-	}
-
-	var vm *egoscale.VirtualMachine
-	switch len(vms) {
-	case 0:
-		return nil, fmt.Errorf("no VMs has been found")
-	case 1:
-		vm = vms[0].(*egoscale.VirtualMachine)
-	default:
-		names := []string{}
-		for _, i := range vms {
-			v := i.(*egoscale.VirtualMachine)
-			if v.Name != vmQuery.Name {
-				continue
-			}
-
-			vm = v
-			names = append(names, fmt.Sprintf("\t%s\t%s\t%s", v.ID.String(), v.ZoneName, v.IP()))
-		}
-
-		if len(names) == 1 {
-			break
-		}
-
-		fmt.Println("More than one VM has been found, use the ID instead:")
-		for _, name := range names {
-			fmt.Println(name)
-		}
-		return nil, fmt.Errorf("abort vm name %q is ambiguous", vmQuery.Name)
 	}
 
 	sshKeyPath := path.Join(gConfigFolder, "instances", vm.ID.String(), "id_rsa")

--- a/cmd/vm.go
+++ b/cmd/vm.go
@@ -13,7 +13,7 @@ var vmCmd = &cobra.Command{
 	Short: "Virtual machines management",
 }
 
-func getVMWithNameOrID(name string) (*egoscale.VirtualMachine, error) {
+func getVirtualMachineByNameOrID(name string) (*egoscale.VirtualMachine, error) {
 	vmQuery := egoscale.VirtualMachine{}
 	id, err := egoscale.ParseUUID(name)
 	if err != nil {

--- a/cmd/vm_delete.go
+++ b/cmd/vm_delete.go
@@ -28,7 +28,7 @@ var vmDeleteCmd = &cobra.Command{
 		vms := make([]egoscale.VirtualMachine, len(args))
 
 		for i, arg := range args {
-			vm, err := getVMWithNameOrID(arg)
+			vm, err := getVirtualMachineByNameOrID(arg)
 			if err != nil {
 				return err
 			}

--- a/cmd/vm_reboot.go
+++ b/cmd/vm_reboot.go
@@ -44,7 +44,7 @@ var vmRebootCmd = &cobra.Command{
 
 // rebootVirtualMachine reboot a virtual machine instance Async
 func rebootVirtualMachine(vmName string) error {
-	vm, err := getVMWithNameOrID(vmName)
+	vm, err := getVirtualMachineByNameOrID(vmName)
 	if err != nil {
 		return err
 	}

--- a/cmd/vm_reset.go
+++ b/cmd/vm_reset.go
@@ -54,7 +54,7 @@ var vmResetCmd = &cobra.Command{
 
 // resetVirtualMachine stop a virtual machine instance
 func resetVirtualMachine(vmName string, diskValue int64PtrValue, force bool) error {
-	vm, err := getVMWithNameOrID(vmName)
+	vm, err := getVirtualMachineByNameOrID(vmName)
 	if err != nil {
 		return err
 	}

--- a/cmd/vm_resize.go
+++ b/cmd/vm_resize.go
@@ -55,7 +55,7 @@ var vmResizeCmd = &cobra.Command{
 
 // resizeVirtualMachine stop a virtual machine instance
 func resizeVirtualMachine(vmName string, diskValue int64, force bool) error {
-	vm, err := getVMWithNameOrID(vmName)
+	vm, err := getVirtualMachineByNameOrID(vmName)
 	if err != nil {
 		return err
 	}

--- a/cmd/vm_scale.go
+++ b/cmd/vm_scale.go
@@ -56,7 +56,7 @@ var vmScaleCmd = &cobra.Command{
 
 // scaleVirtualMachine scale a virtual machine instance Async with context
 func scaleVirtualMachine(vmName string, serviceofferingID egoscale.UUID) error {
-	vm, err := getVMWithNameOrID(vmName)
+	vm, err := getVirtualMachineByNameOrID(vmName)
 	if err != nil {
 		return err
 	}

--- a/cmd/vm_show.go
+++ b/cmd/vm_show.go
@@ -24,7 +24,7 @@ var vmShowCmd = &cobra.Command{
 }
 
 func showVM(name string) error {
-	vm, err := getVMWithNameOrID(name)
+	vm, err := getVirtualMachineByNameOrID(name)
 	if err != nil {
 		return err
 	}

--- a/cmd/vm_start.go
+++ b/cmd/vm_start.go
@@ -44,7 +44,7 @@ var vmStartCmd = &cobra.Command{
 
 // startVirtualMachine start a virtual machine instance Async
 func startVirtualMachine(vmName string) error {
-	vm, err := getVMWithNameOrID(vmName)
+	vm, err := getVirtualMachineByNameOrID(vmName)
 	if err != nil {
 		return err
 	}

--- a/cmd/vm_stop.go
+++ b/cmd/vm_stop.go
@@ -44,7 +44,7 @@ var vmStopCmd = &cobra.Command{
 
 // stopVirtualMachine stop a virtual machine instance
 func stopVirtualMachine(vmName string) error {
-	vm, err := getVMWithNameOrID(vmName)
+	vm, err := getVirtualMachineByNameOrID(vmName)
 	if err != nil {
 		return err
 	}

--- a/cmd/vm_update_ip.go
+++ b/cmd/vm_update_ip.go
@@ -19,7 +19,7 @@ var vmUpdateIPCmd = &cobra.Command{
 		vmName := args[0]
 		netName := args[1]
 
-		vm, err := getVMWithNameOrID(vmName)
+		vm, err := getVirtualMachineByNameOrID(vmName)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
listVMs does a fuzzy search on the `name`, is this new?

```console
% exo api listVirtualMachines --name=test | jq ".virtualmachine[].name"       
"test2"
"test"
"test"

% exo ssh test             
More than one VM has been found, use the ID instead:
        72c54b48-6636-4941-87f0-17fecea52ae0    ch-gva-2        159.100.241.250
        f425c124-6030-4521-a30a-ca2e22d92222    ch-gva-2        159.100.241.252
abort vm name "test" is ambiguous

% exo vm delete f425c124-6030-4521-a30a-ca2e22d92222

% exo ssh test

121 packages can be updated.
37 updates are security updates.
```

:stuck_out_tongue_winking_eye: 

**todo**

- [x] refactor this into `getVirtualMachineByNameOrID`

----

Fixes #75 /cc @JessicaToscani 