### PR TITLE
Add support for output formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 UNRELEASED
 ----------
 
+- Add support for commands output customization (#150)
 - Support template-filter in various commands (#151)
 - Fix output bug in `network delete` command (#152)
 - Display zone in `template (list|show)` commands (#153)

--- a/cmd/affinitygroup.go
+++ b/cmd/affinitygroup.go
@@ -35,14 +35,6 @@ func getAffinityGroupByName(name string) (*egoscale.AffinityGroup, error) {
 	return resp.(*egoscale.AffinityGroup), nil
 }
 
-func getAffinityGroups(vm *egoscale.VirtualMachine) []string {
-	ags := make([]string, len(vm.AffinityGroup))
-	for i, agN := range vm.AffinityGroup {
-		ags[i] = agN.Name
-	}
-	return ags
-}
-
 func init() {
 	RootCmd.AddCommand(affinitygroupCmd)
 }

--- a/cmd/affinitygroup_show.go
+++ b/cmd/affinitygroup_show.go
@@ -1,63 +1,68 @@
 package cmd
 
 import (
-	"bytes"
-	"os"
+	"fmt"
+	"strings"
 
-	"github.com/exoscale/cli/table"
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
 )
 
+type affinityGroupShowOutput struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Instances   []string `json:"instances"`
+}
+
+func (o *affinityGroupShowOutput) Type() string { return "Anti-Affinity Group" }
+func (o *affinityGroupShowOutput) toJSON()      { outputJSON(o) }
+func (o *affinityGroupShowOutput) toText()      { outputText(o) }
+func (o *affinityGroupShowOutput) toTable()     { outputTable(o) }
+
 func init() {
 	affinitygroupCmd.AddCommand(&cobra.Command{
-		Use:     "show <name | id>",
-		Short:   "Show affinity group details",
+		Use:   "show <name | id>",
+		Short: "Show affinity group details",
+		Long: fmt.Sprintf(`This command shows an Anti-Affinity Group details.
+
+Supported output template annotations: %s`,
+			strings.Join(outputterTemplateAnnotations(&affinityGroupShowOutput{}), ", ")),
 		Aliases: gShowAlias,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return cmd.Usage()
 			}
-			return showAffinityGroup(args[0])
+
+			return output(showAffinityGroup(args[0]))
 		},
 	})
 }
 
-func showAffinityGroup(name string) error {
+func showAffinityGroup(name string) (outputter, error) {
 	ag, err := getAffinityGroupByName(name)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	t := table.NewTable(os.Stdout)
-	t.SetHeader([]string{ag.Name})
-
-	t.Append([]string{"ID", ag.ID.String()})
-	t.Append([]string{"Name", ag.Name})
-	t.Append([]string{"Description", ag.Description})
-
-	if len(ag.VirtualMachineIDs) == 0 {
-		t.Append([]string{"Instances", "n/a"})
-		t.Render()
-		return nil
+	out := affinityGroupShowOutput{
+		ID:          ag.ID.String(),
+		Name:        ag.Name,
+		Description: ag.Description,
+		Instances:   make([]string, len(ag.VirtualMachineIDs)),
 	}
 
-	resp, err := cs.ListWithContext(gContext, &egoscale.ListVirtualMachines{IDs: ag.VirtualMachineIDs})
-	if err != nil {
-		return err
+	if len(ag.VirtualMachineIDs) > 0 {
+		resp, err := cs.ListWithContext(gContext, &egoscale.ListVirtualMachines{IDs: ag.VirtualMachineIDs})
+		if err != nil {
+			return nil, err
+		}
+
+		for i, r := range resp {
+			vm := r.(*egoscale.VirtualMachine)
+			out.Instances[i] = vm.Name
+		}
 	}
 
-	buf := bytes.NewBuffer(nil)
-	it := table.NewEmbeddedTable(buf)
-	it.SetHeader([]string{" "})
-	for _, r := range resp {
-		vm := r.(*egoscale.VirtualMachine)
-		it.Append([]string{vm.Name, vm.ID.String()})
-	}
-	it.Render()
-	t.Append([]string{"Instances", buf.String()})
-
-	t.Render()
-
-	return nil
+	return &out, nil
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -19,8 +19,9 @@ import (
 )
 
 type config struct {
-	DefaultAccount string
-	Accounts       []account
+	DefaultAccount      string
+	DefaultOutputFormat string
+	Accounts            []account
 }
 
 type account struct {
@@ -69,6 +70,10 @@ func (a account) AccountName() string {
 	return a.Name
 }
 
+func (a account) IsDefault() bool {
+	return a.Name == gAllAccount.DefaultAccount
+}
+
 const (
 	defaultConfigFileName    = "exoscale"
 	defaultEndpoint          = "https://api.exoscale.ch/compute"
@@ -76,6 +81,7 @@ const (
 	defaultSosEndpoint       = "https://sos-{zone}.exo.io"
 	defaultRunstatusEndpoint = "https://api.runstatus.com"
 	defaultZone              = "ch-dk-2"
+	defaultOutputFormat      = "table"
 )
 
 // configCmd represents the config command

--- a/cmd/config_list.go
+++ b/cmd/config_list.go
@@ -2,26 +2,64 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
+	"github.com/exoscale/cli/table"
 	"github.com/spf13/cobra"
 )
 
-// listCmd represents the list command
-var configListCmd = &cobra.Command{
-	Use:     "list",
-	Short:   "List available accounts",
-	Aliases: gListAlias,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if gAllAccount == nil {
-			return fmt.Errorf("no accounts defined")
+type configListItemOutput struct {
+	Name    string `json:"name"`
+	Default bool   `json:"default"`
+}
+
+type configListOutput []configListItemOutput
+
+func (o *configListOutput) toJSON() { outputJSON(o) }
+
+func (o *configListOutput) toText() { outputText(o) }
+
+func (o *configListOutput) toTable() {
+	t := table.NewTable(os.Stdout)
+	t.SetHeader([]string{"Accounts"})
+
+	for _, i := range *o {
+		a := i.Name
+		if i.Default {
+			a += "*"
 		}
-		for _, account := range listAccounts() {
-			fmt.Println(account)
-		}
-		return nil
-	},
+
+		t.Append([]string{a})
+	}
+
+	t.Render()
 }
 
 func init() {
-	configCmd.AddCommand(configListCmd)
+	configCmd.AddCommand(&cobra.Command{
+		Use:   "list",
+		Short: "List available accounts",
+		Long: fmt.Sprintf(`This command lists configured Exoscale accounts. The default account is marked with (*).
+
+Supported output template annotations: %s`,
+			strings.Join(outputterTemplateAnnotations(&configListOutput{}), ", ")),
+		Aliases: gListAlias,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output(listConfigs(), nil)
+		},
+	})
+}
+
+func listConfigs() outputter {
+	out := configListOutput{}
+
+	for _, a := range gAllAccount.Accounts {
+		out = append(out, configListItemOutput{
+			Name:    a.Name,
+			Default: a.IsDefault(),
+		})
+	}
+
+	return &out
 }

--- a/cmd/dns_show.go
+++ b/cmd/dns_show.go
@@ -2,69 +2,87 @@ package cmd
 
 import (
 	"errors"
-	"os"
-	"strconv"
+	"fmt"
+	"strings"
 
-	"github.com/exoscale/cli/table"
 	"github.com/spf13/cobra"
 )
 
+type dnsShowItemOutput struct {
+	ID         int64  `json:"id"`
+	DomainID   int64  `json:"domain_id" output:"-"`
+	Name       string `json:"name"`
+	RecordType string `json:"record_type"`
+	Content    string `json:"content"`
+	Prio       int    `json:"prio,omitempty"`
+	TTL        int    `json:"ttl,omitempty"`
+	CreatedAt  string `json:"created_at,omitempty" output:"-"`
+	UpdatedAt  string `json:"updated_at,omitempty" output:"-"`
+}
+
+type dnsShowOutput []dnsShowItemOutput
+
+func (o *dnsShowOutput) toJSON()  { outputJSON(o) }
+func (o *dnsShowOutput) toText()  { outputText(o) }
+func (o *dnsShowOutput) toTable() { outputTable(o) }
+
 func init() {
+	var dnsShowCmd = &cobra.Command{
+		Use:   "show <domain name | id> [type ...]",
+		Short: "Show the domain records",
+		Long: fmt.Sprintf(`This command shows a DNS Domain records.
+
+Supported output template annotations: %s`,
+			strings.Join(outputterTemplateAnnotations(&dnsShowOutput{}), ", ")),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var types []string
+
+			if len(args) < 1 {
+				return errors.New("show expects one DNS domain by name or id")
+			}
+
+			if len(args) > 1 {
+				types = make([]string, len(args)-1)
+				copy(types, args[1:])
+			} else {
+				types = []string{""}
+			}
+
+			name, err := cmd.Flags().GetString("name")
+			if err != nil {
+				return err
+			}
+
+			return output(showDNS(args[0], name, types))
+		},
+	}
+
 	dnsCmd.AddCommand(dnsShowCmd)
 	dnsShowCmd.Flags().StringP("name", "n", "", "List records by name")
 }
 
-// dnsShowCmd represents the show command
-var dnsShowCmd = &cobra.Command{
-	Use:   "show <domain name | id> [type]",
-	Short: "Show the domain records",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return errors.New("show expects one DNS domain by name or id")
-		}
-
-		var types []string
-		if len(args) > 1 {
-			types = make([]string, len(args)-1)
-			copy(types, args[1:])
-		} else {
-			types = []string{""}
-		}
-
-		name, err := cmd.Flags().GetString("name")
-		if err != nil {
-			return err
-		}
-
-		t := table.NewTable(os.Stdout)
-		err = domainListRecords(t, args[0], name, types)
-		if err == nil {
-			t.Render()
-		}
-		return err
-	},
-}
-
-func domainListRecords(t *table.Table, domain, name string, types []string) error {
-	t.SetHeader([]string{"Type", "Name", "Content", "TTL", "Prio", "ID"})
+func showDNS(domain, name string, types []string) (outputter, error) {
+	out := dnsShowOutput{}
 
 	for _, recordType := range types {
 		records, err := csDNS.GetRecordsWithFilters(gContext, domain, name, recordType)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		for _, record := range records {
-			t.Append([]string{
-				record.RecordType,
-				record.Name,
-				record.Content,
-				strconv.Itoa(record.TTL),
-				strconv.Itoa(record.Prio),
-				strconv.FormatInt(record.ID, 10),
+			out = append(out, dnsShowItemOutput{
+				ID:         record.ID,
+				Name:       record.Name,
+				RecordType: record.RecordType,
+				Content:    record.Content,
+				TTL:        record.TTL,
+				Prio:       record.Prio,
+				CreatedAt:  record.CreatedAt,
+				UpdatedAt:  record.UpdatedAt,
 			})
 		}
 	}
 
-	return nil
+	return &out, nil
 }

--- a/cmd/eip_list.go
+++ b/cmd/eip_list.go
@@ -2,84 +2,97 @@ package cmd
 
 import (
 	"fmt"
-	"os"
+	"strings"
 
-	"github.com/exoscale/cli/table"
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
 )
 
-// listCmd represents the list command
-var eipListCmd = &cobra.Command{
-	Use:     "list",
-	Short:   "List elastic IP",
-	Aliases: gListAlias,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		zone, err := cmd.Flags().GetString("zone")
-		if err != nil {
-			return err
-		}
-		table := table.NewTable(os.Stdout)
-		table.SetHeader([]string{"zone", "IP", "ID", "Associated Virtual machine"})
-		if err := listIPs(zone, table); err != nil {
-			return err
-		}
-		table.Render()
-		return nil
-	},
+type eipListItemOutput struct {
+	ID        string   `json:"id"`
+	Zone      string   `json:"zone"`
+	IPAddress string   `json:"ip_address"`
+	Managed   bool     `json:"managed"`
+	Instances []string `json:"instances,omitempty"`
 }
 
-func listIPs(zone string, table *table.Table) error {
-	zReq := egoscale.IPAddress{}
+type eipListOutput []eipListItemOutput
 
-	if zone != "" {
-		var err error
-		zReq.ZoneID, err = getZoneIDByName(zone)
-		if err != nil {
-			return err
-		}
-		zReq.IsElastic = true
-		ips, err := cs.ListWithContext(gContext, &zReq)
-		if err != nil {
-			return err
-		}
+func (o *eipListOutput) toJSON()  { outputJSON(o) }
+func (o *eipListOutput) toText()  { outputText(o) }
+func (o *eipListOutput) toTable() { outputTable(o) }
 
-		var zone string
-		for i, ipaddr := range ips {
-			ip := ipaddr.(*egoscale.IPAddress)
-			if i == 0 {
-				zone = ip.ZoneName
-			}
+func init() {
+	var eipListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List elastic IP",
+		Long: fmt.Sprintf(`This command lists existing Elastic IP addresses.
 
-			_, vms, err := eipDetails(ip.ID)
+Supported output template annotations: %s`,
+			strings.Join(outputterTemplateAnnotations(&eipListOutput{}), ", ")),
+		Aliases: gListAlias,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			zone, err := cmd.Flags().GetString("zone")
 			if err != nil {
 				return err
 			}
 
-			nbVM := fmt.Sprintf("%d", len(vms))
-
-			table.Append([]string{zone, ip.IPAddress.String(), ip.ID.String(), nbVM})
-			zone = ""
-		}
-		return nil
+			return output(listEIP(zone))
+		},
 	}
 
-	zones := &egoscale.Zone{}
-	zs, err := cs.ListWithContext(gContext, zones)
-	if err != nil {
-		return err
-	}
-
-	for _, z := range zs {
-		zID := z.(*egoscale.Zone).Name
-		if err := listIPs(zID, table); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func init() {
 	eipListCmd.Flags().StringP("zone", "z", "", "Show IPs from given zone")
 	eipCmd.AddCommand(eipListCmd)
+}
+
+func listEIP(zone string) (outputter, error) {
+	out := eipListOutput{}
+
+	zones, err := cs.ListWithContext(gContext, &egoscale.Zone{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, z := range zones {
+		if zone != "" && z.(*egoscale.Zone).Name != zone {
+			continue
+		}
+
+		req := egoscale.IPAddress{
+			ZoneID:    z.(*egoscale.Zone).ID,
+			IsElastic: true,
+		}
+
+		ips, err := cs.ListWithContext(gContext, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, ip := range ips {
+			eip := ip.(*egoscale.IPAddress)
+
+			_, vms, err := eipDetails(eip.ID)
+			if err != nil {
+				return nil, err
+			}
+			instances := make([]string, len(vms))
+			for i := range vms {
+				instances[i] = vms[i].Name
+			}
+
+			o := eipListItemOutput{
+				ID:        eip.ID.String(),
+				IPAddress: eip.IPAddress.String(),
+				Zone:      z.(*egoscale.Zone).Name,
+				Instances: instances,
+			}
+			if eip.Healthcheck != nil {
+				o.Managed = true
+			}
+
+			out = append(out, o)
+		}
+	}
+
+	return &out, nil
 }

--- a/cmd/eip_show.go
+++ b/cmd/eip_show.go
@@ -3,81 +3,120 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/exoscale/cli/table"
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
 )
 
-// showCmd represents the show command
-var eipShowCmd = &cobra.Command{
-	Use:     "show <ip address | eip id>",
-	Short:   "Show an eip details",
-	Aliases: gShowAlias,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return cmd.Usage()
-		}
+type eipHealthcheckShowOutput struct {
+	Mode        string `json:"mode,omitempty"`
+	Path        string `json:"path,omitempty"`
+	Port        int64  `json:"port,omitempty"`
+	Interval    int64  `json:"interval,omitempty"`
+	Timeout     int64  `json:"timeout,omitempty"`
+	StrikesOk   int64  `json:"strikes_ok,omitempty"`
+	StrikesFail int64  `json:"strikes_fail,omitempty"`
+}
 
-		id, err := egoscale.ParseUUID(args[0])
-		if err != nil {
-			id, err = getEIPIDByIP(args[0])
-			if err != nil {
-				return err
+type eipShowOutput struct {
+	ID          string                    `json:"id"`
+	Zone        string                    `json:"zone"`
+	IPAddress   string                    `json:"ip_address"`
+	Healthcheck *eipHealthcheckShowOutput `json:"healthcheck"`
+	Instances   []string                  `json:"instances"`
+}
+
+func (o *eipShowOutput) toJSON() { outputJSON(o) }
+
+func (o *eipShowOutput) toText() { outputText(o) }
+
+func (o *eipShowOutput) toTable() {
+	t := table.NewTable(os.Stdout)
+	t.SetHeader([]string{"Elastic IP"})
+
+	t.Append([]string{"ID", o.ID})
+	t.Append([]string{"Zone", o.Zone})
+	t.Append([]string{"IP Address", o.IPAddress})
+
+	if o.Healthcheck != nil {
+		t.Append([]string{"Healthcheck Mode", o.Healthcheck.Mode})
+		t.Append([]string{"Healthcheck Port", fmt.Sprint(o.Healthcheck.Port)})
+		if o.Healthcheck.Mode == "http" {
+			t.Append([]string{"Healthcheck Path", o.Healthcheck.Path})
+		}
+		t.Append([]string{"Healthcheck Interval", fmt.Sprint(o.Healthcheck.Interval)})
+		t.Append([]string{"Healthcheck Timeout", fmt.Sprint(o.Healthcheck.Timeout)})
+		t.Append([]string{"Healthcheck Strikes OK", fmt.Sprint(o.Healthcheck.StrikesOk)})
+		t.Append([]string{"Healthcheck Strikes Fail", fmt.Sprint(o.Healthcheck.StrikesFail)})
+	}
+
+	if len(o.Instances) > 0 {
+		t.Append([]string{"Instances", strings.Join(o.Instances, "\n")})
+	}
+
+	t.Render()
+}
+
+func init() {
+	eipCmd.AddCommand(&cobra.Command{
+		Use:   "show <ip address | eip id>",
+		Short: "Show an Elastic IP details",
+		Long: fmt.Sprintf(`This command shows an Elastic IP details.
+
+Supported output template annotations: %s`,
+			strings.Join(outputterTemplateAnnotations(&eipShowOutput{}), ", ")),
+		Aliases: gShowAlias,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return cmd.Usage()
 			}
-		}
 
-		ip, vms, err := eipDetails(id)
+			return output(showEIP(args[0]))
+		},
+	})
+}
+
+func showEIP(eip string) (outputter, error) {
+	id, err := egoscale.ParseUUID(eip)
+	if err != nil {
+		id, err = getEIPIDByIP(eip)
 		if err != nil {
-			return err
+			return nil, err
 		}
+	}
 
-		table := table.NewTable(os.Stdout)
+	ip, vms, err := eipDetails(id)
+	if err != nil {
+		return nil, err
+	}
 
-		zone := ip.ZoneName
-		ipaddr := ip.IPAddress.String()
+	out := eipShowOutput{
+		ID:        id.String(),
+		Zone:      ip.ZoneName,
+		IPAddress: ip.IPAddress.String(),
+	}
 
-		table.SetHeader([]string{ipaddr})
-		table.Append([]string{"ID", id.String()})
-		table.Append([]string{"Zone", zone})
-		if ip.Healthcheck != nil {
-			table.Append([]string{
-				"Healthcheck Mode",
-				ip.Healthcheck.Mode})
-			table.Append([]string{
-				"Healthcheck Path",
-				ip.Healthcheck.Path})
-			table.Append([]string{
-				"Healthcheck Port",
-				fmt.Sprintf("%d", ip.Healthcheck.Port)})
-			table.Append([]string{
-				"Healthcheck Interval",
-				fmt.Sprintf("%d", ip.Healthcheck.Interval)})
-			table.Append([]string{
-				"Healthcheck Strikes Fail",
-				fmt.Sprintf("%d", ip.Healthcheck.StrikesFail)})
-			table.Append([]string{
-				"Healthcheck Strikes OK",
-				fmt.Sprintf("%d", ip.Healthcheck.StrikesOk)})
-			table.Append([]string{
-				"Healthcheck Timeout",
-				fmt.Sprintf("%d", ip.Healthcheck.Timeout)})
+	if ip.Healthcheck != nil {
+		out.Healthcheck = &eipHealthcheckShowOutput{
+			Mode:        ip.Healthcheck.Mode,
+			Path:        ip.Healthcheck.Path,
+			Port:        ip.Healthcheck.Port,
+			Interval:    ip.Healthcheck.Interval,
+			Timeout:     ip.Healthcheck.Timeout,
+			StrikesOk:   ip.Healthcheck.StrikesOk,
+			StrikesFail: ip.Healthcheck.StrikesFail,
 		}
+	}
 
-		if len(vms) > 0 {
-			table.Append([]string{
-				"Instances",
-				vms[0].Name,
-			})
-			for _, vm := range vms[1:] {
-				table.Append([]string{
-					"",
-					vm.Name})
-			}
-		}
-		table.Render()
-		return nil
-	},
+	instances := make([]string, len(vms))
+	for i := range vms {
+		instances[i] = vms[i].Name
+	}
+	out.Instances = instances
+
+	return &out, nil
 }
 
 func eipDetails(eip *egoscale.UUID) (*egoscale.IPAddress, []egoscale.VirtualMachine, error) {
@@ -111,8 +150,4 @@ func eipDetails(eip *egoscale.UUID) (*egoscale.IPAddress, []egoscale.VirtualMach
 	}
 
 	return addr, vmAssociated, nil
-}
-
-func init() {
-	eipCmd.AddCommand(eipShowCmd)
 }

--- a/cmd/firewall_add.go
+++ b/cmd/firewall_add.go
@@ -224,7 +224,7 @@ A set of predefined commands exists, such a ssh, ping or minecraft.
 			return errs[0]
 		}
 
-		return firewallShow.RunE(cmd, []string{securityGroup.ID.String()})
+		return nil
 	},
 }
 

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -1,0 +1,312 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"text/template"
+
+	"github.com/exoscale/cli/table"
+	"github.com/fatih/camelcase"
+	"github.com/spf13/cobra"
+)
+
+// outputter is an interface that must to be implemented by the commands output
+// objects. In addition to the methods, types implementing this interface can
+// also use struct tags to modify the output logic:
+//   * output:"-" is similar to package encoding/json, i.e. that a field with
+//     this tag will not be displayed
+//   * outputLabel:"..." overrides the string displayed as label, which by
+//     default is the field's CamelCase named split with spaces
+type outputter interface {
+	toTable()
+	toJSON()
+	toText()
+}
+
+// output prints an outputter interface to the terminal, formatted according
+// to the global format specified as CLI flag.
+func output(o outputter, err error) error {
+	if err != nil {
+		return err
+	}
+
+	switch gOutputFormat {
+	case "json":
+		o.toJSON()
+
+	case "text":
+		o.toText()
+
+	default:
+		o.toTable()
+	}
+
+	return nil
+}
+
+// outputterTemplateAnnotations returns a list of annotations available for use
+// with an output template.
+func outputterTemplateAnnotations(o interface{}) []string {
+	annotations := make([]string, 0)
+
+	v := reflect.ValueOf(o)
+	v = reflect.Indirect(v)
+	t := v.Type()
+
+	// If the outputter interface is iterable (slice only), use the element type
+	if v.Kind() == reflect.Slice {
+		t = v.Type().Elem()
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		annotations = append(annotations, "."+t.Field(i).Name)
+	}
+
+	return annotations
+}
+
+// outputJSON prints a JSON-formatted rendering of o to the terminal.
+func outputJSON(o interface{}) {
+	j, err := json.Marshal(o)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: unable to encode output to JSON: %s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(string(j))
+}
+
+// outputText prints a template-based plain text rendering of o to the
+// terminal. If the object is of iterable type (slice only), each item is
+// printed on a new line. If none is provided by the user, the default
+// template prints all fields separated by a tabulation character.
+func outputText(o interface{}) {
+	var tpl = gOutputTemplate
+
+	if tpl == "" {
+		tplFields := outputterTemplateAnnotations(o)
+		for i := range tplFields {
+			tplFields[i] = "{{" + tplFields[i] + "}}"
+		}
+		tpl = strings.Join(tplFields, "\t")
+	}
+
+	t, err := template.New("out").Parse(tpl)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: unable to encode output in plaintext using template: %s\n", err)
+		os.Exit(1)
+	}
+
+	// If the outputter interface is iterable (slice only), we loop over the
+	// items and perform the templating directly
+	if v := reflect.ValueOf(o); reflect.Indirect(v).Kind() == reflect.Slice {
+		for i := 0; i < reflect.Indirect(v).Len(); i++ {
+			if err := t.Execute(os.Stdout, reflect.Indirect(v).Index(i).Interface()); err != nil {
+				fmt.Fprintf(os.Stderr, "error: unable to encode output using template: %s\n", err)
+				os.Exit(1)
+			}
+			fmt.Println()
+		}
+		return
+	}
+
+	if err := t.Execute(os.Stdout, o); err != nil {
+		fmt.Fprintf(os.Stderr, "error: unable to encode output using template: %s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println()
+}
+
+// outputTable prints a table-formatted rendering of o to the terminal.
+// If the object is of iterable type (slice only), each item is printed in a
+// table row, with a header containing one column per type field. Otherwise,
+// each field of the object is printed in a key/value formatted table, and a
+// header is printed if the item type implements an optional (Type() string)
+// method.
+func outputTable(o interface{}) {
+	tab := table.NewTable(os.Stdout)
+
+	v := reflect.ValueOf(o)
+	v = reflect.Indirect(v)
+	t := v.Type()
+
+	// If the outputter interface is iterable (slice only), use the element type
+	if v.Kind() == reflect.Slice {
+		t = v.Type().Elem()
+	}
+
+	// Turn CamelCase field names into eye-friendlier labels.
+	// If the field has an `outputLabel` tag, use its value to override the header label.
+	headers := make([]string, 0)
+	for i := 0; i < t.NumField(); i++ {
+		// Check if the field has to be skipped
+		if l, ok := t.Field(i).Tag.Lookup("output"); ok {
+			if l == "-" {
+				continue
+			}
+		}
+
+		label := strings.Join(camelcase.Split(t.Field(i).Name), " ")
+		if l, ok := t.Field(i).Tag.Lookup("outputLabel"); ok {
+			label = l
+		}
+		headers = append(headers, label)
+	}
+
+	// If the outputter interface is iterable (slice only), we loop over the
+	// items and display each one in a table row
+	if v := reflect.ValueOf(o); reflect.Indirect(v).Kind() == reflect.Slice {
+		tab.SetHeader(headers)
+
+		for i := 0; i < reflect.Indirect(v).Len(); i++ {
+			item := reflect.Indirect(v).Index(i)
+			row := make([]string, 0)
+
+			for j := 0; j < item.NumField(); j++ {
+				field := item.Field(j)
+				// Check if the field has to be skipped
+				if l, ok := item.Type().Field(j).Tag.Lookup("output"); ok {
+					if l == "-" {
+						continue
+					}
+				}
+
+				switch field.Kind() {
+				case reflect.Slice:
+					// If the field value is a slice and is empty,
+					// print "n/a" instead of an empty slice
+					if field.Len() == 0 {
+						row = append(row, "n/a")
+					} else {
+						row = append(row, fmt.Sprint(field.Interface()))
+					}
+
+				case reflect.Ptr:
+					// If the field value is a nil pointer, print "n/a" instead of <nil>
+					if field.IsNil() {
+						row = append(row, "n/a")
+					} else {
+						row = append(row, fmt.Sprint(field.Interface()))
+					}
+
+				default:
+					row = append(row, fmt.Sprint(field.Interface()))
+				}
+			}
+
+			tab.Append(row)
+		}
+
+		tab.Render()
+		return
+	}
+
+	// Single item, loop over the type fields and display each item in a key/value-type table
+
+	// If the outputter interface implements the optional `Type()` method,
+	// use its return value as table header
+	if typeMethod := reflect.ValueOf(o).MethodByName("Type"); typeMethod.Kind() != reflect.Invalid {
+		in := make([]reflect.Value, typeMethod.Type().NumIn())
+		header := typeMethod.Call(in)[0].Interface().(string)
+		tab.SetHeader([]string{header, ""})
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		// Check if the field has to be skipped
+		if l, ok := t.Field(i).Tag.Lookup("output"); ok {
+			if l == "-" {
+				continue
+			}
+		}
+
+		label := strings.Join(camelcase.Split(t.Field(i).Name), " ")
+		if l, ok := t.Field(i).Tag.Lookup("outputLabel"); ok {
+			label = l
+		}
+
+		switch v.Field(i).Kind() {
+		case reflect.Slice:
+			// If the field value is a slice and is empty, print "n/a" instead of 0
+			if n := v.Field(i).Len(); n == 0 {
+				tab.Append([]string{label, "n/a"})
+			} else {
+				items := v.Field(i).Interface().([]string)
+				tab.Append([]string{label, strings.Join(items, "\n")})
+			}
+
+		case reflect.Ptr:
+			// If the field value is a nil pointer, print "n/a" instead of <nil>
+			if v.Field(i).IsNil() {
+				tab.Append([]string{label, "n/a"})
+			} else {
+				tab.Append([]string{label, fmt.Sprint(v.Field(i).Interface())})
+			}
+
+		default:
+			tab.Append([]string{label, fmt.Sprint(v.Field(i).Interface())})
+		}
+	}
+
+	tab.Render()
+}
+
+func init() {
+	RootCmd.AddCommand(&cobra.Command{
+		Use:   "output",
+		Short: "Output formatting usage",
+		Long: `The exo CLI tool allows you to customize its commands output using different
+formats such as table, JSON or text template using the "--output-format" flag
+("-O" in short version).
+
+By default the "table" format is applied, best suited for human reading. In
+case you need to process a command output with other CLI tools, for example
+in a shell script, you can either use the "json" output format (e.g. to be
+piped into jq):
+
+	$ exo config list -O json | jq .
+	[
+	  {
+	    "name": "alice",
+	    "default": true
+	  },
+	  {
+	    "name": "bob",
+	    "default": false
+	  }
+	]
+
+The "text" format prints a command's output in plain text according to a
+user-defined formatting template provided with the "--output-template" flag:
+
+	$ exo config list -O text --output-template '{{ .Name }}' | sort
+	alice
+	bob
+
+The templating format is Go's text/template, which allows conditional
+formatting. For example to display a "*" next to the default configuration
+account:
+
+	$ exo config list -O text \
+		--output-template '{{ .Name }}{{ if .Default }}*{{ end }}'
+	alice*
+	bob
+
+If no output template is provided, the default is to print all fields
+separated by a tabulation (\t) character so the output can be parsed by a
+delimiter-based processing tool such as cut(1) or AWK.
+
+Each CLI "show"/"list" command supports specific template annotations that are
+documented in the command's help page (e.g. "exo config list --help").
+
+Note: in "list" commands the templating is applied per entry, so it is not
+necessary to range on iterable data types. Each entry is terminated by a line
+return character.
+
+For the complete Go templating reference, see https://godoc.org/text/template
+`},
+	)
+}

--- a/cmd/privnet_show.go
+++ b/cmd/privnet_show.go
@@ -1,69 +1,67 @@
 package cmd
 
 import (
-	"bytes"
-	"os"
+	"fmt"
+	"strings"
 
-	"github.com/exoscale/cli/table"
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
 )
+
+type privnetShowOutput struct {
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	Zone      string   `json:"zone"`
+	DHCP      string   `json:"dhcp"`
+	Instances []string `json:"instances,omitempty"`
+}
+
+func (o *privnetShowOutput) Type() string { return "Private Network" }
+func (o *privnetShowOutput) toJSON()      { outputJSON(o) }
+func (o *privnetShowOutput) toText()      { outputText(o) }
+func (o *privnetShowOutput) toTable()     { outputTable(o) }
 
 func init() {
 	privnetCmd.AddCommand(&cobra.Command{
 		Use:   "show <privnet name | id>",
 		Short: "Show a private network details",
+		Long: fmt.Sprintf(`This command shows a Private Network details.
+
+Supported output template annotations: %s`,
+			strings.Join(outputterTemplateAnnotations(&privnetShowOutput{}), ", ")),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return cmd.Usage()
 			}
-			return showPrivnet(args[0])
+
+			return output(showPrivnet(args[0]))
 		},
 	})
 }
 
-func showPrivnet(name string) error {
-	network, err := getNetworkByName(name)
+func showPrivnet(name string) (outputter, error) {
+	privnet, err := getNetworkByName(name)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	vms, err := privnetDetails(network)
+	out := privnetShowOutput{
+		ID:   privnet.ID.String(),
+		Name: privnet.Name,
+		Zone: privnet.ZoneName,
+		DHCP: dhcpRange(*privnet),
+	}
+
+	vms, err := privnetDetails(privnet)
 	if err != nil {
-		return err
+		return nil, err
+	}
+	out.Instances = make([]string, len(vms))
+	for i := range vms {
+		out.Instances[i] = vms[i].Name
 	}
 
-	dhcp := dhcpRange(*network)
-
-	t := table.NewTable(os.Stdout)
-	t.SetHeader([]string{network.Name})
-
-	t.Append([]string{"ID", network.ID.String()})
-	t.Append([]string{"Name", network.Name})
-	t.Append([]string{"Description", network.DisplayText})
-	t.Append([]string{"Zone", network.ZoneName})
-	t.Append([]string{"DHCP IP Range", dhcp})
-
-	if len(vms) == 0 {
-		t.Append([]string{"Instances", "n/a"})
-		t.Render()
-		return nil
-	}
-
-	if len(vms) > 0 {
-		buf := bytes.NewBuffer(nil)
-		it := table.NewEmbeddedTable(buf)
-		it.SetHeader([]string{" "})
-		for _, vm := range vms {
-			it.Append([]string{vm.Name, vm.ID.String()})
-		}
-		it.Render()
-		t.Append([]string{"Instances", buf.String()})
-	}
-
-	t.Render()
-
-	return nil
+	return &out, nil
 }
 
 func privnetDetails(network *egoscale.Network) ([]egoscale.VirtualMachine, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,6 +65,11 @@ var versionCmd = &cobra.Command{
 	},
 }
 
+var (
+	gOutputFormat   string
+	gOutputTemplate string
+)
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the RootCmd.
 func Execute(version, commit string) {
@@ -98,6 +103,8 @@ func Execute(version, commit string) {
 func init() {
 	RootCmd.PersistentFlags().StringVarP(&gConfigFilePath, "config", "C", "", "Specify an alternate config file [env EXOSCALE_CONFIG]")
 	RootCmd.PersistentFlags().StringVarP(&gAccountName, "use-account", "A", "", "Account to use in config file [env EXOSCALE_ACCOUNT]")
+	RootCmd.PersistentFlags().StringVarP(&gOutputFormat, "output-format", "O", "", "Output format, can be table|json|text")
+	RootCmd.PersistentFlags().StringVar(&gOutputTemplate, "output-template", "", "Template to use if output format is \"template\"")
 	RootCmd.AddCommand(versionCmd)
 
 	cobra.OnInitialize(initConfig, buildClient)
@@ -236,6 +243,12 @@ func initConfig() {
 
 	if config.DefaultAccount == "" && gAccountName == "" {
 		log.Fatalf("default account not defined")
+	}
+
+	if gOutputFormat == "" {
+		if gOutputFormat = config.DefaultOutputFormat; gOutputFormat == "" {
+			gOutputFormat = defaultOutputFormat
+		}
 	}
 
 	if gAccountName == "" {

--- a/cmd/runstatus.go
+++ b/cmd/runstatus.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +18,24 @@ knowing that when something does go wrong you can keep everyone informed using R
 
 func init() {
 	RootCmd.AddCommand(runstatusCmd)
+}
+
+func getRunstatusPages(names []string) ([]egoscale.RunstatusPage, error) {
+	if len(names) == 0 {
+		return csRunstatus.ListRunstatusPages(gContext)
+	}
+
+	pages := []egoscale.RunstatusPage{}
+	for _, name := range names {
+		page, err := csRunstatus.GetRunstatusPage(gContext, egoscale.RunstatusPage{Subdomain: name})
+		if err != nil {
+			return nil, err
+		}
+
+		pages = append(pages, *page)
+	}
+
+	return pages, nil
 }
 
 func formatSchedule(start, end *time.Time) string {

--- a/cmd/runstatus_incident_show.go
+++ b/cmd/runstatus_incident_show.go
@@ -5,16 +5,72 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/exoscale/cli/table"
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
 )
 
+type runstatusIncidentEventShowOutput struct {
+	Date   *time.Time `json:"date"`
+	Status string     `json:"status"`
+	Text   string     `json:"text"`
+}
+
+type runstatusIncidentShowOutput struct {
+	ID               int                                `json:"id"`
+	Title            string                             `json:"title"`
+	StartDate        *time.Time                         `json:"start_date"`
+	EndDate          *time.Time                         `json:"end_date"`
+	State            string                             `json:"state"`
+	Status           string                             `json:"status"`
+	AffectedServices []string                           `json:"affected_services,omitempty"`
+	Events           []runstatusIncidentEventShowOutput `json:"events,omitempty"`
+}
+
+func (o *runstatusIncidentShowOutput) toJSON() { outputJSON(o) }
+
+func (o *runstatusIncidentShowOutput) toText() { outputText(o) }
+
+func (o *runstatusIncidentShowOutput) toTable() {
+	t := table.NewTable(os.Stdout)
+	t.SetHeader([]string{"Incident"})
+
+	t.Append([]string{"ID", fmt.Sprint(o.ID)})
+	t.Append([]string{"Title", o.Title})
+	t.Append([]string{"State", o.State})
+	t.Append([]string{"Status", o.Status})
+	t.Append([]string{"Start Date", fmt.Sprint(o.StartDate)})
+
+	if o.EndDate != nil {
+		t.Append([]string{"End Date", fmt.Sprint(o.EndDate)})
+	}
+
+	t.Append([]string{"Affected Services", strings.Join(o.AffectedServices, "\n")})
+
+	if len(o.Events) > 0 {
+		buf := bytes.NewBuffer(nil)
+		et := table.NewEmbeddedTable(buf)
+		et.SetHeader([]string{" "})
+		for _, e := range o.Events {
+			et.Append([]string{fmt.Sprint(e.Date), e.Status, e.Text})
+		}
+		et.Render()
+		t.Append([]string{"Event Stream", buf.String()})
+	}
+
+	t.Render()
+}
+
 func init() {
 	runstatusIncidentCmd.AddCommand(&cobra.Command{
-		Use:     "show [page name] <incident name | id>",
-		Short:   "Show an incident details",
+		Use:   "show [page name] <incident name | id>",
+		Short: "Show an incident details",
+		Long: fmt.Sprintf(`This command shows a runstat.us incident details.
+
+Supported output template annotations: %s`,
+			strings.Join(outputterTemplateAnnotations(&runstatusIncidentShowOutput{}), ", ")),
 		Aliases: gShowAlias,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
@@ -25,11 +81,9 @@ func init() {
 			incident := args[0]
 
 			if gCurrentAccount.DefaultRunstatusPage == "" && len(args) == 1 {
-				fmt.Fprintf(os.Stderr, `Error: No default runstat.us page is set:
-  Please specify a page in parameter or add it to %q
-
-  `, gConfigFilePath)
-				return cmd.Usage()
+				return fmt.Errorf("No default runstat.us page is set.\n"+
+					"Please specify a page in parameter or add it to your configuration file %s",
+					gConfigFilePath)
 			}
 
 			if len(args) > 1 {
@@ -37,49 +91,41 @@ func init() {
 				incident = args[1]
 			}
 
-			return showRunstatusIncident(page, incident)
+			return output(showRunstatusIncident(page, incident))
 		},
 	})
 }
 
-func showRunstatusIncident(p, i string) error {
+func showRunstatusIncident(p, i string) (outputter, error) {
 	page, err := csRunstatus.GetRunstatusPage(gContext, egoscale.RunstatusPage{Subdomain: p})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	incident, err := getIncidentByNameOrID(*page, i)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	t := table.NewTable(os.Stdout)
-	t.SetHeader([]string{page.Subdomain})
-
-	t.Append([]string{"ID", fmt.Sprint(incident.ID)})
-	t.Append([]string{"Title", incident.Title})
-	t.Append([]string{"State", incident.State})
-	t.Append([]string{"Status", incident.Status})
-	t.Append([]string{"Start Date", fmt.Sprint(incident.StartDate)})
-
-	if incident.EndDate != nil {
-		t.Append([]string{"End Date", fmt.Sprint(incident.EndDate)})
+	out := runstatusIncidentShowOutput{
+		ID:               incident.ID,
+		Title:            incident.Title,
+		StartDate:        incident.StartDate,
+		EndDate:          incident.EndDate,
+		State:            incident.State,
+		Status:           incident.Status,
+		AffectedServices: incident.Services,
 	}
 
-	t.Append([]string{"Affected Services", strings.Join(incident.Services, "\n")})
-
-	if len(incident.Events) > 0 {
-		buf := bytes.NewBuffer(nil)
-		et := table.NewEmbeddedTable(buf)
-		et.SetHeader([]string{" "})
-		for _, e := range incident.Events {
-			et.Append([]string{fmt.Sprint(e.Created), e.Status, e.Text})
+	if n := len(incident.Events); n > 0 {
+		out.Events = make([]runstatusIncidentEventShowOutput, n)
+		for i, e := range incident.Events {
+			out.Events[i] = runstatusIncidentEventShowOutput{
+				Date:   e.Created,
+				Status: e.Status,
+				Text:   e.Text}
 		}
-		et.Render()
-		t.Append([]string{"Event Stream", buf.String()})
 	}
 
-	t.Render()
-
-	return nil
+	return &out, nil
 }

--- a/cmd/runstatus_maintenance_list.go
+++ b/cmd/runstatus_maintenance_list.go
@@ -1,50 +1,68 @@
 package cmd
 
 import (
-	"os"
-	"strconv"
+	"fmt"
+	"strings"
+	"time"
 
-	"github.com/exoscale/cli/table"
 	"github.com/spf13/cobra"
 )
 
-// listCmd represents the list command
-var runstatusMaintenanceListCmd = &cobra.Command{
-	Use:     "list [page name]+",
-	Short:   "List maintenance from page(s)",
-	Aliases: gListAlias,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		pages, err := runstatusAllPages(args)
-		if err != nil {
-			return err
-		}
-
-		table := table.NewTable(os.Stdout)
-		table.SetHeader([]string{"Page Name", "Title", "Status", "When", "ID"})
-
-		for _, page := range pages {
-			maintenances, err := csRunstatus.ListRunstatusMaintenances(gContext, page)
-			if err != nil {
-				return err
-			}
-
-			for _, maintenance := range maintenances {
-				table.Append([]string{
-					page.Subdomain,
-					maintenance.Title,
-					maintenance.Status,
-					formatSchedule(maintenance.StartDate, maintenance.EndDate),
-					strconv.Itoa(maintenance.ID),
-				})
-				page.Subdomain = ""
-			}
-		}
-		table.Render()
-
-		return nil
-	},
+type runstatusMaintenanceListItemOutput struct {
+	ID        int        `json:"id"`
+	Page      string     `json:"page"`
+	Title     string     `json:"title"`
+	Status    string     `json:"status"`
+	StartDate *time.Time `json:"start_date"`
+	EndDate   *time.Time `json:"end_date"`
 }
 
+type runstatusMaintenanceListOutput []runstatusMaintenanceListItemOutput
+
+func (o *runstatusMaintenanceListOutput) toJSON()  { outputJSON(o) }
+func (o *runstatusMaintenanceListOutput) toText()  { outputText(o) }
+func (o *runstatusMaintenanceListOutput) toTable() { outputTable(o) }
+
 func init() {
-	runstatusMaintenanceCmd.AddCommand(runstatusMaintenanceListCmd)
+	runstatusMaintenanceCmd.AddCommand(&cobra.Command{
+		Use:   "list [page name ...]",
+		Short: "List maintenance from page(s)",
+		Long: fmt.Sprintf(`This command lists existing runstat.us maintenances.
+
+Supported output template annotations: %s`,
+			strings.Join(outputterTemplateAnnotations(&runstatusMaintenanceListOutput{}), ", ")),
+		Aliases: gListAlias,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output(runstatusListMaintenances(args))
+		},
+	})
+}
+
+func runstatusListMaintenances(pageNames []string) (outputter, error) {
+	pages, err := getRunstatusPages(pageNames)
+	if err != nil {
+		return nil, err
+	}
+
+	out := runstatusMaintenanceListOutput{}
+
+	for _, page := range pages {
+		maintenances, err := csRunstatus.ListRunstatusMaintenances(gContext, page)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, maintenance := range maintenances {
+			out = append(out, runstatusMaintenanceListItemOutput{
+				ID:        maintenance.ID,
+				Title:     maintenance.Title,
+				StartDate: maintenance.StartDate,
+				EndDate:   maintenance.EndDate,
+				Status:    maintenance.Status,
+				Page:      page.Subdomain,
+			})
+		}
+	}
+
+	return &out, nil
 }

--- a/cmd/runstatus_service.go
+++ b/cmd/runstatus_service.go
@@ -10,7 +10,7 @@ import (
 // runstatusServiceCmd represents the service command
 var runstatusServiceCmd = &cobra.Command{
 	Use:   "service",
-	Short: "Service management",
+	Short: "Runstat.us service management",
 }
 
 func getServiceByName(page egoscale.RunstatusPage, name string) (*egoscale.RunstatusService, error) {

--- a/cmd/runstatus_service_list.go
+++ b/cmd/runstatus_service_list.go
@@ -1,44 +1,71 @@
 package cmd
 
 import (
-	"os"
+	"fmt"
+	"strings"
 
-	"github.com/exoscale/cli/table"
 	"github.com/spf13/cobra"
 )
 
-// runstatusServiceListCmd represents the list command
-var runstatusServiceListCmd = &cobra.Command{
-	Use:     "list [page name]+",
-	Short:   "List services",
-	Aliases: gListAlias,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		pages, err := runstatusAllPages(args)
-		if err != nil {
-			return err
-		}
+type runstatusServiceListItemOutput struct {
+	ID      int    `page:"id" output:"-"`
+	Service string `json:"service"`
+	State   string `json:"state"`
+	Page    string `page:"page"`
+}
 
-		table := table.NewTable(os.Stdout)
-		table.SetHeader([]string{"Page Name", "Name", "State"})
+type runstatusServiceListOutput []runstatusServiceListItemOutput
 
-		for _, page := range pages {
-			services, err := csRunstatus.ListRunstatusServices(gContext, page)
-			if err != nil {
-				return err
-			}
+func (o *runstatusServiceListOutput) toJSON() { outputJSON(o) }
 
-			for _, service := range services {
-				table.Append([]string{page.Subdomain, service.Name, service.State})
-				page.Subdomain = ""
-			}
-		}
+func (o *runstatusServiceListOutput) toText() { outputText(o) }
 
-		table.Render()
+func (o *runstatusServiceListOutput) toTable() {
+	for i := range *o {
+		(*o)[i].State = strings.ToUpper(strings.Replace((*o)[i].State, "_", " ", -1))
+	}
 
-		return nil
-	},
+	outputTable(o)
 }
 
 func init() {
-	runstatusServiceCmd.AddCommand(runstatusServiceListCmd)
+	runstatusServiceCmd.AddCommand(&cobra.Command{
+		Use:   "list [page name ...]",
+		Short: "List services",
+		Long: fmt.Sprintf(`This command lists existing runstat.us services.
+
+Supported output template annotations: %s`,
+			strings.Join(outputterTemplateAnnotations(&runstatusServiceListOutput{}), ", ")),
+		Aliases: gListAlias,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output(runstatusListServices(args))
+		},
+	})
+}
+
+func runstatusListServices(pageNames []string) (outputter, error) {
+	pages, err := getRunstatusPages(pageNames)
+	if err != nil {
+		return nil, err
+	}
+
+	out := runstatusServiceListOutput{}
+
+	for _, page := range pages {
+		services, err := csRunstatus.ListRunstatusServices(gContext, page)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, service := range services {
+			out = append(out, runstatusServiceListItemOutput{
+				ID:      service.ID,
+				Service: service.Name,
+				State:   service.State,
+				Page:    page.Subdomain,
+			})
+		}
+	}
+
+	return &out, nil
 }

--- a/cmd/runstatus_show.go
+++ b/cmd/runstatus_show.go
@@ -3,66 +3,99 @@ package cmd
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/exoscale/cli/table"
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	runstatusCmd.AddCommand(&cobra.Command{
-		Use:     "show <page name>",
-		Short:   "Show a runstat.us page details",
-		Aliases: gShowAlias,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return errors.New("show expects one page name or id")
-			}
-			return showRunstatusPage(args[0])
-		},
-	})
+type runstatusPageIncidentShowOutput struct {
+	Title     string     `json:"title"`
+	State     string     `json:"state"`
+	Status    string     `json:"status"`
+	StartDate *time.Time `json:"start_date"`
+	EndDate   *time.Time `json:"end_date"`
 }
 
-func showRunstatusPage(name string) error {
-	page, err := csRunstatus.GetRunstatusPage(gContext, egoscale.RunstatusPage{Subdomain: name})
-	if err != nil {
-		return err
+type runstatusPageMaintenanceShowOutput struct {
+	Title     string     `json:"title"`
+	Status    string     `json:"status"`
+	StartDate *time.Time `json:"start_date"`
+	EndDate   *time.Time `json:"end_date"`
+}
+
+type runstatusPageShowOutput struct {
+	ID           int                                  `json:"id"`
+	Name         string                               `json:"name"`
+	URL          string                               `json:"page_url"`
+	Timezone     string                               `json:"timezone"`
+	State        string                               `json:"state"`
+	CustomDomain string                               `json:"custom_domain,omitempty"`
+	Title        string                               `json:"title,omitempty"`
+	SupportEmail string                               `json:"support_email,omitempty"`
+	Services     map[string]string                    `json:"services,omitempty"`
+	Incidents    []runstatusPageIncidentShowOutput    `json:"incidents,omitempty"`
+	Maintenances []runstatusPageMaintenanceShowOutput `json:"maintenances,omitempty"`
+}
+
+func (o *runstatusPageShowOutput) toJSON() { outputJSON(o) }
+
+func (o *runstatusPageShowOutput) toText() { outputText(o) }
+
+func (o *runstatusPageShowOutput) toTable() {
+	t := table.NewTable(os.Stdout)
+	t.SetHeader([]string{"Runstatus"})
+
+	t.Append([]string{"ID", fmt.Sprint(o.ID)})
+	t.Append([]string{"Name", o.Name})
+	if o.Title != "" {
+		t.Append([]string{"Title", o.Title})
+	}
+	t.Append([]string{"Page URL", o.URL})
+	if o.CustomDomain != "" {
+		t.Append([]string{"Custom Domain", o.CustomDomain})
 	}
 
-	t := table.NewTable(os.Stdout)
-	t.SetHeader([]string{page.Subdomain})
+	t.Append([]string{"Timezone", o.Timezone})
+	t.Append([]string{"State", strings.ToUpper(strings.Replace(o.State, "_", " ", -1))})
 
-	t.Append([]string{"Name", page.Subdomain})
-	t.Append([]string{"URL", page.PublicURL})
-	t.Append([]string{"Email", page.SupportEmail})
-	t.Append([]string{"State", page.State})
+	if o.SupportEmail != "" {
+		t.Append([]string{"Email", o.SupportEmail})
+	}
 
-	if len(page.Services) > 0 {
+	if o.Services != nil {
 		buf := bytes.NewBuffer(nil)
 		st := table.NewEmbeddedTable(buf)
 		st.SetHeader([]string{" "})
-		for _, svc := range page.Services {
-			st.Append([]string{svc.Name, svc.State})
+		for name, state := range o.Services {
+			st.Append([]string{name, strings.ToUpper(strings.Replace(state, "_", " ", -1))})
 		}
 		st.Render()
 		t.Append([]string{"Services", buf.String()})
 	}
 
-	if len(page.Incidents) > 0 {
+	if o.Incidents != nil {
 		buf := bytes.NewBuffer(nil)
 		it := table.NewEmbeddedTable(buf)
-		for _, i := range page.Incidents {
-			it.Append([]string{i.Title, i.State, i.Status, formatSchedule(i.StartDate, i.EndDate)})
+		for _, i := range o.Incidents {
+			it.Append([]string{i.Title,
+				strings.ToUpper(strings.Replace(i.State, "_", " ", -1)),
+				i.Status,
+				formatSchedule(i.StartDate, i.EndDate),
+			})
 		}
 		it.Render()
 		t.Append([]string{"Incidents", buf.String()})
 	}
 
-	if len(page.Maintenances) > 0 {
+	if o.Maintenances != nil {
 		buf := bytes.NewBuffer(nil)
 		mt := table.NewEmbeddedTable(buf)
-		for _, m := range page.Maintenances {
+		for _, m := range o.Maintenances {
 			mt.Append([]string{m.Title, m.Status, formatSchedule(m.StartDate, m.EndDate)})
 		}
 		mt.Render()
@@ -70,6 +103,75 @@ func showRunstatusPage(name string) error {
 	}
 
 	t.Render()
+}
 
-	return nil
+func init() {
+	runstatusCmd.AddCommand(&cobra.Command{
+		Use:   "show <page name>",
+		Short: "Show a runstat.us page details",
+		Long: fmt.Sprintf(`This command shows a runstat.us page details.
+
+Supported output template annotations: %s`,
+			strings.Join(outputterTemplateAnnotations(&runstatusPageShowOutput{}), ", ")),
+		Aliases: gShowAlias,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("show expects a page name")
+			}
+
+			return output(showRunstatusPage(args[0]))
+		},
+	})
+}
+
+func showRunstatusPage(name string) (outputter, error) {
+	page, err := csRunstatus.GetRunstatusPage(gContext, egoscale.RunstatusPage{Subdomain: name})
+	if err != nil {
+		return nil, err
+	}
+
+	out := runstatusPageShowOutput{
+		ID:           page.ID,
+		Name:         page.Subdomain,
+		URL:          page.PublicURL,
+		Timezone:     page.TimeZone,
+		State:        page.State,
+		Title:        page.Title,
+		CustomDomain: page.Domain,
+		SupportEmail: page.SupportEmail,
+	}
+
+	if len(page.Services) > 0 {
+		out.Services = make(map[string]string)
+		for _, service := range page.Services {
+			out.Services[service.Name] = service.State
+		}
+	}
+
+	if n := len(page.Incidents); n > 0 {
+		out.Incidents = make([]runstatusPageIncidentShowOutput, n)
+		for i, incident := range page.Incidents {
+			out.Incidents[i] = runstatusPageIncidentShowOutput{
+				Title:     incident.Title,
+				State:     incident.State,
+				Status:    incident.Status,
+				StartDate: incident.StartDate,
+				EndDate:   incident.EndDate,
+			}
+		}
+	}
+
+	if n := len(page.Maintenances); n > 0 {
+		out.Maintenances = make([]runstatusPageMaintenanceShowOutput, n)
+		for i, maintenance := range page.Maintenances {
+			out.Maintenances[i] = runstatusPageMaintenanceShowOutput{
+				Title:     maintenance.Title,
+				Status:    maintenance.Status,
+				StartDate: maintenance.StartDate,
+				EndDate:   maintenance.EndDate,
+			}
+		}
+	}
+
+	return &out, nil
 }

--- a/cmd/snapshot_list.go
+++ b/cmd/snapshot_list.go
@@ -2,94 +2,104 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/exoscale/egoscale"
 
-	"github.com/exoscale/cli/table"
 	"github.com/spf13/cobra"
 )
 
-// listCmd represents the list command
-var snapshotListCmd = &cobra.Command{
-	Use:     "list [vm name | vm id]+",
-	Short:   "List snapshot",
-	Aliases: gListAlias,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		table := table.NewTable(os.Stdout)
-
-		if len(args) == 0 {
-			table.SetHeader([]string{"VM", "State", "Created On", "Size", "ID"})
-			res, err := cs.ListWithContext(gContext, egoscale.Snapshot{})
-			if err != nil {
-				return err
-			}
-
-			var vmNameTmp string
-			for _, s := range res {
-				snapshot := s.(*egoscale.Snapshot)
-				vmName := snapshotVMName(*snapshot)
-				if vmName == vmNameTmp {
-					vmName = ""
-				}
-				table.Append([]string{vmName, snapshot.State, snapshot.Created, fmt.Sprintf("%v", humanize.IBytes(uint64(snapshot.Size))), snapshot.ID.String()})
-				if vmName != "" {
-					vmNameTmp = vmName
-				}
-			}
-
-			table.Render()
-
-			return nil
-		}
-
-		table.SetHeader([]string{"VM", "State", "Created On", "Size", "ID"})
-
-		for _, arg := range args {
-			vm, err := getVirtualMachineByNameOrID(arg)
-			if err != nil {
-				return err
-			}
-
-			volume := &egoscale.Volume{
-				VirtualMachineID: vm.ID,
-				Type:             "ROOT",
-			}
-
-			resp, err := cs.GetWithContext(gContext, volume)
-			if err != nil {
-				return err
-			}
-
-			snapshots, err := cs.ListWithContext(gContext, egoscale.Snapshot{
-				VolumeID: resp.(*egoscale.Volume).ID,
-			})
-
-			if err != nil {
-				return err
-			}
-
-			for _, s := range snapshots {
-				snapshot := s.(*egoscale.Snapshot)
-
-				table.Append([]string{vm.Name, snapshot.State, snapshot.Created, fmt.Sprintf("%v", humanize.IBytes(uint64(snapshot.Size))), snapshot.ID.String()})
-				vm.Name = ""
-			}
-		}
-
-		table.Render()
-
-		return nil
-	},
+type snapshotListItemOutput struct {
+	ID       string `json:"id"`
+	Date     string `json:"date"`
+	Instance string `json:"instance"`
+	State    string `json:"state"`
+	Size     string `json:"size"`
 }
+
+type snapshotListOutput []snapshotListItemOutput
+
+func (o *snapshotListOutput) toJSON()  { outputJSON(o) }
+func (o *snapshotListOutput) toText()  { outputText(o) }
+func (o *snapshotListOutput) toTable() { outputTable(o) }
 
 func init() {
-	snapshotCmd.AddCommand(snapshotListCmd)
+	snapshotCmd.AddCommand(&cobra.Command{
+		Use:   "list [vm name | vm id]+",
+		Short: "List snapshot",
+		Long: fmt.Sprintf(`This command lists existing Compute instance disk snapshots.
+
+Supported output template annotations: %s`,
+			strings.Join(outputterTemplateAnnotations(&snapshotListOutput{}), ", ")),
+		Aliases: gListAlias,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output(listSnapshots(args))
+		},
+	})
 }
 
-// snapshotVMName returns the instance name based on the snapshot name
+func listSnapshots(instances []string) (outputter, error) {
+	out := snapshotListOutput{}
+
+	if len(instances) == 0 {
+		snapshots, err := cs.ListWithContext(gContext, egoscale.Snapshot{})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, s := range snapshots {
+			snapshot := s.(*egoscale.Snapshot)
+			instance := snapshotVMName(*snapshot)
+
+			out = append(out, snapshotListItemOutput{
+				ID:       snapshot.ID.String(),
+				Instance: instance,
+				Date:     snapshot.Created,
+				State:    snapshot.State,
+				Size:     humanize.IBytes(uint64(snapshot.Size)),
+			})
+		}
+
+		return &out, nil
+	}
+
+	for _, i := range instances {
+		instance, err := getVirtualMachineByNameOrID(i)
+		if err != nil {
+			return nil, err
+		}
+
+		volume, err := cs.GetWithContext(gContext, &egoscale.Volume{
+			VirtualMachineID: instance.ID,
+			Type:             "ROOT",
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		snapshots, err := cs.ListWithContext(gContext, egoscale.Snapshot{VolumeID: volume.(*egoscale.Volume).ID})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, s := range snapshots {
+			snapshot := s.(*egoscale.Snapshot)
+
+			out = append(out, snapshotListItemOutput{
+				ID:       snapshot.ID.String(),
+				Instance: instance.Name,
+				Date:     snapshot.Created,
+				State:    snapshot.State,
+				Size:     humanize.IBytes(uint64(snapshot.Size)),
+			})
+		}
+	}
+
+	return &out, nil
+}
+
+// snapshotVMName returns the instance name based on the snapshot name.
 func snapshotVMName(snapshot egoscale.Snapshot) string {
 	names := strings.SplitN(snapshot.Name, "_"+snapshot.VolumeName+"_", 2)
 	return names[0]

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -27,7 +27,7 @@ var templateCmd = &cobra.Command{
 // Returns the template filter to use.
 func validateTemplateFilter(templateFilter string) (string, error) {
 	if templateFilter == "mine" {
-		return "self", nil
+		return "self", nil // nolint
 	}
 	if templateFilter != "self" && templateFilter != "community" && templateFilter != "featured" {
 		return "", fmt.Errorf("invalid template filter %s", templateFilter)

--- a/cmd/template_list.go
+++ b/cmd/template_list.go
@@ -1,120 +1,89 @@
 package cmd
 
 import (
-	"os"
-	"strconv"
+	"fmt"
 	"strings"
 
 	humanize "github.com/dustin/go-humanize"
-	"github.com/exoscale/egoscale"
-
-	"github.com/exoscale/cli/table"
 	"github.com/spf13/cobra"
 )
 
+type templateListItemOutput struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	CreationDate string `json:"creation_date"`
+	Zone         string `json:"zone"`
+	DiskSize     string `json:"disk_size"`
+}
+
+type templateListOutput []templateListItemOutput
+
+func (o *templateListOutput) toJSON()  { outputJSON(o) }
+func (o *templateListOutput) toText()  { outputText(o) }
+func (o *templateListOutput) toTable() { outputTable(o) }
+
 func init() {
 	templateListCmd.Flags().BoolP("community", "", false, "List community templates")
-	templateListCmd.Flags().BoolP("iso", "i", false, "List ISOs")
 	templateListCmd.Flags().BoolP("featured", "", false, "List featured templates")
 	templateListCmd.Flags().BoolP("mine", "", false, "List your templates")
 	templateCmd.AddCommand(templateListCmd)
 }
 
-// templateListCmd represents the list command
 var templateListCmd = &cobra.Command{
-	Use:     "list [keyword]",
-	Short:   "List all available templates. By default, list featured templates.",
+	Use:   "list [keyword]",
+	Short: "List all available templates",
+	Long: fmt.Sprintf(`This command lists available Compute Instance templates. By default, returns "featured" templates.
+
+Supported output template annotations: %s`,
+		strings.Join(outputterTemplateAnnotations(&templateListOutput{}), ", ")),
 	Aliases: gListAlias,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		t := table.NewTable(os.Stdout)
-
-		iso, err := cmd.Flags().GetBool("iso")
-		if err != nil {
-			return err
-		}
-		if iso {
-			return listISOs()
-		}
+		var templateFilter string
 
 		community, err := cmd.Flags().GetBool("community")
 		if err != nil {
 			return err
 		}
-		featured, err := cmd.Flags().GetBool("featured")
-		if err != nil {
-			return err
-		}
+
 		mine, err := cmd.Flags().GetBool("mine")
 		if err != nil {
 			return err
 		}
 
-		// by default, list featured templates
-		if !(community || featured || mine) {
-			featured = true
-		}
-		t.SetHeader([]string{"Operating System", "Disk", "Release Date", "ID", "Zone", "Category"})
-
 		if community {
-			err = listTemplates(t, "community", args)
-			if err != nil {
-				return err
-			}
+			templateFilter = "community"
+		} else if mine {
+			templateFilter = "self"
+		} else {
+			templateFilter = "featured"
 		}
-		if featured {
-			err = listTemplates(t, "featured", args)
-			if err != nil {
-				return err
-			}
-		}
-		if mine {
-			err = listTemplates(t, "self", args)
-			if err != nil {
-				return err
-			}
-		}
-		t.Render()
-		return nil
+
+		return output(listTemplates(templateFilter, args))
 	},
 }
 
-func listISOs() error {
-	t := table.NewTable(os.Stdout)
-	t.SetHeader([]string{"Name", "Size", "Zone", "ID"})
-
-	resp, err := cs.ListWithContext(gContext, &egoscale.ListISOs{})
-	if err != nil {
-		return err
-	}
-
-	for _, i := range resp {
-		iso := i.(*egoscale.ISO)
-		sz := humanize.IBytes(uint64(iso.Size))
-		t.Append([]string{iso.Name, sz, iso.ZoneName, iso.ID.String()})
-	}
-	t.Render()
-
-	return nil
-}
-
-func listTemplates(t *table.Table, templateFilter string, filters []string) error {
+func listTemplates(templateFilter string, filters []string) (outputter, error) {
 	zoneID, err := getZoneIDByName(gCurrentAccount.DefaultZone)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	templates, err := findTemplates(zoneID, templateFilter, filters...)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	out := templateListOutput{}
 
 	for _, template := range templates {
-		sz := strconv.FormatInt(template.Size>>30, 10)
-		if sz == "10" && strings.HasPrefix(template.Name, "Linux") {
-			sz = ""
-		}
-		t.Append([]string{template.Name, sz, template.Created, template.ID.String(), template.ZoneName, templateFilter})
+		out = append(out, templateListItemOutput{
+			ID:           template.ID.String(),
+			Name:         template.Name,
+			DiskSize:     humanize.IBytes(uint64(template.Size)),
+			CreationDate: template.Created,
+			Zone:         template.ZoneName,
+		})
 	}
 
-	return nil
+	return &out, nil
 }

--- a/cmd/vm.go
+++ b/cmd/vm.go
@@ -63,14 +63,6 @@ func getVirtualMachineByNameOrID(name string) (*egoscale.VirtualMachine, error) 
 	return vm, nil
 }
 
-func getSecurityGroup(vm *egoscale.VirtualMachine) []string {
-	sgs := []string{}
-	for _, sgN := range vm.SecurityGroup {
-		sgs = append(sgs, sgN.Name)
-	}
-	return sgs
-}
-
 func getKeyPairPath(vmID string) string {
 	return path.Join(gConfigFolder, "instances", vmID, "id_rsa")
 }

--- a/cmd/vm_firewall.go
+++ b/cmd/vm_firewall.go
@@ -153,9 +153,14 @@ func printVirtualMachineSecurityGroups(vm *egoscale.VirtualMachine) error {
 		return err
 	}
 
+	sgs := []string{}
+	for _, sgN := range vm.SecurityGroup {
+		sgs = append(sgs, sgN.Name)
+	}
+
 	table := table.NewTable(os.Stdout)
 	table.SetHeader([]string{vm.Name})
-	table.Append([]string{"Security Groups", strings.Join(getSecurityGroup(vm), " - ")})
+	table.Append([]string{"Security Groups", strings.Join(sgs, " - ")})
 	table.Render()
 
 	return nil


### PR DESCRIPTION
This change adds support for various output formatting methods, including:

* table (default)
* JSON
* free-form Go templates (a la `docker inspect`/`kubectl get`)

🚧 This is a prototype, implemented only on the `affinitygroup list`/`affinitygroup show` commands for now: if this implementation is validated, I'll apply it to all `list`/`show` commands. 

```console
# table (default)
$ ./exo -O table affinitygroup show ab-abcd-xyz1
┼──────────────┼───────────────────────────────────────────────────────┼
│ AB-ABCD-XYZ1 │                                                       │
┼──────────────┼───────────────────────────────────────────────────────┼
│ ID           │ b061b2c3-12eb-43e2-a066-389daa1cd525                  │
│ Name         │ ab-abcd-xyz1                                          │
│ Description  │ keep ab-abcd-xyz1 on different hyperv                 │
│ Instances    │                                                       │
│              │   ab-abcd006   1ffc2e78-a017-4bc8-be45-cc1700446c28   │
│              │   ab-abcd004   f2bd1007-35fd-427b-93b2-ebe41897064b   │
│              │   ab-abcd005   e3c51601-f7ee-4c10-bc77-ee24eac5412a   │
│              │                                                       │
┼──────────────┼───────────────────────────────────────────────────────┼

# JSON
$ ./exo -O json affinitygroup show ab-abcd-xyz1 | jq .
{
  "id": "b061b2c3-12eb-43e2-a066-389daa1cd525",
  "name": "ab-abcd-xyz1",
  "description": "keep ab-abcd-xyz1 on different hyperv",
  "instances": {
    "ab-abcd004": "f2bd1007-35fd-427b-93b2-ebe41897064b",
    "ab-abcd005": "e3c51601-f7ee-4c10-bc77-ee24eac5412a",
    "ab-abcd006": "1ffc2e78-a017-4bc8-be45-cc1700446c28"
  }
}

# template
$ ./exo -O text --output-template '{{.ID}}/{{.Name}}' affinitygroup show ab-abcd-xyz1
b061b2c3-12eb-43e2-a066-389daa1cd525/ab-abcd-xyz1
```

Implementation status:

- [x] affinitygroup list
- [x] affinitygroup show
- [x] config list
- [x] config show
- [x] dns list
- [x] dns show
- [x] eip list
- [x] eip show
- [x] firewall list
- [x] firewall show
- [x] kube list
- [x] privnet list
- [x] privnet show
- [x] runstatus incident list
- [x] runstatus incident show
- [x] runstatus list
- [x] runstatus maintenance list
- [x] runstatus maintenance show
- [x] runstatus service list
- [x] runstatus service show
- [x] runstatus show
- [x] snapshot list
- [x] sshkey list
- [x] template list
- [x] template show
- [x] vm list
- [x] vm show