### PR TITLE
CLI: show VMs in anti-affinity group

### DIFF
--- a/cmd/affinitygroup.go
+++ b/cmd/affinitygroup.go
@@ -38,7 +38,7 @@ func getAffinityGroupByName(name string) (*egoscale.AffinityGroup, error) {
 func getAffinityGroups(vm *egoscale.VirtualMachine) []string {
 	ags := make([]string, len(vm.AffinityGroup))
 	for _, agN := range vm.AffinityGroup {
-		ags = append(ags, agN.Name)
+		ags[i] = agN.Name
 	}
 	return ags
 }

--- a/cmd/affinitygroup.go
+++ b/cmd/affinitygroup.go
@@ -36,7 +36,7 @@ func getAffinityGroupByName(name string) (*egoscale.AffinityGroup, error) {
 }
 
 func getAffinityGroups(vm *egoscale.VirtualMachine) []string {
-	ags := []string{}
+	ags := make([]string, len(vm.AffinityGroup))
 	for _, agN := range vm.AffinityGroup {
 		ags = append(ags, agN.Name)
 	}

--- a/cmd/affinitygroup.go
+++ b/cmd/affinitygroup.go
@@ -35,6 +35,14 @@ func getAffinityGroupByName(name string) (*egoscale.AffinityGroup, error) {
 	return resp.(*egoscale.AffinityGroup), nil
 }
 
+func getAffinityGroups(vm *egoscale.VirtualMachine) []string {
+	ags := []string{}
+	for _, agN := range vm.AffinityGroup {
+		ags = append(ags, agN.Name)
+	}
+	return ags
+}
+
 func init() {
 	RootCmd.AddCommand(affinitygroupCmd)
 }

--- a/cmd/affinitygroup.go
+++ b/cmd/affinitygroup.go
@@ -37,7 +37,7 @@ func getAffinityGroupByName(name string) (*egoscale.AffinityGroup, error) {
 
 func getAffinityGroups(vm *egoscale.VirtualMachine) []string {
 	ags := make([]string, len(vm.AffinityGroup))
-	for _, agN := range vm.AffinityGroup {
+	for i, agN := range vm.AffinityGroup {
 		ags[i] = agN.Name
 	}
 	return ags

--- a/cmd/affinitygroup_show.go
+++ b/cmd/affinitygroup_show.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/exoscale/cli/table"
+	"github.com/spf13/cobra"
+)
+
+// affinitygroupShowCmd represents the affinitygroup show command
+var affinitygroupShowCmd = &cobra.Command{
+	Use:     "show <name | id>",
+	Short:   "Show affinity group details",
+	Aliases: gShowAlias,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return cmd.Usage()
+		}
+		return showAffinityGroup(args[0])
+	},
+}
+
+func showAffinityGroup(name string) error {
+	ag, err := getAffinityGroupByName(name)
+	if err != nil {
+		return err
+	}
+
+	table := table.NewTable(os.Stdout)
+	table.SetHeader([]string{"Instance Display Name", "Instance ID"})
+
+	for _, id := range ag.VirtualMachineIDs {
+		vm, err := getVirtualMachineByNameOrID(id)
+		if err != nil {
+			return err
+		}
+
+		table.Append([]string{vm.Name, vm.ID.String()})
+	}
+
+	table.Render()
+
+	return nil
+}
+
+func init() {
+	affinitygroupCmd.AddCommand(affinitygroupShowCmd)
+}

--- a/cmd/affinitygroup_show.go
+++ b/cmd/affinitygroup_show.go
@@ -13,7 +13,7 @@ var affinitygroupShowCmd = &cobra.Command{
 	Short:   "Show affinity group details",
 	Aliases: gShowAlias,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
+		if len(args) != 1 {
 			return cmd.Usage()
 		}
 		return showAffinityGroup(args[0])

--- a/cmd/affinitygroup_show.go
+++ b/cmd/affinitygroup_show.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/exoscale/cli/table"
+	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
 )
 
@@ -26,15 +27,16 @@ func showAffinityGroup(name string) error {
 		return err
 	}
 
+	resp, err := cs.ListWithContext(gContext, &egoscale.ListVirtualMachines{IDs: ag.VirtualMachineIDs})
+	if err != nil {
+		return err
+	}
+
 	table := table.NewTable(os.Stdout)
 	table.SetHeader([]string{"Instance Display Name", "Instance ID"})
 
-	for _, id := range ag.VirtualMachineIDs {
-		vm, err := getVirtualMachineByNameOrID(id)
-		if err != nil {
-			return err
-		}
-
+	for _, r := range resp {
+		vm := r.(*egoscale.VirtualMachine)
 		table.Append([]string{vm.Name, vm.ID.String()})
 	}
 

--- a/cmd/affinitygroup_show.go
+++ b/cmd/affinitygroup_show.go
@@ -27,6 +27,10 @@ func showAffinityGroup(name string) error {
 		return err
 	}
 
+	if len(ag.VirtualMachineIDs) == 0 {
+		return nil
+	}
+
 	resp, err := cs.ListWithContext(gContext, &egoscale.ListVirtualMachines{IDs: ag.VirtualMachineIDs})
 	if err != nil {
 		return err

--- a/cmd/vm_show.go
+++ b/cmd/vm_show.go
@@ -84,7 +84,11 @@ func showVM(name string) error {
 
 	sgName := strings.Join(sgs, " - ")
 
-	table.Append([]string{"Security Group", sgName})
+	table.Append([]string{"Security Groups", sgName})
+
+	ags := getAffinityGroups(vm)
+
+	table.Append([]string{"Affinity Groups", strings.Join(ags, " - ")})
 
 	table.Append([]string{"Instance IP", vm.IP().String()})
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/cpuguy83/go-md2man v1.0.8 // indirect
 	github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d
-	github.com/exoscale/egoscale v0.14.1
+	github.com/exoscale/egoscale v0.14.3
 	github.com/fatih/camelcase v1.0.0
 	github.com/go-ini/ini v1.42.0
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect

--- a/vendor/github.com/exoscale/egoscale/.travis.yml
+++ b/vendor/github.com/exoscale/egoscale/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 
-dist: trusty
+dist: xenial
 sudo: required
 
 go:
@@ -9,6 +9,7 @@ go:
 - "1.9.x"
 - "1.10.x"
 - "1.11.x"
+- "1.12.x"
 - tip
 
 env:

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+0.14.3
+------
+
+- fix: `AffinityGroup` lists virtual machines with `UUID` rather than string
+
+0.14.2
+------
+
+- fix: `ListVirtualMachines` by `IDs` to accept `UUID` rather than string
+
 0.14.1
 ------
 

--- a/vendor/github.com/exoscale/egoscale/affinity_groups.go
+++ b/vendor/github.com/exoscale/egoscale/affinity_groups.go
@@ -11,12 +11,12 @@ import (
 // Affinity and Anti-Affinity groups provide a way to influence where VMs should run.
 // See: http://docs.cloudstack.apache.org/projects/cloudstack-administration/en/stable/virtual_machines.html#affinity-groups
 type AffinityGroup struct {
-	Account           string   `json:"account,omitempty" doc:"the account owning the affinity group"`
-	Description       string   `json:"description,omitempty" doc:"the description of the affinity group"`
-	ID                *UUID    `json:"id,omitempty" doc:"the ID of the affinity group"`
-	Name              string   `json:"name,omitempty" doc:"the name of the affinity group"`
-	Type              string   `json:"type,omitempty" doc:"the type of the affinity group"`
-	VirtualMachineIDs []string `json:"virtualmachineIds,omitempty" doc:"virtual machine Ids associated with this affinity group"`
+	Account           string `json:"account,omitempty" doc:"the account owning the affinity group"`
+	Description       string `json:"description,omitempty" doc:"the description of the affinity group"`
+	ID                *UUID  `json:"id,omitempty" doc:"the ID of the affinity group"`
+	Name              string `json:"name,omitempty" doc:"the name of the affinity group"`
+	Type              string `json:"type,omitempty" doc:"the type of the affinity group"`
+	VirtualMachineIDs []UUID `json:"virtualmachineIds,omitempty" doc:"virtual machine Ids associated with this affinity group"`
 }
 
 // ListRequest builds the ListAffinityGroups request

--- a/vendor/github.com/exoscale/egoscale/version.go
+++ b/vendor/github.com/exoscale/egoscale/version.go
@@ -1,4 +1,4 @@
 package egoscale
 
 // Version of the library
-const Version = "0.14.1"
+const Version = "0.14.3"

--- a/vendor/github.com/exoscale/egoscale/virtual_machines.go
+++ b/vendor/github.com/exoscale/egoscale/virtual_machines.go
@@ -509,7 +509,7 @@ type ListVirtualMachines struct {
 	ForVirtualNetwork *bool         `json:"forvirtualnetwork,omitempty" doc:"list by network type; true if need to list vms using Virtual Network, false otherwise"`
 	GroupID           *UUID         `json:"groupid,omitempty" doc:"the group ID"`
 	ID                *UUID         `json:"id,omitempty" doc:"the ID of the virtual machine"`
-	IDs               []string      `json:"ids,omitempty" doc:"the IDs of the virtual machines, mutually exclusive with id"`
+	IDs               []UUID        `json:"ids,omitempty" doc:"the IDs of the virtual machines, mutually exclusive with id"`
 	IPAddress         net.IP        `json:"ipaddress,omitempty" doc:"an IP address to filter the result"`
 	IsoID             *UUID         `json:"isoid,omitempty" doc:"list vms by iso"`
 	Keyword           string        `json:"keyword,omitempty" doc:"List by keyword"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -17,7 +17,7 @@ github.com/client9/misspell
 github.com/cpuguy83/go-md2man/md2man
 # github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.14.1
+# github.com/exoscale/egoscale v0.14.3
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/admin
 # github.com/fatih/camelcase v1.0.0


### PR DESCRIPTION
Output example:

```console
$ exo affinitygroup show aa0
┼───────────────────────┼──────────────────────────────────────┼
│ INSTANCE DISPLAY NAME │             INSTANCE ID              │
┼───────────────────────┼──────────────────────────────────────┼
│ vm1                   │ xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx │
│ vm2                   │ yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy │
┼───────────────────────┼──────────────────────────────────────┼

$ exo vm show vm1
┼───────────────────────┼──────────────────────────────────────┼
│          VM1          │                                      │
┼───────────────────────┼──────────────────────────────────────┼
│ State                 │ Running                              │
│ OS Template           │ Linux Ubuntu 18.04 LTS 64-bit        │
│ Region                │ ch-gva-2                             │
│ Instance Type         │ Micro                                │
│ Disk                  │ 10 GB                                │
│ Instance Hostname     │ vm1                                  │
│ Instance Display Name │ vm1                                  │
│ Instance Username     │ ubuntu                               │
│ Created on            │ 2019-02-27T10:12:28+0100             │
│ Base SSH Key          │ default                              │
│ Security Groups       │ default                              │
│ Affinity Groups       │ aa0                                  │
│ Instance IP           │ a.b.c.d                              │
│ ID                    │ xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx │
┼───────────────────────┼──────────────────────────────────────┼
```