### PR TITLE
Allow VM instance security group modification

### DIFF
--- a/cmd/vm_firewall.go
+++ b/cmd/vm_firewall.go
@@ -138,7 +138,7 @@ func setVirtualMachineSecurityGroups(vm *egoscale.VirtualMachine, sgs []egoscale
 	table := table.NewTable(os.Stdout)
 	table.SetHeader([]string{vm.Name})
 	vmsgs := getSecurityGroup(vm)
-	table.Append([]string{"Security Groups", strings.Join(vmsgs, " - ")})
+	table.Append([]string{"Security Groups", strings.Join(vmsgs, ", ")})
 	table.Render()
 
 	return nil

--- a/cmd/vm_firewall.go
+++ b/cmd/vm_firewall.go
@@ -35,6 +35,7 @@ var vmFirewallSetCmd = &cobra.Command{
 			return err
 		}
 
+		defer printVirtualMachineSecurityGroups(vm)
 		return setVirtualMachineSecurityGroups(vm, sgs)
 	},
 }
@@ -71,6 +72,7 @@ var vmFirewallAddCmd = &cobra.Command{
 			sgToAdd = append(sgToAdd, sgs[i])
 		}
 
+		defer printVirtualMachineSecurityGroups(vm)
 		return setVirtualMachineSecurityGroups(vm, append(vm.SecurityGroup, sgToAdd...))
 	},
 }
@@ -106,6 +108,7 @@ var vmFirewallRemoveCmd = &cobra.Command{
 			sgRemaining = append(sgRemaining, vm.SecurityGroup[i])
 		}
 
+		defer printVirtualMachineSecurityGroups(vm)
 		return setVirtualMachineSecurityGroups(vm, sgRemaining)
 	},
 }
@@ -135,13 +138,18 @@ func setVirtualMachineSecurityGroups(vm *egoscale.VirtualMachine, sgs []egoscale
 		return fmt.Errorf("wrong type expected %q, got %T", "egoscale.VirtualMachine", resp)
 	}
 
+	return nil
+}
+
+// printVirtualMachineSecurityGroups prints a virtual machine instance security groups to standard output.
+func printVirtualMachineSecurityGroups(vm *egoscale.VirtualMachine) {
+	// Refresh the vm object to ensure its properties are up-to-date
+	vm, _ = getVirtualMachineByNameOrID(vm.ID.String())
+
 	table := table.NewTable(os.Stdout)
 	table.SetHeader([]string{vm.Name})
-	vmsgs := getSecurityGroup(vm)
-	table.Append([]string{"Security Groups", strings.Join(vmsgs, ", ")})
+	table.Append([]string{"Security Groups", strings.Join(getSecurityGroup(vm), " - ")})
 	table.Render()
-
-	return nil
 }
 
 // getSecurityGroupsByNameOrID tries to retrieve a list of security groups by their name or ID.

--- a/cmd/vm_firewall.go
+++ b/cmd/vm_firewall.go
@@ -1,0 +1,166 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/exoscale/cli/table"
+	"github.com/exoscale/egoscale"
+	"github.com/spf13/cobra"
+)
+
+// vmFirewallCmd represents the vm firewall command
+var vmFirewallCmd = &cobra.Command{
+	Use:   "firewall",
+	Short: "Virtual machines firewall management",
+}
+
+// vmFirewallSetCmd represents the firewall set command
+var vmFirewallSetCmd = &cobra.Command{
+	Use:   "set <vm name> <firewall name> [firewall name] ...",
+	Short: "set the firewalls of a virtual machine",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 2 {
+			return cmd.Usage()
+		}
+
+		sgs, err := getFirewallsByNameOrID(args[1:])
+		if err != nil {
+			return err
+		}
+
+		vm, err := getVirtualMachineByNameOrID(args[0])
+		if err != nil {
+			return err
+		}
+
+		return setVirtualMachineFirewalls(vm, sgs)
+	},
+}
+
+// vmFirewallAddCmd represents the firewall add command
+var vmFirewallAddCmd = &cobra.Command{
+	Use:   "add <vm name> <firewall name> [firewall name] ...",
+	Short: "add firewalls to a virtual machine",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 2 {
+			return cmd.Usage()
+		}
+
+		sgs, err := getFirewallsByNameOrID(args[1:])
+		if err != nil {
+			return err
+		}
+
+		vm, err := getVirtualMachineByNameOrID(args[0])
+		if err != nil {
+			return err
+		}
+
+		sgToAdd := make([]egoscale.SecurityGroup, 0)
+
+	next:
+		// Check if requested firewalls are not already set to the VM instance
+		for i := range sgs {
+			for j := range vm.SecurityGroup {
+				if sgs[i].ID.Equal(*vm.SecurityGroup[j].ID) {
+					continue next
+				}
+			}
+			sgToAdd = append(sgToAdd, sgs[i])
+		}
+
+		return setVirtualMachineFirewalls(vm, append(vm.SecurityGroup, sgToAdd...))
+	},
+}
+
+// vmFirewallRemoveCmd represents the firewall remove command
+var vmFirewallRemoveCmd = &cobra.Command{
+	Use:   "remove <vm name> <firewall name> [firewall name] ...",
+	Short: "remove firewalls from a virtual machine",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 2 {
+			return cmd.Usage()
+		}
+
+		sgs, err := getFirewallsByNameOrID(args[1:])
+		if err != nil {
+			return err
+		}
+
+		vm, err := getVirtualMachineByNameOrID(args[0])
+		if err != nil {
+			return err
+		}
+
+		sgRemaining := make([]egoscale.SecurityGroup, 0)
+
+	next:
+		for i := range vm.SecurityGroup {
+			for j := range sgs {
+				if sgs[j].ID.Equal(*vm.SecurityGroup[i].ID) {
+					continue next
+				}
+			}
+			sgRemaining = append(sgRemaining, vm.SecurityGroup[i])
+		}
+
+		return setVirtualMachineFirewalls(vm, sgRemaining)
+	},
+}
+
+// setVirtualMachineFirewalls sets a virtual machine instance firewalls
+func setVirtualMachineFirewalls(vm *egoscale.VirtualMachine, firewalls []egoscale.SecurityGroup) error {
+	state := (string)(egoscale.VirtualMachineStopped)
+	if vm.State != state {
+		return fmt.Errorf("this operation is not permitted if your VM is not stopped")
+	}
+
+	ids := make([]egoscale.UUID, len(firewalls))
+	for i := range firewalls {
+		ids[i] = *firewalls[i].ID
+	}
+
+	resp, err := cs.RequestWithContext(gContext, &egoscale.UpdateVirtualMachine{
+		ID:               vm.ID,
+		SecurityGroupIDs: ids,
+	})
+	if err != nil {
+		return err
+	}
+
+	vm, ok := resp.(*egoscale.VirtualMachine)
+	if !ok {
+		return fmt.Errorf("wrong type expected %q, got %T", "egoscale.VirtualMachine", resp)
+	}
+
+	table := table.NewTable(os.Stdout)
+	table.SetHeader([]string{vm.Name})
+	sgs := getSecurityGroup(vm)
+	table.Append([]string{"Security Groups", strings.Join(sgs, " - ")})
+	table.Render()
+
+	return nil
+}
+
+// getFirewallsByNameOrID tries to retrieve a list of firewalls by their name or ID.
+func getFirewallsByNameOrID(firewalls []string) ([]egoscale.SecurityGroup, error) {
+	sgs := make([]egoscale.SecurityGroup, len(firewalls))
+	for i, s := range firewalls {
+		sg, err := getSecurityGroupByNameOrID(s)
+		if err != nil {
+			return nil, fmt.Errorf("unable to retrieve firewall %q: %s", s, err)
+		}
+		sgs[i] = *sg
+	}
+
+	return sgs, nil
+}
+
+func init() {
+	vmFirewallCmd.AddCommand(vmFirewallAddCmd)
+	vmFirewallCmd.AddCommand(vmFirewallRemoveCmd)
+	vmFirewallCmd.AddCommand(vmFirewallSetCmd)
+	vmCmd.AddCommand(vmFirewallCmd)
+}

--- a/cmd/vm_firewall.go
+++ b/cmd/vm_firewall.go
@@ -39,8 +39,7 @@ var vmFirewallSetCmd = &cobra.Command{
 			return err
 		}
 
-		printVirtualMachineSecurityGroups(vm)
-		return nil
+		return printVirtualMachineSecurityGroups(vm)
 	},
 }
 
@@ -80,8 +79,7 @@ var vmFirewallAddCmd = &cobra.Command{
 			return err
 		}
 
-		printVirtualMachineSecurityGroups(vm)
-		return nil
+		return printVirtualMachineSecurityGroups(vm)
 	},
 }
 
@@ -120,8 +118,7 @@ var vmFirewallRemoveCmd = &cobra.Command{
 			return err
 		}
 
-		printVirtualMachineSecurityGroups(vm)
-		return nil
+		return printVirtualMachineSecurityGroups(vm)
 	},
 }
 
@@ -149,18 +146,19 @@ func setVirtualMachineSecurityGroups(vm *egoscale.VirtualMachine, sgs []egoscale
 }
 
 // printVirtualMachineSecurityGroups prints a virtual machine instance security groups to standard output.
-func printVirtualMachineSecurityGroups(vm *egoscale.VirtualMachine) {
+func printVirtualMachineSecurityGroups(vm *egoscale.VirtualMachine) error {
 	// Refresh the vm object to ensure its properties are up-to-date
 	vm, err := getVirtualMachineByNameOrID(vm.ID.String())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
+		return err
 	}
 
 	table := table.NewTable(os.Stdout)
 	table.SetHeader([]string{vm.Name})
 	table.Append([]string{"Security Groups", strings.Join(getSecurityGroup(vm), " - ")})
 	table.Render()
+
+	return nil
 }
 
 // getSecurityGroupsByNameOrID tries to retrieve a list of security groups by their name or ID.


### PR DESCRIPTION
Fixes #113.

Example usage:

```console
$ ./exo vm show vm1
┼───────────────────────┼──────────────────────────────────────┼
│          VM1          │                                      │
┼───────────────────────┼──────────────────────────────────────┼
│ State                 │ Stopped                              │
│ OS Template           │ Linux Ubuntu 18.04 LTS 64-bit        │
│ Region                │ ch-dk-2                              │
│ Instance Type         │ Tiny                                 │
│ Disk                  │ 10 GB                                │
│ Instance Hostname     │ vm1                                  │
│ Instance Display Name │ vm1                                  │
│ Instance Username     │ ubuntu                               │
│ Created on            │ 2019-03-08T11:25:12+0100             │
│ Base SSH Key          │ default                              │
│ Security Groups       │ default                              │
│ Affinity Groups       │                                      │
│ Instance IP           │ a.b.c.d                              │
│ ID                    │ 1ed46c21-b32d-4359-bd38-d0d149adbe09 │
┼───────────────────────┼──────────────────────────────────────┼

$ ./exo vm firewall add vm1 sg1 sg2
┼─────────────────┼─────────────────────┼
│       VM1       │                     │
┼─────────────────┼─────────────────────┼
│ Security Groups │ default - sg1 - sg2 │
┼─────────────────┼─────────────────────┼

$ ./exo vm firewall remove vm1 sg2
┼─────────────────┼───────────────┼
│       VM1       │               │
┼─────────────────┼───────────────┼
│ Security Groups │ default - sg1 │
┼─────────────────┼───────────────┼

$ ./exo vm firewall set vm1 default
┼─────────────────┼─────────┼
│       VM1       │         │
┼─────────────────┼─────────┼
│ Security Groups │ default │
┼─────────────────┼─────────┼
```