### PR TITLE
template list: add the templateFilter parameter

### DIFF
--- a/cmd/template.go
+++ b/cmd/template.go
@@ -54,14 +54,14 @@ func getTemplateByName(zoneID *egoscale.UUID, name string) (*egoscale.Template, 
 	return &sortedTemplates[0], nil
 }
 
-func findTemplates(zoneID *egoscale.UUID, filters ...string) ([]egoscale.Template, error) {
+func findTemplates(zoneID *egoscale.UUID, templateFilter string, filters ...string) ([]egoscale.Template, error) {
 	allOS := make(map[string]*egoscale.Template)
 
 	reLinux := regexp.MustCompile(`^Linux (?P<name>.+?) (?P<version>[0-9]+(\.[0-9]+)?)`)
 	reVersion := regexp.MustCompile(`(?P<version>[0-9]+(\.[0-9]+)?)`)
 
 	req := &egoscale.ListTemplates{
-		TemplateFilter: "featured",
+		TemplateFilter: templateFilter,
 		ZoneID:         zoneID,
 		Keyword:        strings.Join(filters, " "),
 	}


### PR DESCRIPTION
Users should be able to list community, self, and featured templates.
By default, featured template are shown.

```
./exo vm template list
┼──────────────────────────────────┼──────┼───────────────────┼──────────────────────────────────────┼──────────┼
│         OPERATING SYSTEM         │ DISK │   RELEASE DATE    │                  ID                  │ CATEGORY │
┼──────────────────────────────────┼──────┼───────────────────┼──────────────────────────────────────┼──────────┼
│ CiscoASAv-9101_001               │ 8    │ 2019-04-10        │ bbec29ac-6f78-4a4e-81a4-eb5d5d6983a1 │ featured │
│ FreeBSD pfSense 2.5 64-bit       │ 1    │ 2019-04-16        │ 628f4609-8bf1-43df-b2fe-db315acdf9b0 │ featured │
│ Linux CentOS 7.6 64-bit          │ 1    │ 2019-03-11        │ 74e22423-2731-4835-9e6e-10035f2e4c24 │ featured │
│ Linux CoreOS 1975 64-bit         │      │ 2019-04-10        │ 22e956a4-d9df-4d04-bc78-b4b50a539659 │ featured │
│ Linux Debian 9 Exoscale 64-bit   │ 1    │ 2019-02-26        │ 1943fe75-ad80-4720-aee2-5834122ea4aa │ featured │
│ Linux Fedora 29 64-bit           │ 2    │ 2019-02-01        │ 7aeeb462-fd4e-4039-8a53-7d784fdbebdc │ featured │
│ Linux RancherOS 1.5.1 64-bit     │      │ 2019-03-28        │ ea818a2b-cc15-4c85-a9d2-f25479d7ace7 │ featured │
│ Linux RedHat 7.6 64-bit          │ 2    │ 2019-03-26        │ e9b184ca-8a8e-4a49-8e97-5fd12e5322dc │ featured │
│ Linux Ubuntu 18.10 64-bit        │      │ 2018-10-18-74807a │ 441276f3-114a-4572-9e84-ec21dd908a6f │ featured │
│ Linux Ubuntu 18.04 64-bit        │      │ 2018-04-26-0e6133 │ f3bfb04d-4ccb-420c-9540-db95a4aec3ea │ featured │
│ Pfsense 2.4.4 64-bit             │ 10   │ 2019-03-28        │ 4d388ced-209d-4be4-932c-f99d14d6e3b9 │ featured │
│ TestingCompute: Exoscale-NetBoot │ 0    │ 2019-01-27        │ 85489f78-efd2-4748-bcd7-d0cb2fe1fe33 │ featured │
│ Ubuntu Minimal 18.04             │ 0    │ 2019-02-01        │ cd829888-2120-4051-b30e-3b5c78ea1bc8 │ featured │
│ Windows Server 2016              │ 50   │ 2018-04-28-f0232  │ 500eb7f6-9771-4e89-9a6f-1d9a16f77d87 │ featured │
│ netboot.xyz                      │ 100  │ 2016-12-06-3e9b74 │ 7309c685-d4b4-4221-b989-7df396d1eed0 │ featured │
┼──────────────────────────────────┼──────┼───────────────────┼──────────────────────────────────────┼──────────┼


./exo vm template list --featured --mine --community
┼──────────────────────────────────────────┼──────┼───────────────────┼──────────────────────────────────────┼───────────┼
│             OPERATING SYSTEM             │ DISK │   RELEASE DATE    │                  ID                  │ CATEGORY  │
┼──────────────────────────────────────────┼──────┼───────────────────┼──────────────────────────────────────┼───────────┼
│ FreeBSD pfSense 2.5 64-bit               │ 1    │ 2019-03-29        │ e41df185-6791-40be-8b1e-2b548c58d9e3 │ community │
│ Linux CentOS 7.6 Big Data 64-bit         │ 1    │ 2019-01-28        │ 61e14ee6-9ff8-4208-b2e1-25a5df695c35 │ community │
│ Linux CentOS UEFI 7.6 64-bit             │ 1    │ 2019-02-26        │ 3d710cf0-5c0f-4137-b3f2-d36438fca9a6 │ community │
│ Linux CoreOS 1975 64-bit                 │ 0    │ 2019-02-12        │ d41c812e-3661-4979-b074-455b320bcef9 │ community │
│ Linux Debian 9 DD 64-bit                 │ 1    │ 2019-02-07        │ 0199b787-3810-4668-8ed7-91af3f760113 │ community │
│ Linux RedHat 7.6 Vanilla Big Data 64-bit │ 1    │ 2019-02-04        │ 5c48278f-f6f1-4722-9b4a-95a4d7354dc9 │ community │
│ Linux Ubuntu UEFI 64-bit                 │ 0    │ 2019-02-26        │ b40cabd0-5cb2-4eff-85f4-9e7bf7f531c5 │ community │
│ Ubuntu Minimal 18.04                     │ 0    │ call              │ 1ee08a18-bada-4924-aba8-d2fdee787c87 │ community │
│ CiscoASAv-9101_001                       │ 8    │ 2019-04-10        │ bbec29ac-6f78-4a4e-81a4-eb5d5d6983a1 │ featured  │
│ FreeBSD pfSense 2.5 64-bit               │ 1    │ 2019-04-16        │ 628f4609-8bf1-43df-b2fe-db315acdf9b0 │ featured  │
│ Linux CentOS 7.6 64-bit                  │ 1    │ 2019-03-11        │ 74e22423-2731-4835-9e6e-10035f2e4c24 │ featured  │
│ Linux CoreOS 1975 64-bit                 │      │ 2019-04-10        │ 22e956a4-d9df-4d04-bc78-b4b50a539659 │ featured  │
│ Linux Debian 9 Exoscale 64-bit           │ 1    │ 2019-02-26        │ 1943fe75-ad80-4720-aee2-5834122ea4aa │ featured  │
│ Linux Fedora 29 64-bit                   │ 2    │ 2019-02-01        │ 7aeeb462-fd4e-4039-8a53-7d784fdbebdc │ featured  │
│ Linux RancherOS 1.5.1 64-bit             │      │ 2019-03-28        │ ea818a2b-cc15-4c85-a9d2-f25479d7ace7 │ featured  │
│ Linux RedHat 7.6 64-bit                  │ 2    │ 2019-03-26        │ e9b184ca-8a8e-4a49-8e97-5fd12e5322dc │ featured  │
│ Linux Ubuntu 18.10 64-bit                │      │ 2018-10-18-74807a │ 441276f3-114a-4572-9e84-ec21dd908a6f │ featured  │
│ Linux Ubuntu 18.04 64-bit                │      │ 2018-04-26-0e6133 │ f3bfb04d-4ccb-420c-9540-db95a4aec3ea │ featured  │
│ Pfsense 2.4.4 64-bit                     │ 10   │ 2019-03-28        │ 4d388ced-209d-4be4-932c-f99d14d6e3b9 │ featured  │
│ TestingCompute: Exoscale-NetBoot         │ 0    │ 2019-01-27        │ 85489f78-efd2-4748-bcd7-d0cb2fe1fe33 │ featured  │
│ Ubuntu Minimal 18.04                     │ 0    │ 2019-02-01        │ cd829888-2120-4051-b30e-3b5c78ea1bc8 │ featured  │
│ Windows Server 2016                      │ 50   │ 2018-04-28-f0232  │ 500eb7f6-9771-4e89-9a6f-1d9a16f77d87 │ featured  │
│ netboot.xyz                              │ 100  │ 2016-12-06-3e9b74 │ 7309c685-d4b4-4221-b989-7df396d1eed0 │ featured  │
│ Linux Debian mcorbin 30 64-bit           │ 1    │ 2019-04-17        │ 4ba63720-cbbb-41d8-b3a2-da6543e5863a │ self      │
┼──────────────────────────────────────────┼──────┼───────────────────┼──────────────────────────────────────┼───────────┼

```