### PR TITLE
eip_create/eip-show: support for healthchecks

### DIFF
--- a/cmd/eip_create.go
+++ b/cmd/eip_create.go
@@ -18,19 +18,57 @@ var eipCreateCmd = &cobra.Command{
 		if len(args) >= 1 {
 			zone = args[0]
 		}
-		return associateIPAddress(zone)
+
+		interval, err := cmd.Flags().GetInt64("healthcheck-interval")
+		if err != nil {
+			return err
+		}
+		mode, err := cmd.Flags().GetString("healthcheck-mode")
+		if err != nil {
+			return err
+		}
+		path, err := cmd.Flags().GetString("healthcheck-path")
+		if err != nil {
+			return err
+		}
+		port, err := cmd.Flags().GetInt64("healthcheck-port")
+		if err != nil {
+			return err
+		}
+		strikesFail, err := cmd.Flags().GetInt64("healthcheck-strikes-fail")
+		if err != nil {
+			return err
+		}
+		strikesOK, err := cmd.Flags().GetInt64("healthcheck-strikes-ok")
+		if err != nil {
+			return err
+		}
+		timeout, err := cmd.Flags().GetInt64("healthcheck-timeout")
+		if err != nil {
+			return err
+		}
+		req := egoscale.AssociateIPAddress{
+			HealthcheckInterval:    interval,
+			HealthcheckMode:        mode,
+			HealthcheckPath:        path,
+			HealthcheckPort:        port,
+			HealthcheckStrikesFail: strikesFail,
+			HealthcheckStrikesOk:   strikesOK,
+			HealthcheckTimeout:     timeout,
+		}
+
+		return associateIPAddress(req, zone)
 	},
 }
 
-func associateIPAddress(name string) error {
-	ipReq := egoscale.AssociateIPAddress{}
-	var err error
-	ipReq.ZoneID, err = getZoneIDByName(name)
+func associateIPAddress(associateIPAddress egoscale.AssociateIPAddress, zone string) error {
+	zoneID, err := getZoneIDByName(zone)
 	if err != nil {
 		return err
 	}
+	associateIPAddress.ZoneID = zoneID
 
-	resp, err := cs.RequestWithContext(gContext, &ipReq)
+	resp, err := cs.RequestWithContext(gContext, associateIPAddress)
 	if err != nil {
 		return err
 	}
@@ -47,5 +85,12 @@ func associateIPAddress(name string) error {
 }
 
 func init() {
+	eipCreateCmd.Flags().Int64P("healthcheck-interval", "", 0, "the time in seconds to wait for between each healthcheck.")
+	eipCreateCmd.Flags().StringP("healthcheck-mode", "", "", "the healthcheck type. Should be tcp or http.")
+	eipCreateCmd.Flags().StringP("healthcheck-path", "", "", "the healthcheck path. Required if mode is http.")
+	eipCreateCmd.Flags().Int64P("healthcheck-port", "", 0, "the healthcheck port (e.g. 80 for http).")
+	eipCreateCmd.Flags().Int64P("healthcheck-strikes-fail", "", 0, "the number of times to retry before declaring the IP dead.")
+	eipCreateCmd.Flags().Int64P("healthcheck-strikes-ok", "", 0, "the number of times to retry before declaring the IP healthy.")
+	eipCreateCmd.Flags().Int64P("healthcheck-timeout", "", 0, "the timeout in seconds to wait for each check (default is 2). Should be lower than the interval.")
 	eipCmd.AddCommand(eipCreateCmd)
 }

--- a/cmd/eip_show.go
+++ b/cmd/eip_show.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/exoscale/cli/table"
@@ -32,18 +33,47 @@ var eipShowCmd = &cobra.Command{
 		}
 
 		table := table.NewTable(os.Stdout)
-		table.SetHeader([]string{"Zone", "IP", "Virtual Machine", "Virtual Machine ID"})
 
 		zone := ip.ZoneName
 		ipaddr := ip.IPAddress.String()
+
+		table.SetHeader([]string{ipaddr})
+		table.Append([]string{"ID", id.String()})
+		table.Append([]string{"Zone", zone})
+		if ip.Healthcheck != nil {
+			table.Append([]string{
+				"Healthcheck Mode",
+				ip.Healthcheck.Mode})
+			table.Append([]string{
+				"Healthcheck Path",
+				ip.Healthcheck.Path})
+			table.Append([]string{
+				"Healthcheck Port",
+				fmt.Sprintf("%d", ip.Healthcheck.Port)})
+			table.Append([]string{
+				"Healthcheck Interval",
+				fmt.Sprintf("%d", ip.Healthcheck.Interval)})
+			table.Append([]string{
+				"Healthcheck Strikes Fail",
+				fmt.Sprintf("%d", ip.Healthcheck.StrikesFail)})
+			table.Append([]string{
+				"Healthcheck Strikes OK",
+				fmt.Sprintf("%d", ip.Healthcheck.StrikesOk)})
+			table.Append([]string{
+				"Healthcheck Timeout",
+				fmt.Sprintf("%d", ip.Healthcheck.Timeout)})
+		}
+
 		if len(vms) > 0 {
-			for _, vm := range vms {
-				table.Append([]string{zone, ipaddr, vm.Name, vm.ID.String()})
-				zone = ""
-				ipaddr = ""
+			table.Append([]string{
+				"Instances",
+				vms[0].Name,
+			})
+			for _, vm := range vms[1:] {
+				table.Append([]string{
+					"",
+					vm.Name})
 			}
-		} else {
-			table.Append([]string{zone, ipaddr})
 		}
 		table.Render()
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/cpuguy83/go-md2man v1.0.8 // indirect
 	github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d
-	github.com/exoscale/egoscale v0.14.3
+	github.com/exoscale/egoscale v0.15.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/go-ini/ini v1.42.0
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect

--- a/vendor/github.com/exoscale/egoscale/.gitignore
+++ b/vendor/github.com/exoscale/egoscale/.gitignore
@@ -2,3 +2,4 @@
 dist
 ops.asc
 vendor
+listApis.json

--- a/vendor/github.com/exoscale/egoscale/README.md
+++ b/vendor/github.com/exoscale/egoscale/README.md
@@ -14,7 +14,7 @@ A wrapper for the [Exoscale public cloud](https://www.exoscale.com) API.
 - [Exoscale CLI](https://github.com/exoscale/cli)
 - [Exoscale Terraform provider](https://github.com/exoscale/terraform-provider-exoscale)
 - [ExoIP](https://github.com/exoscale/exoip): IP Watchdog
-- [Lego](https://github.com/xenolf/lego): Let's Encrypt and ACME library
+- [Lego](https://github.com/go-acme/lego): Let's Encrypt and ACME library
 - Kubernetes Incubator: [External DNS](https://github.com/kubernetes-incubator/external-dns)
 - [Docker machine](https://docs.docker.com/machine/drivers/exoscale/)
 - [etc.](https://godoc.org/github.com/exoscale/egoscale?importers)

--- a/vendor/github.com/exoscale/egoscale/addresses.go
+++ b/vendor/github.com/exoscale/egoscale/addresses.go
@@ -6,6 +6,17 @@ import (
 	"net"
 )
 
+// Healthcheck represents an Healthcheck attached to an IP
+type Healthcheck struct {
+	Interval    int64  `json:"interval,omitempty" doc:"healthcheck definition: time in seconds to wait for each check. Default: 10, minimum: 5"`
+	Mode        string `json:"mode,omitempty" doc:"healthcheck definition: healthcheck mode can be either 'tcp' or 'http'"`
+	Path        string `json:"path,omitempty" doc:"healthcheck definition: the path against which the 'http' healthcheck will be performed. Required if mode is 'http', ignored otherwise."`
+	Port        int64  `json:"port,omitempty" doc:"healthcheck definition: the port against which the healthcheck will be performed. Required if a 'mode' is provided."`
+	StrikesFail int64  `json:"strikes-fail,omitempty" doc:"healthcheck definition: number of times to retry before declaring the healthcheck 'dead'. Default: 3"`
+	StrikesOk   int64  `json:"strikes-ok,omitempty" doc:"healthcheck definition: number of times to retry before declaring the healthcheck 'alive'. Default: 2"`
+	Timeout     int64  `json:"timeout,omitempty" doc:"healthcheck definition: time in seconds to wait for each check. Default: 2, cannot be greater than interval."`
+}
+
 // IPAddress represents an IP Address
 type IPAddress struct {
 	Allocated                 string        `json:"allocated,omitempty" doc:"date the public IP address was acquired"`
@@ -13,6 +24,7 @@ type IPAddress struct {
 	AssociatedNetworkID       *UUID         `json:"associatednetworkid,omitempty" doc:"the ID of the Network associated with the IP address"`
 	AssociatedNetworkName     string        `json:"associatednetworkname,omitempty" doc:"the name of the Network associated with the IP address"`
 	ForVirtualNetwork         bool          `json:"forvirtualnetwork,omitempty" doc:"the virtual network for the IP address"`
+	Healthcheck               *Healthcheck  `json:"healthcheck,omitempty" doc:"The IP healthcheck configuration"`
 	ID                        *UUID         `json:"id,omitempty" doc:"public IP address id"`
 	IPAddress                 net.IP        `json:"ipaddress,omitempty" doc:"public IP address"`
 	IsElastic                 bool          `json:"iselastic,omitempty" doc:"is an elastic ip"`
@@ -77,10 +89,15 @@ func (ipaddress IPAddress) Delete(ctx context.Context, client *Client) error {
 
 // AssociateIPAddress (Async) represents the IP creation
 type AssociateIPAddress struct {
-	IsPortable *bool `json:"isportable,omitempty" doc:"should be set to true if public IP is required to be transferable across zones, if not specified defaults to false"`
-	NetworkdID *UUID `json:"networkid,omitempty" doc:"The network this ip address should be associated to."`
-	ZoneID     *UUID `json:"zoneid,omitempty" doc:"the ID of the availability zone you want to acquire an public IP address from"`
-	_          bool  `name:"associateIpAddress" description:"Acquires and associates a public IP to an account."`
+	HealthcheckInterval    int64  `json:"interval,omitempty" doc:"healthcheck definition: time in seconds to wait for each check. Default: 10, minimum: 5"`
+	HealthcheckMode        string `json:"mode,omitempty" doc:"healthcheck definition: healthcheck mode can be either 'tcp' or 'http'"`
+	HealthcheckPath        string `json:"path,omitempty" doc:"healthcheck definition: the path against which the 'http' healthcheck will be performed. Required if mode is 'http', ignored otherwise."`
+	HealthcheckPort        int64  `json:"port,omitempty" doc:"healthcheck definition: the port against which the healthcheck will be performed. Required if a 'mode' is provided."`
+	HealthcheckStrikesFail int64  `json:"strikes-fail,omitempty" doc:"healthcheck definition: number of times to retry before declaring the healthcheck 'dead'. Default: 3"`
+	HealthcheckStrikesOk   int64  `json:"strikes-ok,omitempty" doc:"healthcheck definition: number of times to retry before declaring the healthcheck 'alive'. Default: 2"`
+	HealthcheckTimeout     int64  `json:"timeout,omitempty" doc:"healthcheck definition: time in seconds to wait for each check. Default: 2, cannot be greater than interval."`
+	ZoneID                 *UUID  `json:"zoneid,omitempty" doc:"the ID of the availability zone you want to acquire an public IP address from"`
+	_                      bool   `name:"associateIpAddress" description:"Acquires and associates a public IP to an account."`
 }
 
 // Response returns the struct to unmarshal

--- a/vendor/github.com/exoscale/egoscale/dns.go
+++ b/vendor/github.com/exoscale/egoscale/dns.go
@@ -14,9 +14,6 @@ import (
 // DNSDomain represents a domain
 type DNSDomain struct {
 	ID             int64  `json:"id"`
-	AccountID      int64  `json:"account_id,omitempty"`
-	UserID         int64  `json:"user_id,omitempty"`
-	RegistrantID   int64  `json:"registrant_id,omitempty"`
 	Name           string `json:"name"`
 	UnicodeName    string `json:"unicode_name"`
 	Token          string `json:"token"`

--- a/vendor/github.com/exoscale/egoscale/version.go
+++ b/vendor/github.com/exoscale/egoscale/version.go
@@ -1,4 +1,4 @@
 package egoscale
 
 // Version of the library
-const Version = "0.14.3"
+const Version = "0.15.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -54,7 +54,7 @@ github.com/dlclark/regexp2
 github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.14.3
+# github.com/exoscale/egoscale v0.14.4-0.20190401095233-3ad41b3e71e6
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/admin
 # github.com/fatih/camelcase v1.0.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -54,7 +54,7 @@ github.com/dlclark/regexp2
 github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.14.4-0.20190401095233-3ad41b3e71e6
+# github.com/exoscale/egoscale v0.15.0
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/admin
 # github.com/fatih/camelcase v1.0.0


### PR DESCRIPTION
- in eip_create.go, add new parameters for the healthcheck definition
- in eip_show.go, show the healthcheck parameters.

```
./exo -A dev eip create --mode http --path "/" --port 8080
┼──────────┼─────────────────┼──────────────────────────────────────┼
│   ZONE   │       IP        │                  ID                  │
┼──────────┼─────────────────┼──────────────────────────────────────┼
│ ch-gva-2 │ 159.100.241.213 │ f0b14bcc-cd82-4364-b36d-b63d2e05af8d │
┼──────────┼─────────────────┼──────────────────────────────────────┼


./exo -A dev eip show f0b14bcc-cd82-4364-b36d-b63d2e05af8d
┼──────────┼─────────────────┼─────────────────┼────────────────────┼──────────┼──────┼──────┼──────┼──────────────┼────────────┼─────────┼
│   ZONE   │       IP        │ VIRTUAL MACHINE │ VIRTUAL MACHINE ID │ INTERVAL │ MODE │ PATH │ PORT │ STRIKES FAIL │ STRIKES OK │ TIMEOUT │
┼──────────┼─────────────────┼─────────────────┼────────────────────┼──────────┼──────┼──────┼──────┼──────────────┼────────────┼─────────┼
│ ch-gva-2 │ 159.100.241.213 │                 │                    │ 10       │ http │ /    │ 8080 │ 3            │ 2          │ 2       │
┼──────────┼─────────────────┼─────────────────┼────────────────────┼──────────┼──────┼──────┼──────┼──────────────┼────────────┼─────────┼

```

This PR needs https://github.com/exoscale/egoscale/pull/396 merged.

Story: [EIP health checking in exo CLI](https://app.clubhouse.io/exoscale/story/1915)