### PR TITLE
firewall: fix --my-ip and flagless add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -----
 
 - change: `firewall add` sets a CIDR by default
+- fix: `firewall add --my-ip` to not create the default CIDR
 
 1.0.4
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,26 @@
-1.0.5
+
+
+1.0.7
 -----
 
 - change: `firewall add` sets a CIDR by default
 - fix: `firewall add --my-ip` to not create the default CIDR
+
+1.0.6
+-----
+
+- feature: runstatus
+- feature: lab kube
+
+1.0.5
+-----
+
+- feature: sos recursive upload
+- feature: EXOSCALE_TRACE on the sos command
+- feature: allow secrets to come from an external source
+- feature: use XDG_CONFIG_HOME by default
+- feature: dns remove asks for confirmation
+- fix: `--my-ip` fix by @falzm
 
 1.0.4
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.0.5
+-----
+
+- change: `firewall add` sets a CIDR by default
+
 1.0.4
 -----
 

--- a/cmd/firewall_add.go
+++ b/cmd/firewall_add.go
@@ -18,7 +18,7 @@ func init() {
 	firewallAddCmd.Flags().BoolP("ipv6", "6", false, "Set ipv6 on default rules or on --my-ip")
 	firewallAddCmd.Flags().BoolP("my-ip", "", false, "Set CIDR for my ip")
 	firewallAddCmd.Flags().BoolP("egress", "e", false, "By default rule is INGRESS (set --egress to have EGRESS rule)")
-	firewallAddCmd.Flags().StringP("protocol", "p", "tcp", "Rule Protocol available [tcp, udp, icmp, icmpv6, ah, esp, gre]")
+	firewallAddCmd.Flags().StringP("protocol", "p", "", "Rule Protocol available [tcp, udp, icmp, icmpv6, ah, esp, gre]")
 	firewallAddCmd.Flags().StringP("cidr", "c", "", "Rule Cidr [CIDR 0.0.0.0/0,::/0,...]")
 	firewallAddCmd.Flags().StringP("security-group", "s", "", "Rule security group [name or id ex: sg1,sg2...]")
 	firewallAddCmd.Flags().StringP("port", "P", "", "Rule port range [80-80,443,22-22]")
@@ -39,6 +39,21 @@ func init() {
 var firewallAddCmd = &cobra.Command{
 	Use:   "add <security group name | id>  [ssh | telnet | rdp | ...] (default preset rules)",
 	Short: "Add rule to a security group",
+	Long: `
+No arguments create a IPv4 wide open rule.
+
+For ICMP rules, specify the icmp-code and icmp-type.
+
+	firewall add <security group> --protocol icmp --icmp-type 8 --icmp-code 0
+
+For the other protocols specify the port ranges.
+
+	firewall add <security group> --protocol tcp --port 8000-8080
+
+A set of predefined commands exists, such a ssh, ping or minecraft.
+
+	firewall add <security group> ssh
+`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return cmd.Usage()
@@ -87,6 +102,10 @@ var firewallAddCmd = &cobra.Command{
 		sg, err := cmd.Flags().GetString("security-group")
 		if err != nil {
 			return err
+		}
+
+		if cidrList == "" && sg == "" {
+			cidrList = "0.0.0.0/0"
 		}
 
 		isIpv6, err := cmd.Flags().GetBool("ipv6")

--- a/cmd/firewall_add.go
+++ b/cmd/firewall_add.go
@@ -18,7 +18,7 @@ func init() {
 	firewallAddCmd.Flags().BoolP("ipv6", "6", false, "Set ipv6 on default rules or on --my-ip")
 	firewallAddCmd.Flags().BoolP("my-ip", "", false, "Set CIDR for my ip")
 	firewallAddCmd.Flags().BoolP("egress", "e", false, "By default rule is INGRESS (set --egress to have EGRESS rule)")
-	firewallAddCmd.Flags().StringP("protocol", "p", "", "Rule Protocol available [tcp, udp, icmp, icmpv6, ah, esp, gre]")
+	firewallAddCmd.Flags().StringP("protocol", "p", "tcp", "Rule Protocol available [tcp, udp, icmp, icmpv6, ah, esp, gre]")
 	firewallAddCmd.Flags().StringP("cidr", "c", "", "Rule Cidr [CIDR 0.0.0.0/0,::/0,...]")
 	firewallAddCmd.Flags().StringP("security-group", "s", "", "Rule security group [name or id ex: sg1,sg2...]")
 	firewallAddCmd.Flags().StringP("port", "P", "", "Rule port range [80-80,443,22-22]")

--- a/cmd/firewall_remove.go
+++ b/cmd/firewall_remove.go
@@ -64,7 +64,10 @@ var firewallRemoveCmd = &cobra.Command{
 			return err
 		}
 
-		var cidr *egoscale.CIDR
+		cidr := defaultCIDR
+		if isIpv6 {
+			cidr = defaultCIDR6
+		}
 		if isMyIP {
 			c, errGet := getMyCIDR(isIpv6)
 			if errGet != nil {
@@ -85,10 +88,10 @@ var firewallRemoveCmd = &cobra.Command{
 				}
 			}
 
-			r, err := getDefaultRule(arg, isIpv6)
+			r, err := getDefaultRule(arg)
 			if err == nil {
 				ru := &egoscale.IngressRule{
-					CIDR:      &r.CIDRList[0],
+					CIDR:      cidr,
 					StartPort: r.StartPort,
 					EndPort:   r.EndPort,
 					Protocol:  r.Protocol,


### PR DESCRIPTION
* if protocol is not set, rule will be created with
  * protocol set to all
  * port set to 0

```console
% exo firewall add egress --cidr 1.2.3.4/32 --port 45678
 SOURCE                   │ PROTOCOL │   PORT   │ 
 CIDR 1.2.3.4/32          │ all      │ 0        │             │ 
```

Maybe we should not accept --port without  --protocol 

* if protocol is set to all with --port

It is strange to have the possibility to set protocol to all with the cli but not through the portal

*exo 1.0.6 e886eca13deef7a2016a9c542fb3eca79deab4a4 (egoscale 0.13.2)*