### PR TITLE
template: don't filter templates.

### DIFF
--- a/cmd/template.go
+++ b/cmd/template.go
@@ -95,9 +95,6 @@ func findTemplates(zoneID *egoscale.UUID, templateFilter string, filters ...stri
 				allOS[key] = template
 				return true
 			}
-			// skip
-			log.Printf("Malformed Linux. %q", template.DisplayText)
-			return true
 		}
 
 		if strings.HasPrefix(template.Name, "Windows Server") || strings.HasPrefix(template.Name, "OpenBSD") {
@@ -112,9 +109,6 @@ func findTemplates(zoneID *egoscale.UUID, templateFilter string, filters ...stri
 				allOS[key] = template
 				return true
 			}
-
-			log.Printf("Malformed Windows/OpenBSD. %q", template.DisplayText)
-			return true
 		}
 
 		// In doubt, use it directly


### PR DESCRIPTION
We now have custom templates, so the name of a template can be
whatever the user wants. We should not ignore templates because they
does not match the regex.

fix https://github.com/exoscale/cli/issues/140