### PR TITLE
CLI: normalize output format across `exo * show` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ UNRELEASED
 
 - config: add support for client request custom HTTP headers
 - vm: add support for *rescue profile* to `vm create`
+- Various `exo * show` commands output normalization
 
 1.2.0
 -----

--- a/cmd/affinitygroup_show.go
+++ b/cmd/affinitygroup_show.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
+	"bytes"
 	"os"
-	"strings"
 
 	"github.com/exoscale/cli/table"
 	"github.com/exoscale/egoscale"
@@ -46,12 +46,15 @@ func showAffinityGroup(name string) error {
 		return err
 	}
 
-	instances := make([]string, len(ag.VirtualMachineIDs))
-	for i, r := range resp {
+	buf := bytes.NewBuffer(nil)
+	it := table.NewEmbeddedTable(buf)
+	it.SetHeader([]string{" "})
+	for _, r := range resp {
 		vm := r.(*egoscale.VirtualMachine)
-		instances[i] = vm.ID.String() + " │ " + vm.Name
+		it.Append([]string{vm.Name, vm.ID.String()})
 	}
-	t.Append([]string{"Instances", strings.Join(instances, "\n")})
+	it.Render()
+	t.Append([]string{"Instances", buf.String()})
 
 	t.Render()
 

--- a/cmd/affinitygroup_show.go
+++ b/cmd/affinitygroup_show.go
@@ -9,17 +9,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// affinitygroupShowCmd represents the affinitygroup show command
-var affinitygroupShowCmd = &cobra.Command{
-	Use:     "show <name | id>",
-	Short:   "Show affinity group details",
-	Aliases: gShowAlias,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			return cmd.Usage()
-		}
-		return showAffinityGroup(args[0])
-	},
+func init() {
+	affinitygroupCmd.AddCommand(&cobra.Command{
+		Use:     "show <name | id>",
+		Short:   "Show affinity group details",
+		Aliases: gShowAlias,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return cmd.Usage()
+			}
+			return showAffinityGroup(args[0])
+		},
+	})
 }
 
 func showAffinityGroup(name string) error {
@@ -59,8 +60,4 @@ func showAffinityGroup(name string) error {
 	t.Render()
 
 	return nil
-}
-
-func init() {
-	affinitygroupCmd.AddCommand(affinitygroupShowCmd)
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -252,7 +252,11 @@ Let's start over.
 		account.Name = name
 	}
 
-	for doesAccountExist(account.Name) {
+	for {
+		if a := getAccountByName(account.Name); a == nil {
+			break
+		}
+
 		fmt.Printf("Name [%s] already exist\n", name)
 		name, err = readInput(reader, "Name", account.Name)
 		if err != nil {
@@ -470,7 +474,11 @@ func importCloudstackINI(option, csPath, cfgPath string) error {
 			csAccount.Name = name
 		}
 
-		for doesAccountExist(csAccount.Name) {
+		for {
+			if a := getAccountByName(csAccount.Name); a == nil {
+				break
+			}
+
 			fmt.Printf("Account name [%s] already exist\n", csAccount.Name)
 			name, err = readInput(reader, fmt.Sprintf("Name (org: %q)", csAccount.Account), csAccount.Name)
 			if err != nil {
@@ -502,20 +510,6 @@ func importCloudstackINI(option, csPath, cfgPath string) error {
 
 	gAllAccount = nil
 	return addAccount(cfgPath, config)
-}
-
-func doesAccountExist(name string) bool {
-	if gAllAccount == nil {
-		return gCurrentAccount.Name == name
-	}
-
-	for _, acc := range gAllAccount.Accounts {
-		if acc.Name == name {
-			return true
-		}
-	}
-
-	return false
 }
 
 func createConfigFile(fileName string) (string, error) {
@@ -604,11 +598,13 @@ func getAccountByName(name string) *account {
 	if gAllAccount == nil {
 		return nil
 	}
+
 	for i, acc := range gAllAccount.Accounts {
 		if acc.Name == name {
 			return &gAllAccount.Accounts[i]
 		}
 	}
+
 	return nil
 }
 

--- a/cmd/config_delete.go
+++ b/cmd/config_delete.go
@@ -19,7 +19,7 @@ var configDeleteCmd = &cobra.Command{
 		if gAllAccount == nil {
 			return fmt.Errorf("no accounts defined")
 		}
-		if !doesAccountExist(args[0]) {
+		if a := getAccountByName(args[0]); a == nil {
 			return fmt.Errorf("account %q doesn't exist", args[0])
 		}
 

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -19,7 +19,7 @@ var configSetCmd = &cobra.Command{
 			return fmt.Errorf("no accounts are defined")
 		}
 
-		if !doesAccountExist(args[0]) {
+		if a := getAccountByName(args[0]); a == nil {
 			return fmt.Errorf("account %q does not exist", args[0])
 		}
 

--- a/cmd/config_show.go
+++ b/cmd/config_show.go
@@ -9,69 +9,66 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// showCmd represents the show command
-var showCmd = &cobra.Command{
-	Use:     "show <account name>",
-	Short:   "Show an account details",
-	Aliases: gShowAlias,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if gAllAccount == nil {
-			return fmt.Errorf("no accounts are defined")
-		}
+func init() {
+	configCmd.AddCommand(&cobra.Command{
+		Use:     "show <account name>",
+		Short:   "Show an account details",
+		Aliases: gShowAlias,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if gAllAccount == nil {
+				return fmt.Errorf("no accounts are defined")
+			}
+			name := gCurrentAccount.AccountName()
 
-		name := gCurrentAccount.AccountName()
-		if len(args) > 0 {
-			name = args[0]
-		}
+			if len(args) > 0 {
+				name = args[0]
+			}
 
-		if !doesAccountExist(name) {
-			return fmt.Errorf("account %q does not exist", name)
-		}
-
-		account := getAccountByName(name)
-		if account == nil {
-			return fmt.Errorf("account %q was not found", name)
-		}
-
-		secret := strings.Repeat("×", len(account.Key))
-		if len(account.SecretCommand) > 0 {
-			secret = strings.Join(account.SecretCommand, " ")
-		}
-
-		t := table.NewTable(os.Stdout)
-		t.SetHeader([]string{name})
-
-		t.Append([]string{"Account Name", account.Account})
-		t.Append([]string{"API Key", account.Key})
-		t.Append([]string{"API Secret", secret})
-		t.Append([]string{"Default Zone", account.DefaultZone})
-
-		if account.DefaultTemplate != "" {
-			t.Append([]string{"Default Template", account.DefaultTemplate})
-		}
-
-		if account.Endpoint != defaultEndpoint {
-			t.Append([]string{"Endpoint", account.Endpoint})
-			t.Append([]string{"DNS Endpoint", account.DNSEndpoint})
-		}
-
-		if account.SosEndpoint != defaultSosEndpoint {
-			t.Append([]string{"SOS Endpoint", account.SosEndpoint})
-		}
-
-		if gConfigFilePath != "" {
-			t.Append([]string{"Configuration Folder", gConfigFolder})
-			t.Append([]string{"Configuration", gConfigFilePath})
-		} else {
-			t.Append([]string{"Configuration", "environment variables"})
-		}
-
-		t.Render()
-
-		return nil
-	},
+			return showConfig(name)
+		},
+	})
 }
 
-func init() {
-	configCmd.AddCommand(showCmd)
+func showConfig(name string) error {
+	account := getAccountByName(name)
+	if account == nil {
+		return fmt.Errorf("account %q was not found", name)
+	}
+
+	secret := strings.Repeat("×", len(account.Key))
+	if len(account.SecretCommand) > 0 {
+		secret = strings.Join(account.SecretCommand, " ")
+	}
+
+	t := table.NewTable(os.Stdout)
+	t.SetHeader([]string{name})
+
+	t.Append([]string{"Account Name", account.Account})
+	t.Append([]string{"API Key", account.Key})
+	t.Append([]string{"API Secret", secret})
+	t.Append([]string{"Default Zone", account.DefaultZone})
+
+	if account.DefaultTemplate != "" {
+		t.Append([]string{"Default Template", account.DefaultTemplate})
+	}
+
+	if account.Endpoint != defaultEndpoint {
+		t.Append([]string{"Endpoint", account.Endpoint})
+		t.Append([]string{"DNS Endpoint", account.DNSEndpoint})
+	}
+
+	if account.SosEndpoint != defaultSosEndpoint {
+		t.Append([]string{"SOS Endpoint", account.SosEndpoint})
+	}
+
+	if gConfigFilePath != "" {
+		t.Append([]string{"Configuration Folder", gConfigFolder})
+		t.Append([]string{"Configuration", gConfigFilePath})
+	} else {
+		t.Append([]string{"Configuration", "environment variables"})
+	}
+
+	t.Render()
+
+	return nil
 }

--- a/cmd/privnet_show.go
+++ b/cmd/privnet_show.go
@@ -1,62 +1,69 @@
 package cmd
 
 import (
+	"bytes"
 	"os"
-	"strings"
 
 	"github.com/exoscale/cli/table"
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
 )
 
-// showCmd represents the show command
-var privnetShowCmd = &cobra.Command{
-	Use:   "show <privnet name | id>",
-	Short: "Show a private network details",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			return cmd.Usage()
-		}
-
-		network, err := getNetworkByName(args[0])
-		if err != nil {
-			return err
-		}
-
-		vms, err := privnetDetails(network)
-		if err != nil {
-			return err
-		}
-
-		dhcp := dhcpRange(*network)
-
-		t := table.NewTable(os.Stdout)
-		t.SetHeader([]string{network.Name})
-
-		t.Append([]string{"ID", network.ID.String()})
-		t.Append([]string{"Name", network.Name})
-		t.Append([]string{"Description", network.DisplayText})
-		t.Append([]string{"Zone", network.ZoneName})
-		t.Append([]string{"DHCP IP Range", dhcp})
-
-		if len(vms) == 0 {
-			t.Append([]string{"Instances", "n/a"})
-			t.Render()
-			return nil
-		}
-
-		if len(vms) > 0 {
-			instances := make([]string, len(vms))
-			for i, vm := range vms {
-				instances[i] = strings.Join([]string{vm.ID.String(), vm.Name}, " │ ")
+func init() {
+	privnetCmd.AddCommand(&cobra.Command{
+		Use:   "show <privnet name | id>",
+		Short: "Show a private network details",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return cmd.Usage()
 			}
-			t.Append([]string{"Instances", strings.Join(instances, "\n")})
-		}
+			return showPrivnet(args[0])
+		},
+	})
+}
 
+func showPrivnet(name string) error {
+	network, err := getNetworkByName(name)
+	if err != nil {
+		return err
+	}
+
+	vms, err := privnetDetails(network)
+	if err != nil {
+		return err
+	}
+
+	dhcp := dhcpRange(*network)
+
+	t := table.NewTable(os.Stdout)
+	t.SetHeader([]string{network.Name})
+
+	t.Append([]string{"ID", network.ID.String()})
+	t.Append([]string{"Name", network.Name})
+	t.Append([]string{"Description", network.DisplayText})
+	t.Append([]string{"Zone", network.ZoneName})
+	t.Append([]string{"DHCP IP Range", dhcp})
+
+	if len(vms) == 0 {
+		t.Append([]string{"Instances", "n/a"})
 		t.Render()
-
 		return nil
-	},
+	}
+
+	if len(vms) > 0 {
+		buf := bytes.NewBuffer(nil)
+		it := table.NewEmbeddedTable(buf)
+		it.SetHeader([]string{" "})
+		for _, vm := range vms {
+			it.Append([]string{vm.Name, vm.ID.String()})
+		}
+		it.Render()
+		t.Append([]string{"Instances", buf.String()})
+	}
+
+	t.Render()
+
+	return nil
 }
 
 func privnetDetails(network *egoscale.Network) ([]egoscale.VirtualMachine, error) {
@@ -78,8 +85,4 @@ func privnetDetails(network *egoscale.Network) ([]egoscale.VirtualMachine, error
 	}
 
 	return vmsRes, nil
-}
-
-func init() {
-	privnetCmd.AddCommand(privnetShowCmd)
 }

--- a/cmd/runstatus_incident_show.go
+++ b/cmd/runstatus_incident_show.go
@@ -1,60 +1,85 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"os"
-	"text/tabwriter"
+	"strings"
 
+	"github.com/exoscale/cli/table"
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
 )
 
-// runstatusIncidentShowCmd represents the show command
-var runstatusIncidentShowCmd = &cobra.Command{
-	Use:     "show [page name] <incident name | id>",
-	Short:   "Show an incident detail",
-	Aliases: gShowAlias,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return cmd.Usage()
-		}
+func init() {
+	runstatusIncidentCmd.AddCommand(&cobra.Command{
+		Use:     "show [page name] <incident name | id>",
+		Short:   "Show an incident detail",
+		Aliases: gShowAlias,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return cmd.Usage()
+			}
 
-		pageName := gCurrentAccount.DefaultRunstatusPage
-		incidentName := args[0]
+			page := gCurrentAccount.DefaultRunstatusPage
+			incident := args[0]
 
-		if gCurrentAccount.DefaultRunstatusPage == "" && len(args) == 1 {
-			fmt.Fprintf(os.Stderr, `Error: No default runstat.us page is set:
+			if gCurrentAccount.DefaultRunstatusPage == "" && len(args) == 1 {
+				fmt.Fprintf(os.Stderr, `Error: No default runstat.us page is set:
   Please specify a page in parameter or add it to %q
 
   `, gConfigFilePath)
-			return cmd.Usage()
-		}
+				return cmd.Usage()
+			}
 
-		if len(args) > 1 {
-			pageName = args[0]
-			incidentName = args[1]
-		}
+			if len(args) > 1 {
+				page = args[0]
+				incident = args[1]
+			}
 
-		runstatusPage, err := csRunstatus.GetRunstatusPage(gContext, egoscale.RunstatusPage{Subdomain: pageName})
-		if err != nil {
-			return err
-		}
-
-		incident, err := getIncidentByNameOrID(*runstatusPage, incidentName)
-		if err != nil {
-			return err
-		}
-
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.TabIndent)
-		fmt.Fprintf(w, "Title:\t%s\n", incident.Title)            // nolint: errcheck
-		fmt.Fprintf(w, "Description:\t%s\n", incident.StatusText) // nolint: errcheck
-		fmt.Fprintf(w, "State:\t%s\n", incident.State)            // nolint: errcheck
-		fmt.Fprintf(w, "Status:\t%s\n", incident.Status)          // nolint: errcheck
-
-		return w.Flush()
-	},
+			return showRunstatusIncident(page, incident)
+		},
+	})
 }
 
-func init() {
-	runstatusIncidentCmd.AddCommand(runstatusIncidentShowCmd)
+func showRunstatusIncident(p, i string) error {
+	page, err := csRunstatus.GetRunstatusPage(gContext, egoscale.RunstatusPage{Subdomain: p})
+	if err != nil {
+		return err
+	}
+
+	incident, err := getIncidentByNameOrID(*page, i)
+	if err != nil {
+		return err
+	}
+
+	t := table.NewTable(os.Stdout)
+	t.SetHeader([]string{page.Subdomain})
+
+	t.Append([]string{"ID", fmt.Sprint(incident.ID)})
+	t.Append([]string{"Title", incident.Title})
+	t.Append([]string{"State", incident.State})
+	t.Append([]string{"Status", incident.Status})
+	t.Append([]string{"Start Date", fmt.Sprint(incident.StartDate)})
+
+	if incident.EndDate != nil {
+		t.Append([]string{"End Date", fmt.Sprint(incident.EndDate)})
+	}
+
+	t.Append([]string{"Affected Services", strings.Join(incident.Services, "\n")})
+
+	if len(incident.Events) > 0 {
+		buf := bytes.NewBuffer(nil)
+		et := table.NewEmbeddedTable(buf)
+		et.SetHeader([]string{" "})
+		for _, e := range incident.Events {
+			et.Append([]string{fmt.Sprint(e.Created), e.Status, e.Text})
+		}
+		et.Render()
+		t.Append([]string{"Event Stream", buf.String()})
+	}
+
+	t.Render()
+
+	return nil
 }

--- a/cmd/runstatus_incident_show.go
+++ b/cmd/runstatus_incident_show.go
@@ -14,7 +14,7 @@ import (
 func init() {
 	runstatusIncidentCmd.AddCommand(&cobra.Command{
 		Use:     "show [page name] <incident name | id>",
-		Short:   "Show an incident detail",
+		Short:   "Show an incident details",
 		Aliases: gShowAlias,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {

--- a/cmd/runstatus_maintenance_show.go
+++ b/cmd/runstatus_maintenance_show.go
@@ -14,7 +14,7 @@ func init() {
 	runstatusMaintenanceCmd.AddCommand(
 		&cobra.Command{
 			Use:     "show [page name] <maintenance name|id>",
-			Short:   "Show a runstat.us page maintenance details",
+			Short:   "Show a maintenance details",
 			Aliases: gShowAlias,
 			RunE: func(cmd *cobra.Command, args []string) error {
 				if len(args) < 1 {

--- a/cmd/runstatus_maintenance_show.go
+++ b/cmd/runstatus_maintenance_show.go
@@ -3,57 +3,67 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"text/tabwriter"
+	"strings"
 
+	"github.com/exoscale/cli/table"
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
 )
 
-// runstatusMaintenanceShowCmd represents the show command
-var runstatusMaintenanceShowCmd = &cobra.Command{
-	Use:     "show [page name] <maintenance name>",
-	Short:   "Show a maintenance",
-	Aliases: gShowAlias,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return cmd.Usage()
-		}
+func init() {
+	runstatusMaintenanceCmd.AddCommand(
+		&cobra.Command{
+			Use:     "show [page name] <maintenance name|id>",
+			Short:   "Show a runstat.us page maintenance details",
+			Aliases: gShowAlias,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				if len(args) < 1 {
+					return cmd.Usage()
+				}
 
-		pageName := gCurrentAccount.DefaultRunstatusPage
-		serviceName := args[0]
+				page := gCurrentAccount.DefaultRunstatusPage
+				maintenance := args[0]
 
-		if gCurrentAccount.DefaultRunstatusPage == "" && len(args) == 1 {
-			fmt.Fprintf(os.Stderr, `Error: No default runstat.us page is set:
+				if gCurrentAccount.DefaultRunstatusPage == "" && len(args) == 1 {
+					fmt.Fprintf(os.Stderr, `Error: No default runstat.us page is set:
   Please specify a page in parameter or add it to %q
 
   `, gConfigFilePath)
-			return cmd.Usage()
-		}
+					return cmd.Usage()
+				}
 
-		if len(args) > 1 {
-			pageName = args[0]
-			serviceName = args[1]
-		}
+				if len(args) > 1 {
+					page = args[0]
+					maintenance = args[1]
+				}
 
-		runstatusPage, err := csRunstatus.GetRunstatusPage(gContext, egoscale.RunstatusPage{Subdomain: pageName})
-		if err != nil {
-			return err
-		}
-
-		maintenance, err := getMaintenanceByNameOrID(*runstatusPage, serviceName)
-		if err != nil {
-			return err
-		}
-
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.TabIndent)
-		fmt.Fprintf(w, "Title:\t%s\n", maintenance.Title)  // nolint: errcheck
-		fmt.Fprintf(w, "State:\t%s\n", maintenance.Status) // nolint: errcheck
-		fmt.Fprintf(w, "URL:\t%s\n", maintenance.URL)      // nolint: errcheck
-
-		return w.Flush()
-	},
+				return showRunstatusMaintenance(page, maintenance)
+			},
+		})
 }
 
-func init() {
-	runstatusMaintenanceCmd.AddCommand(runstatusMaintenanceShowCmd)
+func showRunstatusMaintenance(p, m string) error {
+	page, err := csRunstatus.GetRunstatusPage(gContext, egoscale.RunstatusPage{Subdomain: p})
+	if err != nil {
+		return err
+	}
+
+	maintenance, err := getMaintenanceByNameOrID(*page, m)
+	if err != nil {
+		return err
+	}
+	t := table.NewTable(os.Stdout)
+	t.SetHeader([]string{page.Subdomain})
+
+	t.Append([]string{"ID", fmt.Sprint(maintenance.ID)})
+	t.Append([]string{"Title", maintenance.Title})
+	t.Append([]string{"Description", maintenance.Description})
+	t.Append([]string{"State", maintenance.Status})
+	t.Append([]string{"Start Date", fmt.Sprint(maintenance.StartDate)})
+	t.Append([]string{"End Date", fmt.Sprint(maintenance.EndDate)})
+	t.Append([]string{"Affected Services", strings.Join(maintenance.Services, "\n")})
+
+	t.Render()
+
+	return nil
 }

--- a/cmd/runstatus_maintenance_show.go
+++ b/cmd/runstatus_maintenance_show.go
@@ -52,6 +52,7 @@ func showRunstatusMaintenance(p, m string) error {
 	if err != nil {
 		return err
 	}
+
 	t := table.NewTable(os.Stdout)
 	t.SetHeader([]string{page.Subdomain})
 

--- a/cmd/runstatus_service_show.go
+++ b/cmd/runstatus_service_show.go
@@ -3,57 +3,62 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"text/tabwriter"
 
+	"github.com/exoscale/cli/table"
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
 )
 
-// runstatusServiceShowCmd represents the show command
-var runstatusServiceShowCmd = &cobra.Command{
-	Use:     "show [page name] <service name>",
-	Short:   "Show a service",
-	Aliases: gShowAlias,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return cmd.Usage()
-		}
+func init() {
+	runstatusServiceCmd.AddCommand(&cobra.Command{
+		Use:     "show [page name] <service name>",
+		Short:   "Show a service",
+		Aliases: gShowAlias,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return cmd.Usage()
+			}
 
-		pageName := gCurrentAccount.DefaultRunstatusPage
-		serviceName := args[0]
+			page := gCurrentAccount.DefaultRunstatusPage
+			service := args[0]
 
-		if gCurrentAccount.DefaultRunstatusPage == "" && len(args) == 1 {
-			fmt.Fprintf(os.Stderr, `Error: No default runstat.us page is set:
+			if gCurrentAccount.DefaultRunstatusPage == "" && len(args) == 1 {
+				fmt.Fprintf(os.Stderr, `Error: No default runstat.us page is set:
   Please specify a page in parameter or add it to %q
 
   `, gConfigFilePath)
-			return cmd.Usage()
-		}
+				return cmd.Usage()
+			}
 
-		if len(args) > 1 {
-			pageName = args[0]
-			serviceName = args[1]
-		}
+			if len(args) > 1 {
+				page = args[0]
+				service = args[1]
+			}
 
-		runstatusPage, err := csRunstatus.GetRunstatusPage(gContext, egoscale.RunstatusPage{Subdomain: pageName})
-		if err != nil {
-			return err
-		}
-
-		service, err := getServiceByName(*runstatusPage, serviceName)
-		if err != nil {
-			return err
-		}
-
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.TabIndent)
-		fmt.Fprintf(w, "Name:\t%s\n", service.Name)   // nolint: errcheck
-		fmt.Fprintf(w, "State:\t%s\n", service.State) // nolint: errcheck
-		fmt.Fprintf(w, "URL:\t%s\n", service.URL)     // nolint: errcheck
-
-		return w.Flush()
-	},
+			return showRunstatusService(page, service)
+		},
+	})
 }
 
-func init() {
-	runstatusServiceCmd.AddCommand(runstatusServiceShowCmd)
+func showRunstatusService(p, s string) error {
+	page, err := csRunstatus.GetRunstatusPage(gContext, egoscale.RunstatusPage{Subdomain: p})
+	if err != nil {
+		return err
+	}
+
+	service, err := getServiceByName(*page, s)
+	if err != nil {
+		return err
+	}
+
+	t := table.NewTable(os.Stdout)
+	t.SetHeader([]string{page.Subdomain})
+
+	t.Append([]string{"ID", fmt.Sprint(service.ID)})
+	t.Append([]string{"Name", service.Name})
+	t.Append([]string{"State", service.State})
+
+	t.Render()
+
+	return nil
 }

--- a/cmd/runstatus_service_show.go
+++ b/cmd/runstatus_service_show.go
@@ -12,7 +12,7 @@ import (
 func init() {
 	runstatusServiceCmd.AddCommand(&cobra.Command{
 		Use:     "show [page name] <service name>",
-		Short:   "Show a service",
+		Short:   "Show a service details",
 		Aliases: gShowAlias,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {

--- a/cmd/runstatus_show.go
+++ b/cmd/runstatus_show.go
@@ -49,6 +49,26 @@ func showRunstatusPage(name string) error {
 		t.Append([]string{"Services", buf.String()})
 	}
 
+	if len(page.Incidents) > 0 {
+		buf := bytes.NewBuffer(nil)
+		it := table.NewEmbeddedTable(buf)
+		for _, i := range page.Incidents {
+			it.Append([]string{i.Title, i.State, i.Status, formatSchedule(i.StartDate, i.EndDate)})
+		}
+		it.Render()
+		t.Append([]string{"Incidents", buf.String()})
+	}
+
+	if len(page.Maintenances) > 0 {
+		buf := bytes.NewBuffer(nil)
+		mt := table.NewEmbeddedTable(buf)
+		for _, m := range page.Maintenances {
+			mt.Append([]string{m.Title, m.Status, formatSchedule(m.StartDate, m.EndDate)})
+		}
+		mt.Render()
+		t.Append([]string{"Maintenances", buf.String()})
+	}
+
 	t.Render()
 
 	return nil

--- a/cmd/runstatus_show.go
+++ b/cmd/runstatus_show.go
@@ -1,105 +1,55 @@
 package cmd
 
 import (
-	"fmt"
+	"bytes"
+	"errors"
 	"os"
-	"strconv"
-	"text/tabwriter"
 
 	"github.com/exoscale/cli/table"
+	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
 )
 
-// runstatusShowCmd represents the list command
-var runstatusShowCmd = &cobra.Command{
-	Use:     "show [page name]+",
-	Short:   "Show runstat.us page details",
-	Aliases: gShowAlias,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		pages, err := runstatusAllPages(args)
-		if err != nil {
-			return err
-		}
-
-		for _, page := range pages {
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.TabIndent)
-
-			fmt.Fprintf(w, "Page:\t%s\n", page.Subdomain)     // nolint: errcheck
-			fmt.Fprintf(w, "URL:\t%s\n", page.PublicURL)      // nolint: errcheck
-			fmt.Fprintf(w, "Email:\t%s\n", page.SupportEmail) // nolint: errcheck
-			fmt.Fprintf(w, "State:\t%s\n", page.State)        // nolint: errcheck
-
-			if len(page.Services) > 0 {
-				fmt.Fprintf(w, "Services:\n") // nolint: errcheck
-				w.Flush()                     // nolint: errcheck
-
-				table := table.NewTable(os.Stdout)
-				table.SetHeader([]string{"Name", "State", "ID"})
-
-				for _, svc := range page.Services {
-					table.Append([]string{
-						svc.Name,
-						svc.State,
-						strconv.Itoa(svc.ID),
-					})
-				}
-				table.Render()
-
-				fmt.Fprintln(w, "") // nolint: errcheck
-			} else {
-				fmt.Fprintf(w, "Services:\tn/a\n") // nolint: errcheck
+func init() {
+	runstatusCmd.AddCommand(&cobra.Command{
+		Use:     "show <page name>",
+		Short:   "Show runstat.us page details",
+		Aliases: gShowAlias,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("show expects one page name or id")
 			}
-
-			if len(page.Incidents) > 0 {
-				fmt.Fprintf(w, "Incidents:\n") // nolint: errcheck
-				w.Flush()                      // nolint: errcheck
-
-				table := table.NewTable(os.Stdout)
-				table.SetHeader([]string{"Title", "State", "Status", "When", "ID"})
-
-				for _, incident := range page.Incidents {
-					table.Append([]string{
-						incident.Title,
-						incident.State,
-						incident.Status,
-						formatSchedule(incident.StartDate, incident.EndDate),
-						strconv.Itoa(incident.ID),
-					})
-				}
-				table.Render()
-
-				fmt.Fprintln(w, "") // nolint: errcheck
-			} else {
-				fmt.Fprintf(w, "Incidents:\tn/a\n") // nolint: errcheck
-			}
-
-			if len(page.Maintenances) > 0 {
-				fmt.Fprintf(w, "Maintenances:\n") // nolint: errcheck
-				w.Flush()                         // nolint: errcheck
-
-				table := table.NewTable(os.Stdout)
-				table.SetHeader([]string{"Title", "Status", "When", "ID"})
-
-				for _, maintenance := range page.Maintenances {
-					table.Append([]string{
-						maintenance.Title,
-						maintenance.Status,
-						formatSchedule(maintenance.StartDate, maintenance.EndDate),
-						strconv.Itoa(maintenance.ID),
-					})
-				}
-				table.Render()
-
-				fmt.Fprintln(w, "") // nolint: errcheck
-			} else {
-				fmt.Fprintf(w, "Maintenances:\tn/a\n") // nolint: errcheck
-			}
-		}
-
-		return nil
-	},
+			return showRunstatusPage(args[0])
+		},
+	})
 }
 
-func init() {
-	runstatusCmd.AddCommand(runstatusShowCmd)
+func showRunstatusPage(name string) error {
+	page, err := csRunstatus.GetRunstatusPage(gContext, egoscale.RunstatusPage{Subdomain: name})
+	if err != nil {
+		return err
+	}
+
+	t := table.NewTable(os.Stdout)
+	t.SetHeader([]string{page.Subdomain})
+
+	t.Append([]string{"Name", page.Subdomain})
+	t.Append([]string{"URL", page.PublicURL})
+	t.Append([]string{"Email", page.SupportEmail})
+	t.Append([]string{"State", page.State})
+
+	if len(page.Services) > 0 {
+		buf := bytes.NewBuffer(nil)
+		st := table.NewEmbeddedTable(buf)
+		st.SetHeader([]string{" "})
+		for _, svc := range page.Services {
+			st.Append([]string{svc.Name, svc.State})
+		}
+		st.Render()
+		t.Append([]string{"Services", buf.String()})
+	}
+
+	t.Render()
+
+	return nil
 }

--- a/cmd/runstatus_show.go
+++ b/cmd/runstatus_show.go
@@ -13,7 +13,7 @@ import (
 func init() {
 	runstatusCmd.AddCommand(&cobra.Command{
 		Use:     "show <page name>",
-		Short:   "Show runstat.us page details",
+		Short:   "Show a runstat.us page details",
 		Aliases: gShowAlias,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -30,7 +30,6 @@ var statusCmd = &cobra.Command{
 
 		t := table.NewTable(os.Stdout)
 		t.SetHeader([]string{"Service", "Status"})
-
 		for service, status := range status.Status {
 			t.Append([]string{service, status.State})
 		}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -17,62 +18,6 @@ const (
 	statusContentPage = "application/json"
 	twitterURL        = "https://twitter.com/exoscalestatus"
 )
-
-// statusCmd represents the status command
-var statusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Exoscale status",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		status, err := fetchRunStatus(jsonStatusURL)
-		if err != nil {
-			return err
-		}
-
-		t := table.NewTable(os.Stdout)
-		t.SetHeader([]string{"Service", "Status"})
-		for service, status := range status.Status {
-			t.Append([]string{service, status.State})
-		}
-		t.Render()
-
-		if len(status.Incidents) > 0 {
-			suffix := ""
-			if len(status.Incidents) > 1 {
-				suffix = "s"
-			}
-			msg := fmt.Sprintf("%d ongoing Incident%s (last: %s)",
-				len(status.Incidents),
-				suffix,
-				status.Incidents[0].Title)
-			fmt.Println(msg)
-			fmt.Printf("Updates available at %s\n", twitterURL)
-			return fmt.Errorf(msg)
-		}
-
-		return nil
-	},
-}
-
-func fetchRunStatus(url string) (*RunStatus, error) {
-	// XXX need gContext
-	r, err := http.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	defer r.Body.Close()
-
-	contentType := r.Header.Get("content-type")
-	if contentType != statusContentPage {
-		return nil, fmt.Errorf("status page content type expected %q, but got %q", statusContentPage, contentType)
-	}
-
-	response := &RunStatus{}
-	if err := json.NewDecoder(r.Body).Decode(response); err != nil {
-		return nil, err
-	}
-
-	return response, nil
-}
 
 // ServiceStatus represents the state of a service
 type ServiceStatus struct {
@@ -98,5 +43,79 @@ type RunStatus struct {
 }
 
 func init() {
-	RootCmd.AddCommand(statusCmd)
+	RootCmd.AddCommand(&cobra.Command{
+		Use:   "status",
+		Short: "Exoscale status",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return statusShow()
+		},
+	})
+}
+
+func statusShow() error {
+	status, err := fetchRunStatus(jsonStatusURL)
+	if err != nil {
+		return err
+	}
+
+	t := table.NewTable(os.Stdout)
+	t.SetHeader([]string{"Exoscale Status"})
+
+	buf := bytes.NewBuffer(nil)
+	st := table.NewEmbeddedTable(buf)
+	for service, status := range status.Status {
+		st.Append([]string{service, status.State})
+	}
+	st.Render()
+
+	t.Append([]string{"Services", buf.String()})
+
+	buf = bytes.NewBuffer([]byte("n/a"))
+	if len(status.Incidents) > 0 {
+		buf.Reset()
+		it := table.NewEmbeddedTable(buf)
+		for _, i := range status.Incidents {
+			it.Append([]string{i.Title, i.Status, fmt.Sprint(i.Created), fmt.Sprint(i.Updated)})
+		}
+		it.Render()
+	}
+	t.Append([]string{"Incidents", buf.String()})
+
+	buf = bytes.NewBuffer([]byte("n/a"))
+	if len(status.UpcomingMaintenances) > 0 {
+		buf.Reset()
+		mt := table.NewEmbeddedTable(buf)
+		for _, m := range status.UpcomingMaintenances {
+			mt.Append([]string{m.Title, m.Description, fmt.Sprint(m.Date)})
+		}
+		mt.Render()
+	}
+	t.Append([]string{"Maintenances", buf.String()})
+
+	t.Render()
+
+	fmt.Println("Updates available at", twitterURL)
+
+	return nil
+}
+
+func fetchRunStatus(url string) (*RunStatus, error) {
+	// XXX need gContext
+	r, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+
+	contentType := r.Header.Get("content-type")
+	if contentType != statusContentPage {
+		return nil, fmt.Errorf("status page content type expected %q, but got %q", statusContentPage, contentType)
+	}
+
+	response := &RunStatus{}
+	if err := json.NewDecoder(r.Body).Decode(response); err != nil {
+		return nil, err
+	}
+
+	return response, nil
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"text/tabwriter"
 	"time"
 
+	"github.com/exoscale/cli/table"
 	"github.com/spf13/cobra"
 )
 
@@ -28,15 +28,14 @@ var statusCmd = &cobra.Command{
 			return err
 		}
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.FilterHTML)
+		t := table.NewTable(os.Stdout)
+		t.SetHeader([]string{"Service", "Status"})
 
-		fmt.Printf("Exoscale Status\n\t%s\n\n", statusURL)
-
-		for k, service := range status.Status {
-			fmt.Fprintf(w, "%s\t%s\n", k, service.State) // nolint: errcheck
+		for service, status := range status.Status {
+			t.Append([]string{service, status.State})
 		}
-		fmt.Fprintln(w) // nolint: errcheck
-		w.Flush()
+		t.Render()
+
 		if len(status.Incidents) > 0 {
 			suffix := ""
 			if len(status.Incidents) > 1 {

--- a/cmd/template_show.go
+++ b/cmd/template_show.go
@@ -10,19 +10,16 @@ import (
 )
 
 func init() {
-	templateCmd.AddCommand(templateShowCmd)
-}
-
-// templateShowCmd represents the show command
-var templateShowCmd = &cobra.Command{
-	Use:   "show <template name | id>",
-	Short: "Show a template",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			return errors.New("show expects one template by name or id")
-		}
-		return showTemplate(args[0])
-	},
+	templateCmd.AddCommand(&cobra.Command{
+		Use:   "show <template name | id>",
+		Short: "Show a template details",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("show expects one template by name or id")
+			}
+			return showTemplate(args[0])
+		},
+	})
 }
 
 func showTemplate(name string) error {

--- a/cmd/vm_show.go
+++ b/cmd/vm_show.go
@@ -13,7 +13,7 @@ import (
 // showCmd represents the show command
 var vmShowCmd = &cobra.Command{
 	Use:     "show <name | id>",
-	Short:   "Show virtual machine details",
+	Short:   "Show a virtual machine details",
 	Aliases: gShowAlias,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {

--- a/table/table.go
+++ b/table/table.go
@@ -1,6 +1,7 @@
 package table
 
 import (
+	"bytes"
 	"os"
 
 	"github.com/olekukonko/tablewriter"
@@ -34,6 +35,24 @@ func NewTable(fd *os.File) *Table {
 	t.SetBorders(tablewriter.Border{
 		Left:   true,
 		Right:  true,
+		Top:    false,
+		Bottom: false,
+	})
+
+	return t
+}
+
+func NewEmbeddedTable(buf *bytes.Buffer) *Table {
+	t := &Table{tablewriter.NewWriter(buf)}
+
+	t.SetAutoWrapText(false)
+	t.SetHeaderLine(false)
+	t.SetCenterSeparator(" ")
+	t.SetColumnSeparator(" ")
+	t.SetRowSeparator(" ")
+	t.SetBorders(tablewriter.Border{
+		Left:   false,
+		Right:  false,
 		Top:    false,
 		Bottom: false,
 	})


### PR DESCRIPTION
This change normalizes the `exo * show` commands output on a table-based format:

```console
$ exo config show
#
# Before
#
                  marc

Account:          marc
API Key:          EXO000000000000000000000000
API Secret:       ××××××××××

Default zone:     ch-gva-2
Default template: Linux Ubuntu 18.04 LTS 64-bit

Configuration:    /Users/marc/.exoscale/exoscale.toml
Storage:          /Users/marc/.exoscale

#
# After
#
┼──────────────────────┼─────────────────────────────────────┼
│         MARC         │                                     │
┼──────────────────────┼─────────────────────────────────────┼
│ Account Name         │ marc                                │
│ API Key              │ EXO000000000000000000000000         │
│ API Secret           │ ×××××××××××××××××××××××××××         │
│ Default Zone         │ ch-gva-2                            │
│ Default Template     │ Linux Ubuntu 18.04 LTS 64-bit       │
│ Configuration Folder │ /Users/marc/.exoscale               │
│ Configuration        │ /Users/marc/.exoscale/exoscale.toml │
┼──────────────────────┼─────────────────────────────────────┼
```

```console
$ exo status
#
# Before
#
Exoscale Status
    https://exoscalestatus.com

Compute        operational
Compute API    operational
DNS            operational
Object Storage operational

#
# After
#
┼─────────────────┼──────────────────────────────────┼
│ EXOSCALE STATUS │                                  │
┼─────────────────┼──────────────────────────────────┼
│ Services        │   Object Storage   operational   │
│                 │   Compute          operational   │
│                 │   Compute API      operational   │
│                 │   DNS              operational   │
│                 │                                  │
│ Incidents       │ n/a                              │
│ Maintenances    │ n/a                              │
┼─────────────────┼──────────────────────────────────┼
Updates available at https://twitter.com/exoscalestatus
```

```console
$ exo affinitygroup show
#
# Before
#
Affinity Group: kube-workers
ID:             6d4ab1f2-70eb-4cdb-95a4-ba2b1c13b6d8
Description:    keep all the workers on different hyperv
Type:           host anti-affinity
VirtualMachines:
┼─────────────────┼──────────────────────────────────────┼
│      NAME       │                  ID                  │
┼─────────────────┼──────────────────────────────────────┼
│ kube-worker001  │ 7db505a4-775e-402b-912f-21d2a9867bde |
│ kube-worker002  │ 60fbadd3b-dd1-49dd-b8a0-a75aa83895be │
│ kube-worker003  │ 91f60a68-a313-4a9b-999b-2f2fd4e17525 │
│ kube-worker004  │ 9fea40ee-8356-4793-be35-ac295140993f │
│ kube-worker005  │ bde932fa-6439-4058-88b9-ce92d8d8afa6 │
┼─────────────────┼──────────────────────────────────────┼

#
# After
#
┼──────────────────┼────────────────────────────────────────────────────────────┼
│ KUBE-WORKER      │                                                            │
┼──────────────────┼────────────────────────────────────────────────────────────┼
│ ID               │ 6d4ab1f2-70eb-4cdb-95a4-ba2b1c13b6d8                       │
│ Name             │ kube-workers                                               │
│ Description      │ keep all the workers on different hyperv                   │
│ Instances        │                                                            │
│                  │   kube-worker001    7db505a4-775e-402b-912f-21d2a9867bde   │
│                  │   kube-worker002    60fbadd3b-dd1-49dd-b8a0-a75aa83895be   │
│                  │   kube-worker003    91f60a68-a313-4a9b-999b-2f2fd4e17525   │
│                  │   kube-worker004    9fea40ee-8356-4793-be35-ac295140993f   │
│                  │   kube-worker005    bde932fa-6439-4058-88b9-ce92d8d8afa6   │
│                  │                                                            │
┼──────────────────┼────────────────────────────────────────────────────────────┼
```

```console
$ exo privnet show
#
# Before
#
Network:     net0
Description:
Zone:        ch-gva-2
IP Range:    n/a
# Instances: 1
┼──────────────────────────────────────┼──────┼─────────────────┼─────────────┼
│                  ID                  │ NAME │    PUBLIC IP    │ INTERNAL IP │
┼──────────────────────────────────────┼──────┼─────────────────┼─────────────┼
│ e8db5c21-da06-4bb0-adb1-2f914972e158 │ irc0 │ 159.100.242.155 │ n/a         │
┼──────────────────────────────────────┼──────┼─────────────────┼─────────────┼

#
# After
#
┼───────────────┼─────────────────────────────────────────────────┼
│     NET0      │                                                 │
┼───────────────┼─────────────────────────────────────────────────┼
│ ID            │ b84115fe-ceef-4444-b87c-56810983bc42            │
│ Name          │ net0                                            │
│ Description   │                                                 │
│ Zone          │ ch-gva-2                                        │
│ DHCP IP Range │ n/a                                             │
│ Instances     │                                                 │
│               │   irc0   e8db5c21-da06-4bb0-adb1-2f914972e158   │
│               │                                                 │
┼───────────────┼─────────────────────────────────────────────────┼
```

```console
$ exo vm template show
#
# Before
#
ID:        84074627-0f31-49c4-b446-9611f4674ba0
Name:      Linux Ubuntu 18.10 64-bit
OS Type:   Linux Ubuntu (64-bit)
Username:  ubuntu
Size:      10 GiB
Created:   2018-10-19T12:02:37+0200
Password?: true

#
# After
#
┼───────────────────────────┼──────────────────────────────────────┼
│ LINUX UBUNTU 18.10 64-BIT │                                      │
┼───────────────────────────┼──────────────────────────────────────┼
│ ID                        │ 84074627-0f31-49c4-b446-9611f4674ba0 │
│ Name                      │ Linux Ubuntu 18.10 64-bit            │
│ OS Type                   │ Linux Ubuntu (64-bit)                │
│ Created                   │ 2018-10-19T12:02:37+0200             │
│ Size                      │ 10                                   │
│ Username                  │ ubuntu                               │
│ Password?                 │ true                                 │
┼───────────────────────────┼──────────────────────────────────────┼
```

```console
$ exo runstatus show
#
# Before
#
Page:  exoscale-test
URL:   https://exoscale-test.runstat.us
Email:
State: operational
Services:
┼──────────────────────────┼─────────────┼──────┼
│           NAME           │    STATE    │  ID  │
┼──────────────────────────┼─────────────┼──────┼
│ Fake service             │ operational │ 1299 │
│ Mission-critical service │ operational │ 1301 │
│ Real service             │ operational │ 1300 │
│ Test service             │ operational │ 1298 │
┼──────────────────────────┼─────────────┼──────┼

#
# After
#
┼───────────────┼────────────────────────────────────────────┼
│ EXOSCALE-TEST │                                            │
┼───────────────┼────────────────────────────────────────────┼
│ Name          │ exoscale-test                              │
│ URL           │ https://exoscale-test.runstat.us           │
│ Email         │                                            │
│ State         │ operational                                │
│ Services      │                                            │
│               │   Fake service               operational   │
│               │   Mission-critical service   operational   │
│               │   Real service               operational   │
│               │   Test service               operational   │
│               │                                            │
┼───────────────┼────────────────────────────────────────────┼
```

```console
$ exo runstatus show 
#
# Before
#
Page:  exoscale-test
URL:   https://exoscale-test.runstat.us
Email:
State: major_outage
Services:
┼──────────────────────────┼──────────────┼──────┼
│           NAME           │    STATE     │  ID  │
┼──────────────────────────┼──────────────┼──────┼
│ Fake service             │ operational  │ 1299 │
│ Mission-critical service │ operational  │ 1301 │
│ Real service             │ major_outage │ 1300 │
│ Test service             │ major_outage │ 1298 │
┼──────────────────────────┼──────────────┼──────┼

Incidents:
┼───────────┼──────────────┼────────────┼──────┼──────┼
│   TITLE   │    STATE     │   STATUS   │ WHEN │  ID  │
┼───────────┼──────────────┼────────────┼──────┼──────┼
│ It's fine │ major_outage │ identified │      │ 1012 │
┼───────────┼──────────────┼────────────┼──────┼──────┼

Maintenances:
┼──────────────────────────────────┼─────────────┼────────────────────────────────────────────────┼─────┼
│              TITLE               │   STATUS    │                      WHEN                      │ ID  │
┼──────────────────────────────────┼─────────────┼────────────────────────────────────────────────┼─────┼
│ Attention chérie ca va couper... │ in-progress │ 2019-05-13 10:00:14.098 +0000 UTC - 4h0m0.006s │ 658 │
┼──────────────────────────────────┼─────────────┼────────────────────────────────────────────────┼─────┼

#
# After
#
┼───────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┼
│ EXOSCALE-TEST │                                                                                                     │
┼───────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┼
│ Name          │ exoscale-test                                                                                       │
│ URL           │ https://exoscale-test.runstat.us                                                                    │
│ Email         │                                                                                                     │
│ State         │ major_outage                                                                                        │
│ Services      │                                                                                                     │
│               │   Fake service               operational                                                            │
│               │   Mission-critical service   operational                                                            │
│               │   Real service               major_outage                                                           │
│               │   Test service               major_outage                                                           │
│               │                                                                                                     │
│ Incidents     │   It's fine   major_outage   identified                                                             │
│               │                                                                                                     │
│ Maintenances  │   Attention chérie ca va couper...   in-progress   2019-05-13 10:00:14.098 +0000 UTC - 4h0m0.006s   │
│               │                                                                                                     │
┼───────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┼
```

```console
$ exo runstatus maintenance show
#
# Before
#
Title: On casse tout
State: scheduled
URL:   https://api.runstatus.com/pages/exoscale-test/maintenances/659

#
# After
#
┼───────────────────┼───────────────────────────────────┼
│   EXOSCALE-TEST   │                                   │
┼───────────────────┼───────────────────────────────────┼
│ ID                │ 659                               │
│ Title             │ On casse tout                     │
│ Description       │ On casse tout !                   │
│ State             │ scheduled                         │
│ Start Date        │ 2019-05-13 13:50:32.836 +0000 UTC │
│ End Date          │ 2019-05-13 13:50:32.84 +0000 UTC  │
│ Affected Services │ Fake service                      │
┼───────────────────┼───────────────────────────────────┼
```

```console
$ exo runstatus incident show
#
# Before
#
Title:       Blah
Description: update 2
State:       partial_outage
Status:      monitoring

#
# After
#
┼───────────────────┼─────────────────────────────────────────────────────────────────────────┼
│   EXOSCALE-TEST   │                                                                         │
┼───────────────────┼─────────────────────────────────────────────────────────────────────────┼
│ ID                │ 1013                                                                    │
│ Title             │ Blah                                                                    │
│ State             │ partial_outage                                                          │
│ Status            │ monitoring                                                              │
│ Start Date        │ 2019-05-13 15:40:31.631928 +0000 UTC                                    │
│ Affected Services │ Fake service                                                            │
│                   │ Mission-critical service                                                │
│                   │ Real service                                                            │
│                   │ Test service                                                            │
│ Event Stream      │                                                                         │
│                   │   2019-05-13 15:45:22.130425 +0000 UTC   monitoring   update 2          │
│                   │   2019-05-13 15:45:14.852029 +0000 UTC   identified   update 1          │
│                   │   2019-05-13 15:40:31.631928 +0000 UTC   identified   Une description   │
│                   │                                                                         │
┼───────────────────┼─────────────────────────────────────────────────────────────────────────┼
```

```console
$ exo runstatus service show
#
# Before
#
Name:  Test service
State: partial_outage
URL:   https://api.runstatus.com/pages/exoscale-test/services/1298

#
# After
#
┼───────────────┼────────────────┼
│ EXOSCALE-TEST │                │
┼───────────────┼────────────────┼
│ ID            │ 1298           │
│ Name          │ Test service   │
│ State         │ partial_outage │
┼───────────────┼────────────────┼
```

```console
$ exo runstatus service show
#
# Before
#
Name:  Test service
State: partial_outage
URL:   https://api.runstatus.com/pages/exoscale-test/services/1298

#
# After
#
┼───────────────┼────────────────┼
│ EXOSCALE-TEST │                │
┼───────────────┼────────────────┼
│ ID            │ 1298           │
│ Name          │ Test service   │
│ State         │ partial_outage │
┼───────────────┼────────────────┼
```