### PR TITLE
client: add support for custom HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+UNRELEASED
+----------
+
+- Add support for client request custom HTTP headers
+
 1.2.0
 -----
 
@@ -27,7 +32,6 @@
 
 - Fix #117
 - makefile: build exoscale/cli:latest
-
 
 1.1.2
 -----

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"net/http"
+
+	"github.com/exoscale/egoscale"
+)
+
+// roundTripper implements the http.RoundTripper interface and allows client
+// request customization, such as HTTP headers injection. If provided with a
+// non-nil rt parameter, it will wrap around it when performing requests.
+type roundTripper struct {
+	reqHeaders http.Header
+	rt         http.RoundTripper
+}
+
+func newRoundTripper(rt http.RoundTripper, headers map[string]string) roundTripper {
+	var roundTripper = roundTripper{
+		rt:         http.DefaultTransport,
+		reqHeaders: http.Header{},
+	}
+
+	if rt != nil {
+		roundTripper.rt = rt
+	}
+
+	for k, v := range headers {
+		roundTripper.reqHeaders.Add(k, v)
+	}
+
+	return roundTripper
+}
+
+func (rt roundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.Header = rt.reqHeaders
+	return rt.rt.RoundTrip(r)
+}
+
+func buildClient() {
+	if ignoreClientBuild {
+		return
+	}
+
+	if cs != nil {
+		return
+	}
+
+	cs = egoscale.NewClient(gCurrentAccount.Endpoint,
+		gCurrentAccount.Key,
+		gCurrentAccount.APISecret())
+
+	if gCurrentAccount.CustomHeaders != nil {
+		cs.HTTPClient.Transport = newRoundTripper(cs.HTTPClient.Transport, gCurrentAccount.CustomHeaders)
+	}
+
+	csDNS = egoscale.NewClient(gCurrentAccount.DNSEndpoint,
+		gCurrentAccount.Key,
+		gCurrentAccount.APISecret())
+
+	csRunstatus = egoscale.NewClient(gCurrentAccount.RunstatusEndpoint,
+		gCurrentAccount.Key,
+		gCurrentAccount.APISecret())
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -38,6 +38,7 @@ type account struct {
 	DefaultSSHKey        string
 	DefaultTemplate      string
 	DefaultRunstatusPage string
+	CustomHeaders        map[string]string
 }
 
 func (a account) APISecret() string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,20 +105,6 @@ func init() {
 
 var ignoreClientBuild = false
 
-func buildClient() {
-	if ignoreClientBuild {
-		return
-	}
-
-	if cs != nil {
-		return
-	}
-
-	csDNS = egoscale.NewClient(gCurrentAccount.DNSEndpoint, gCurrentAccount.Key, gCurrentAccount.APISecret())
-	cs = egoscale.NewClient(gCurrentAccount.Endpoint, gCurrentAccount.Key, gCurrentAccount.APISecret())
-	csRunstatus = egoscale.NewClient(gCurrentAccount.RunstatusEndpoint, gCurrentAccount.Key, gCurrentAccount.APISecret())
-}
-
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
 	envs := map[string]string{


### PR DESCRIPTION
This change adds support for user-defined arbitrary headers to be
injected to every outgoing HTTP request to the Exoscale API.
Configuration is done through a new `customHeaders` account key in the
`exoscale.toml` file:

```toml
[[accounts]]
  account = "myaccount"
  defaultTemplate = "Linux Ubuntu 18.04 LTS 64-bit"
  defaultZone = "ch-gva-2"
  endpoint = "https://api.exoscale.ch/compute"
  key = "EXO************************"
  name = "myaccount"
  secret = "*******************************************"
  [[accounts.customHeaders]]
  X-Custom-Header1 = "foo"
  X-Custom-Header2 = "bar"
```

Story: [Support arbitrary headers in egoscale and cli](https://app.clubhouse.io/exoscale/story/2543)