### PR TITLE
config: improve life of people without config

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -81,9 +81,9 @@ const (
 var configCmd = &cobra.Command{
 	Use:   "config",
 	Short: "Manage config for exo cli",
-	PersistentPreRun: func(_ *cobra.Command, _ []string) {
-		if gAllAccount == nil {
-			log.Fatalf("remove ENV credentials variables to use config cmd")
+	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
+		if strings.HasPrefix(cmd.Use, "config") && gAllAccount == nil {
+			log.Fatalf("remove ENV credentials variables to use %s", cmd.CalledAs())
 		}
 	},
 }
@@ -252,7 +252,7 @@ Let's start over.
 		account.Name = name
 	}
 
-	for isAccountExist(account.Name) {
+	for doesAccountExist(account.Name) {
 		fmt.Printf("Name [%s] already exist\n", name)
 		name, err = readInput(reader, "Name", account.Name)
 		if err != nil {
@@ -477,7 +477,7 @@ func importCloudstackINI(option, csPath, cfgPath string) error {
 			csAccount.Name = name
 		}
 
-		for isAccountExist(csAccount.Name) {
+		for doesAccountExist(csAccount.Name) {
 			fmt.Printf("Account name [%s] already exist\n", csAccount.Name)
 			name, err = readInput(reader, fmt.Sprintf("Name (org: %q)", csAccount.Account), csAccount.Name)
 			if err != nil {
@@ -511,10 +511,10 @@ func importCloudstackINI(option, csPath, cfgPath string) error {
 	return addAccount(cfgPath, config)
 }
 
-func isAccountExist(name string) bool {
+func doesAccountExist(name string) bool {
 
 	if gAllAccount == nil {
-		return false
+		return gCurrentAccount.Name == name
 	}
 
 	for _, acc := range gAllAccount.Accounts {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -81,15 +81,15 @@ const (
 var configCmd = &cobra.Command{
 	Use:   "config",
 	Short: "Manage config for exo cli",
-	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
-		if strings.HasPrefix(cmd.Use, "config") && gAllAccount == nil {
-			log.Fatalf("remove ENV credentials variables to use %s", cmd.CalledAs())
-		}
-	},
+	RunE:  configCmdRun,
 }
 
 func configCmdRun(cmd *cobra.Command, args []string) error {
-	if viper.ConfigFileUsed() != "" && gAccountName != "" {
+	if gConfigFilePath == "" && gCurrentAccount.Key != "" {
+		log.Fatalf("remove ENV credentials variables to use %s", cmd.CalledAs())
+	}
+
+	if gConfigFilePath != "" && gCurrentAccount.Key != "" {
 		fmt.Println("Good day! exo is already configured:")
 		accounts := listAccounts()
 		prompt := promptui.Select{
@@ -657,6 +657,5 @@ func chooseZone(accountName string, cs *egoscale.Client) (string, error) {
 
 func init() {
 
-	configCmd.RunE = configCmdRun
 	RootCmd.AddCommand(configCmd)
 }

--- a/cmd/config_delete.go
+++ b/cmd/config_delete.go
@@ -19,7 +19,7 @@ var configDeleteCmd = &cobra.Command{
 		if gAllAccount == nil {
 			return fmt.Errorf("no accounts defined")
 		}
-		if !isAccountExist(args[0]) {
+		if !doesAccountExist(args[0]) {
 			return fmt.Errorf("account %q doesn't exist", args[0])
 		}
 

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -19,7 +19,7 @@ var configSetCmd = &cobra.Command{
 			return fmt.Errorf("no accounts are defined")
 		}
 
-		if !isAccountExist(args[0]) {
+		if !doesAccountExist(args[0]) {
 			return fmt.Errorf("account %q does not exist", args[0])
 		}
 

--- a/cmd/config_show.go
+++ b/cmd/config_show.go
@@ -15,7 +15,7 @@ var showCmd = &cobra.Command{
 	Short:   "Show an account details",
 	Aliases: gShowAlias,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if gCurrentAccount == nil {
+		if gAllAccount == nil {
 			return fmt.Errorf("no accounts are defined")
 		}
 
@@ -30,10 +30,7 @@ var showCmd = &cobra.Command{
 
 		acc := getAccountByName(account)
 		if acc == nil {
-			if account != gCurrentAccount.AccountName() {
-				return fmt.Errorf("account %q was not found", account)
-			}
-			acc = gCurrentAccount
+			return fmt.Errorf("account %q was not found", account)
 		}
 
 		secret := strings.Repeat("×", len(acc.Secret)/4)
@@ -64,7 +61,7 @@ var showCmd = &cobra.Command{
 			fmt.Fprintf(w, "SOS Endpoint:\t%s\n", acc.SosEndpoint) // nolint: errcheck
 		}
 
-		fmt.Fprintf(w, "\t\n")                                  // nolink: errcheck
+		fmt.Fprintf(w, "\t\n") // nolink: errcheck
 		if gConfigFilePath != "" {
 			fmt.Fprintf(w, "Configuration:\t%s\n", gConfigFilePath) // nolink: errcheck
 			fmt.Fprintf(w, "Storage:\t%s\n", gConfigFolder)         // nolint: errcheck

--- a/cmd/config_show.go
+++ b/cmd/config_show.go
@@ -15,7 +15,7 @@ var showCmd = &cobra.Command{
 	Short:   "Show an account details",
 	Aliases: gShowAlias,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if gAllAccount == nil {
+		if gCurrentAccount == nil {
 			return fmt.Errorf("no accounts are defined")
 		}
 
@@ -24,13 +24,16 @@ var showCmd = &cobra.Command{
 			account = args[0]
 		}
 
-		if !isAccountExist(account) {
+		if !doesAccountExist(account) {
 			return fmt.Errorf("account %q does not exist", account)
 		}
 
 		acc := getAccountByName(account)
 		if acc == nil {
-			return fmt.Errorf("account %q was not found", account)
+			if account != gCurrentAccount.AccountName() {
+				return fmt.Errorf("account %q was not found", account)
+			}
+			acc = gCurrentAccount
 		}
 
 		secret := strings.Repeat("×", len(acc.Secret)/4)
@@ -62,8 +65,12 @@ var showCmd = &cobra.Command{
 		}
 
 		fmt.Fprintf(w, "\t\n")                                  // nolink: errcheck
-		fmt.Fprintf(w, "Configuration:\t%s\n", gConfigFilePath) // nolink: errcheck
-		fmt.Fprintf(w, "Storage:\t%s\n", gConfigFolder)         // nolint: errcheck
+		if gConfigFilePath != "" {
+			fmt.Fprintf(w, "Configuration:\t%s\n", gConfigFilePath) // nolink: errcheck
+			fmt.Fprintf(w, "Storage:\t%s\n", gConfigFolder)         // nolint: errcheck
+		} else {
+			fmt.Fprintf(w, "Configuration:\tenvironment variables\n") // nolink: errcheck
+		}
 
 		return w.Flush()
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -174,7 +174,13 @@ func initConfig() {
 			gCurrentAccount.SosEndpoint = envSosEndpoint
 		}
 
+		gAllAccount = &config{
+			DefaultAccount: gCurrentAccount.Name,
+			Accounts:       []account{*gCurrentAccount},
+		}
+
 		cs = egoscale.NewClient(gCurrentAccount.Endpoint, envKey, envSecret)
+
 		return
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ var gAccountName string
 var gCurrentAccount = &account{
 	DefaultZone:     defaultZone,
 	DefaultTemplate: defaultTemplate,
+	Endpoint:        defaultEndpoint,
 	SosEndpoint:     defaultSosEndpoint,
 }
 
@@ -120,7 +121,6 @@ func buildClient() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-
 	envs := map[string]string{
 		"EXOSCALE_CONFIG":  "config",
 		"EXOSCALE_ACCOUNT": "account",
@@ -161,11 +161,20 @@ func initConfig() {
 		"EXOSCALE_SOS_ENDPOINT",
 	)
 
-	if envEndpoint != "" && envKey != "" && envSecret != "" {
-		gCurrentAccount.SosEndpoint = envSosEndpoint
+	if envKey != "" && envSecret != "" {
+		gCurrentAccount.Name = "environment variables"
+		gCurrentAccount.Account = "unknown"
 		gCurrentAccount.Key = envKey
 		gCurrentAccount.Secret = envSecret
-		cs = egoscale.NewClient(envEndpoint, envKey, envSecret)
+
+		if envEndpoint != "" {
+			gCurrentAccount.Endpoint = envEndpoint
+		}
+		if envSosEndpoint != "" {
+			gCurrentAccount.SosEndpoint = envSosEndpoint
+		}
+
+		cs = egoscale.NewClient(gCurrentAccount.Endpoint, envKey, envSecret)
 		return
 	}
 
@@ -203,14 +212,14 @@ func initConfig() {
 		viper.AddConfigPath(".")
 	}
 
-	nonCredentialCmd := []string{"config", "version", "status"}
-
-	if err := viper.ReadInConfig(); err != nil && isNonCredentialCmd(nonCredentialCmd...) {
-		ignoreClientBuild = true
-		return
-	}
+	nonCredentialCmds := []string{"config", "version", "status"}
 
 	if err := viper.ReadInConfig(); err != nil {
+		if isNonCredentialCmd(nonCredentialCmds...) {
+			ignoreClientBuild = true
+			return
+		}
+
 		log.Fatal(err)
 	}
 
@@ -223,7 +232,7 @@ func initConfig() {
 	}
 
 	if len(config.Accounts) == 0 {
-		if isNonCredentialCmd(nonCredentialCmd...) {
+		if isNonCredentialCmd(nonCredentialCmds...) {
 			ignoreClientBuild = true
 			return
 		}
@@ -240,7 +249,6 @@ func initConfig() {
 		gAccountName = config.DefaultAccount
 	}
 
-	gAllAccount = config
 	gAllAccount.DefaultAccount = gAccountName
 
 	for i, acc := range config.Accounts {


### PR DESCRIPTION
`exo config` should play nicer now.

**env**

```
% exo config     
remove ENV credentials variables to use config
% exo config show
                  environment variables

Account:          unknown
API Key:          EXO4d60e5e69f0225b35cb4fa05
API Secret:       ××××××××××

Default zone:     ch-dk-2
Default template: Linux Ubuntu 18.04 LTS 64-bit

Configuration:    environment variables
```

**no env**

```
% exo config
We've found a "cloudstack.ini" configuration file with the following configurations:
    ...

% exo config show
no accounts are defined
```