### PR TITLE
Fix content-type sniffing on files < 512 bytes

### DIFF
--- a/cmd/sos_upload.go
+++ b/cmd/sos_upload.go
@@ -102,20 +102,19 @@ var sosUploadCmd = &cobra.Command{
 			} else {
 				var contentType string
 				var bufferSize int64
-				
+
 				// Only the first 512 bytes are used to sniff the content type.
 				if fileStat.Size() >= 512 {
 					bufferSize = 512
 				} else {
 					bufferSize = fileStat.Size()
 				}
-				
+
 				buffer := make([]byte, bufferSize)
 				_, err = file.Read(buffer)
 
 				contentType = http.DetectContentType(buffer)
 
-				
 				filesToUpload = append(filesToUpload, fileToUpload{
 					localPath:   filePath,
 					remotePath:  remote,

--- a/cmd/sos_upload.go
+++ b/cmd/sos_upload.go
@@ -101,14 +101,21 @@ var sosUploadCmd = &cobra.Command{
 				filesToUpload, err = getFiles(filePath, strings.TrimRight(remote, "/"), filesToUpload)
 			} else {
 				var contentType string
+				var bufferSize int
+				
+				// Only the first 512 bytes are used to sniff the content type.
 				if fileStat.Size() >= 512 {
-					// Only the first 512 bytes are used to sniff the content type.
-					buffer := make([]byte, 512)
-					_, err = file.Read(buffer)
-
-					contentType = http.DetectContentType(buffer)
-
+					bufferSize = 512
+				} else {
+					bufferSize = fileStat.Size()
 				}
+				
+				buffer := make([]byte, bufferSize)
+				_, err = file.Read(buffer)
+
+				contentType = http.DetectContentType(buffer)
+
+				
 				filesToUpload = append(filesToUpload, fileToUpload{
 					localPath:   filePath,
 					remotePath:  remote,

--- a/cmd/sos_upload.go
+++ b/cmd/sos_upload.go
@@ -101,7 +101,7 @@ var sosUploadCmd = &cobra.Command{
 				filesToUpload, err = getFiles(filePath, strings.TrimRight(remote, "/"), filesToUpload)
 			} else {
 				var contentType string
-				var bufferSize int
+				var bufferSize int64
 				
 				// Only the first 512 bytes are used to sniff the content type.
 				if fileStat.Size() >= 512 {


### PR DESCRIPTION
Fix #130 