### PR TITLE
firewall: add --my-ip to replace default cidr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.0.5
+-----
+
+- fix: `firewall add --my-ip` to not create the default CIDR
+
 1.0.4
 -----
 

--- a/cmd/firewall_add.go
+++ b/cmd/firewall_add.go
@@ -99,14 +99,14 @@ var firewallAddCmd = &cobra.Command{
 			return err
 		}
 
-		var ip *egoscale.CIDR
+		var cidr *egoscale.CIDR
 		if isMyIP {
-			cidr, cirdErr := getMyCIDR(isIpv6)
+			c, cirdErr := getMyCIDR(isIpv6)
 			if cirdErr != nil {
 				return cirdErr
 			}
 
-			ip = cidr
+			cidr = c
 		}
 
 		tasks := []task{}
@@ -132,9 +132,10 @@ var firewallAddCmd = &cobra.Command{
 				rule.Protocol = strings.ToLower(protocol)
 			}
 
-			if ip != nil {
-				rule.CIDRList = append(rule.CIDRList, *ip)
+			if cidr != nil {
+				rule.CIDRList = []egoscale.CIDR{*cidr}
 			}
+
 			if cidrList != "" {
 				cidrs := getCommaflag(cidrList)
 				for _, cidr := range cidrs {


### PR DESCRIPTION
Closes #81 

```console
% exo firewall add wide-open ssh --my-ip
% exo firewall add wide-open --protocol tcp --port 1000 --my-ip
```

|  TYPE   |        SOURCE         | PROTOCOL |   PORT   | DESCRIPTION |                  ID                  |
|---------|-----------------------|----------|----------|-------------|--------------------------------------|
| INGRESS | CIDR 80.244.112.23/32 | tcp      | 1000     |             | 5dbdaf78-fab3-4f14-95a4-787dba792c5a |
|         | CIDR 80.244.112.23/32 | tcp      | 22 (ssh) |             | 7f9fc125-d04c-42ff-bb3b-9be7fa6c3077 |
