### PR TITLE
config: panic on empty defaultZone

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -277,9 +277,14 @@ func initConfig() {
 		}
 	}
 
+	if gCurrentAccount.DefaultZone == "" {
+		gCurrentAccount.DefaultZone = defaultZone
+	}
+
 	if gCurrentAccount.DNSEndpoint == "" {
 		gCurrentAccount.DNSEndpoint = strings.Replace(gCurrentAccount.Endpoint, "/compute", "/dns", 1)
 	}
+
 	if gCurrentAccount.DefaultTemplate == "" {
 		gCurrentAccount.DefaultTemplate = defaultTemplate
 	}


### PR DESCRIPTION
be resilient when the config doesn't have any zone set.