### PR TITLE
Set build version/commit in Makefile

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,8 @@ builds:
       - CGO_ENABLED=0
     flags:
       - -mod=vendor
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
     goos:
       - windows
       - darwin


### PR DESCRIPTION
This change aligns the binaries generated using [GoReleaser](https://goreleaser.com/) and the standard Makefile by setting the same version/commit information at build time.

Before this change, building the binary using the Makefile would produce a `exo version` output such as `exo dev n/a (egoscale 0.17.0)`.

Now, if building from source on a tag the output would be: `exo v1.2.0 0d64517fd734f675ec2b225d002a9a2f9857594e (egoscale 0.17.0)`

If building from master, it will be: `exo dev c251678065838b95a1eff2cdf7e3b78b9469b03d (egoscale 0.17.1)`