### PR TITLE
kube: force to accept the new conf of cloud-init

### DIFF
--- a/cmd/kube_create.go
+++ b/cmd/kube_create.go
@@ -21,10 +21,10 @@ import (
 
 const (
 	// kubeDockerVersion is the version recommended by Kubernetes
-	kubeDockerVersion = "18.09"
+	kubeDockerVersion = "18.06"
 
 	// kubeCalicoVersion is the version of Calico installed
-	kubeCalicoVersion = "3.5"
+	kubeCalicoVersion = "3.4"
 
 	// kubeDefaultTemplate is the template to install Kubernetes on.
 	kubeDefaultTemplate = defaultTemplate

--- a/cmd/kube_create.go
+++ b/cmd/kube_create.go
@@ -20,15 +20,13 @@ import (
 )
 
 const (
-	// kubeDockerVersion is the version installed on Ubuntu Xenial
+	// kubeDockerVersion is the version recommended by Kubernetes
 	kubeDockerVersion = "18.06"
 
 	// kubeCalicoVersion is the version of Calico installed
-	kubeCalicoVersion = "3.4"
+	kubeCalicoVersion = "3.5"
 
 	// kubeDefaultTemplate is the template to install Kubernetes on.
-	//
-	// Using xenial means cfssl must be installed by other means
 	kubeDefaultTemplate = defaultTemplate
 )
 
@@ -57,7 +55,7 @@ var kubeBootstrapSteps = []kubeBootstrapStep{
 set -xe
 
 sudo -E DEBIAN_FRONTEND=noninteractive apt-get update
-sudo -E DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
+sudo -E DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" upgrade -y
 sudo -E DEBIAN_FRONTEND=noninteractive apt-get install -y \
 	apt-transport-https \
 	ca-certificates \

--- a/cmd/kube_create.go
+++ b/cmd/kube_create.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// kubeDockerVersion is the version recommended by Kubernetes
-	kubeDockerVersion = "18.06"
+	kubeDockerVersion = "18.09"
 
 	// kubeCalicoVersion is the version of Calico installed
 	kubeCalicoVersion = "3.5"


### PR DESCRIPTION
Fix #122 

```console
% exo labe kube list
|   NAME   |  IP ADDRESS   |  SIZE  | VERSION |  STATE  |
|----------|---------------|--------|---------|---------|
| min1kube | 185.19.29.246 | Medium | 1.14.0  | Running |

% kubectl cluster-info
Kubernetes master is running at https://185.19.29.246:6443
KubeDNS is running at https://185.19.29.246:6443/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy

% kubectl get nodes        
NAME       STATUS   ROLES    AGE   VERSION
min1kube   Ready    master   76s   v1.14.0
```