### PR TITLE
kube: calico/docker version

### DIFF
--- a/cmd/kube.go
+++ b/cmd/kube.go
@@ -14,8 +14,14 @@ var (
 	// kubeSecurityGroup represents the firewall security group to add k8s VM instances into
 	kubeSecurityGroup = "exokube"
 
-	// kubeTagName represents the name of the tag used to store the kubernetes version
-	kubeTagName = "exokube:kubernetes"
+	// kubeTagKubernetes represents the name of the tag used to store the version of Kubernetes
+	kubeTagKubernetes = "exokube:kubernetes"
+
+	// kubeTagCalico represents the name of the tag used to store the version of Calico
+	kubeTagCalico = "exokube:calico"
+
+	// kubeTagDocker represents the name of the tag used to store the version of Docker
+	kubeTagDocker = "exokube:docker"
 )
 
 // kubeCmd represents the kube command
@@ -28,9 +34,9 @@ cluster inside an Exoscale VM for users looking to try out Kubernetes or develop
 with it day-to-day.`,
 }
 
-func getKubeInstanceVersion(vm *egoscale.VirtualMachine) string {
+func getKubeInstanceVersion(vm *egoscale.VirtualMachine, tagName string) string {
 	for _, tag := range vm.Tags {
-		if tag.Key == kubeTagName {
+		if tag.Key == tagName {
 			return tag.Value
 		}
 	}

--- a/cmd/kube_list.go
+++ b/cmd/kube_list.go
@@ -30,17 +30,19 @@ func listKubeInstances() error {
 	}
 
 	table := table.NewTable(os.Stdout)
-	table.SetHeader([]string{"Name", "IP Address", "Size", "Version", "State"})
+	table.SetHeader([]string{"Name", "IP Address", "Size", "Version", "Calico", "Docker", "State"})
 
 	for _, key := range vms {
 		vm := key.(*egoscale.VirtualMachine)
 
-		kubeVersion := getKubeInstanceVersion(vm)
-		if kubeVersion == "" {
-			continue
-		}
-
-		table.Append([]string{vm.Name, vm.IP().String(), vm.ServiceOfferingName, kubeVersion, vm.State})
+		table.Append([]string{
+			vm.Name,
+			vm.IP().String(),
+			vm.ServiceOfferingName,
+			getKubeInstanceVersion(vm, kubeTagKubernetes),
+			getKubeInstanceVersion(vm, kubeTagCalico),
+			getKubeInstanceVersion(vm, kubeTagDocker),
+			vm.State})
 	}
 
 	table.Render()


### PR DESCRIPTION
more flags and calico 3.6 support.

```console
% exo lab kube create min1kube --debug --calico-version 3.4 --docker-version 18.06 --version 1.12.7
% exo lab kube list  
|   NAME   |   IP ADDRESS    |  SIZE  | VERSION | CALICO | DOCKER |  STATE  |
|----------|-----------------|--------|---------|--------|--------|---------|
| min1kube | 159.100.251.200 | Medium | 1.12.7  | 3.4    | 18.06  | Running |
```