### PR TITLE
Support template-filter in various commands

### DIFF
--- a/cmd/kube_create.go
+++ b/cmd/kube_create.go
@@ -28,6 +28,9 @@ const (
 
 	// kubeDefaultTemplate is the template to install Kubernetes on.
 	kubeDefaultTemplate = defaultTemplate
+
+	// kubeTemplateFilter is the template filter for the default template
+	kubeTemplateFilter = "featured"
 )
 
 // kubeCreateDebug represents a debug mode flag
@@ -249,7 +252,7 @@ var kubeCreateCmd = &cobra.Command{
 			return err
 		}
 
-		template, err := getTemplateByName(zone, kubeDefaultTemplate)
+		template, err := getTemplateByName(zone, kubeDefaultTemplate, kubeTemplateFilter)
 		if err != nil {
 			return err
 		}

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -12,6 +12,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	templateFilterHelp = "The template filter to use (mine,community,featured)"
+)
+
 // templateCmd represents the template command
 var templateCmd = &cobra.Command{
 	Use:   "template",
@@ -54,7 +58,7 @@ func getTemplateByName(zoneID *egoscale.UUID, name string, templateFilter string
 	if len(resp) == 1 {
 		return resp[0].(*egoscale.Template), nil
 	}
-	return nil, fmt.Errorf("more than one templates found for %q", name)
+	return nil, fmt.Errorf("multiple templates found for %q", name)
 }
 
 func findTemplates(zoneID *egoscale.UUID, templateFilter string, filters ...string) ([]egoscale.Template, error) {

--- a/cmd/template_show.go
+++ b/cmd/template_show.go
@@ -70,6 +70,6 @@ var templateShowCmd = &cobra.Command{
 
 func init() {
 	templateCmd.AddCommand(templateShowCmd)
-	templateShowCmd.Flags().StringP("template-filter", "", "featured", "The template filter to use (mine,community,featured)")
+	templateShowCmd.Flags().StringP("template-filter", "", "featured", templateFilterHelp)
 	templateShowCmd.Flags().StringP("zone", "z", "", zoneHelp)
 }

--- a/cmd/template_show.go
+++ b/cmd/template_show.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -9,48 +8,68 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	templateCmd.AddCommand(&cobra.Command{
-		Use:   "show <template name | id>",
-		Short: "Show a template details",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return errors.New("show expects one template by name or id")
-			}
-			return showTemplate(args[0])
-		},
-	})
+var templateShowCmd = &cobra.Command{
+	Use:   "show <template name | id>",
+	Short: "Show a template details",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return cmd.Usage()
+		}
+		name := args[0]
+
+		templateFilterCmd, err := cmd.Flags().GetString("template-filter")
+		if err != nil {
+			return err
+		}
+		templateFilter, err := validateTemplateFilter(templateFilterCmd)
+		if err != nil {
+			return err
+		}
+
+		zoneName, err := cmd.Flags().GetString("zone")
+		if err != nil {
+			return err
+		}
+
+		if zoneName == "" {
+			zoneName = gCurrentAccount.DefaultZone
+		}
+
+		zoneID, err := getZoneIDByName(zoneName)
+		if err != nil {
+			return err
+		}
+
+		template, err := getTemplateByName(zoneID, name, templateFilter)
+		if err != nil {
+			return err
+		}
+
+		username, usernameOk := template.Details["username"]
+
+		t := table.NewTable(os.Stdout)
+		t.SetHeader([]string{template.Name})
+
+		t.Append([]string{"ID", template.ID.String()})
+		t.Append([]string{"Name", template.Name})
+		t.Append([]string{"OS Type", template.OsTypeName})
+		t.Append([]string{"Created", template.Created})
+		t.Append([]string{"Size", fmt.Sprintf("%d", template.Size>>30)})
+
+		if usernameOk {
+			t.Append([]string{"Username", username})
+		}
+
+		t.Append([]string{"Password?", fmt.Sprintf("%t", template.PasswordEnabled)})
+
+		t.Render()
+
+		return nil
+	},
 }
 
-func showTemplate(name string) error {
-	zoneID, err := getZoneIDByName(gCurrentAccount.DefaultZone)
-	if err != nil {
-		return err
-	}
-
-	template, err := getTemplateByName(zoneID, name)
-	if err != nil {
-		return err
-	}
-
-	username, usernameOk := template.Details["username"]
-
-	t := table.NewTable(os.Stdout)
-	t.SetHeader([]string{template.Name})
-
-	t.Append([]string{"ID", template.ID.String()})
-	t.Append([]string{"Name", template.Name})
-	t.Append([]string{"OS Type", template.OsTypeName})
-	t.Append([]string{"Created", template.Created})
-	t.Append([]string{"Size", fmt.Sprintf("%d", template.Size>>30)})
-
-	if usernameOk {
-		t.Append([]string{"Username", username})
-	}
-
-	t.Append([]string{"Password?", fmt.Sprintf("%t", template.PasswordEnabled)})
-
-	t.Render()
-
-	return nil
+func init() {
+	templateCmd.AddCommand(templateShowCmd)
+	templateShowCmd.Flags().StringP("template-filter", "", "featured", "The template filter to use (mine,community,featured)")
+	templateShowCmd.Flags().StringP("zone", "z", "", zoneHelp)
 }

--- a/cmd/vm_create.go
+++ b/cmd/vm_create.go
@@ -331,7 +331,7 @@ func init() {
 	vmCreateCmd.Flags().StringP("cloud-init-file", "f", "", "Deploy instance with a cloud-init file")
 	vmCreateCmd.Flags().StringP("zone", "z", "", zoneHelp)
 	vmCreateCmd.Flags().StringP("template", "t", "", fmt.Sprintf("<template name | id> (default: %s)", defaultTemplate))
-	vmCreateCmd.Flags().StringP("template-filter", "", "featured", "The template filter to use (mine,community,featured)")
+	vmCreateCmd.Flags().StringP("template-filter", "", "featured", templateFilterHelp)
 	vmCreateCmd.Flags().Int64P("disk", "d", 50, "<disk size>")
 	vmCreateCmd.Flags().StringP("keypair", "k", "", "<ssh keys name>")
 	vmCreateCmd.Flags().StringP("security-group", "s", "", "<name | id, name | id, ...>")

--- a/cmd/vm_create.go
+++ b/cmd/vm_create.go
@@ -21,6 +21,14 @@ var vmCreateCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 
+		templateFilterCmd, err := cmd.Flags().GetString("template-filter")
+		if err != nil {
+			return err
+		}
+		templateFilter, err := validateTemplateFilter(templateFilterCmd)
+		if err != nil {
+			return err
+		}
 		userDataPath, err := cmd.Flags().GetString("cloud-init-file")
 		if err != nil {
 			return err
@@ -63,7 +71,7 @@ var vmCreateCmd = &cobra.Command{
 			return err
 		}
 
-		template, err := getTemplateByName(zone, templateName)
+		template, err := getTemplateByName(zone, templateName, templateFilter)
 		if err != nil {
 			return err
 		}
@@ -321,8 +329,9 @@ func createVM(deploys []egoscale.DeployVirtualMachine) ([]egoscale.VirtualMachin
 
 func init() {
 	vmCreateCmd.Flags().StringP("cloud-init-file", "f", "", "Deploy instance with a cloud-init file")
-	vmCreateCmd.Flags().StringP("zone", "z", "", "<zone name | id | keyword> (ch-dk-2|ch-gva-2|at-vie-1|de-fra-1)")
+	vmCreateCmd.Flags().StringP("zone", "z", "", zoneHelp)
 	vmCreateCmd.Flags().StringP("template", "t", "", fmt.Sprintf("<template name | id> (default: %s)", defaultTemplate))
+	vmCreateCmd.Flags().StringP("template-filter", "", "featured", "The template filter to use (mine,community,featured)")
 	vmCreateCmd.Flags().Int64P("disk", "d", 50, "<disk size>")
 	vmCreateCmd.Flags().StringP("keypair", "k", "", "<ssh keys name>")
 	vmCreateCmd.Flags().StringP("security-group", "s", "", "<name | id, name | id, ...>")

--- a/cmd/vm_reset.go
+++ b/cmd/vm_reset.go
@@ -163,6 +163,6 @@ func init() {
 	diskSizeVarP := new(int64PtrValue)
 	vmResetCmd.Flags().VarP(diskSizeVarP, "disk", "d", "New disk size after reset in GB")
 	vmResetCmd.Flags().StringP("template", "t", "", fmt.Sprintf("<template name | id> (default: %s)", defaultTemplate))
-	vmResetCmd.Flags().StringP("template-filter", "", "featured", "The template filter to use (mine,community,featured)")
+	vmResetCmd.Flags().StringP("template-filter", "", "featured", templateFilterHelp)
 	vmResetCmd.Flags().BoolP("force", "f", false, "Attempt to reset vitual machine without prompting for confirmation")
 }

--- a/cmd/zone.go
+++ b/cmd/zone.go
@@ -8,6 +8,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	zoneHelp = "<zone name | id | keyword> (ch-dk-2|ch-gva-2|at-vie-1|de-fra-1|bg-sof-1)"
+)
+
 // zoneCmd represents the zone command
 var zoneCmd = &cobra.Command{
 	Use:   "zone",

--- a/cmd/zone.go
+++ b/cmd/zone.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	zoneHelp = "<zone name | id | keyword> (ch-dk-2|ch-gva-2|at-vie-1|de-fra-1|bg-sof-1)"
+	zoneHelp = "<zone name | id> (ch-dk-2|ch-gva-2|at-vie-1|de-fra-1|bg-sof-1)"
 )
 
 // zoneCmd represents the zone command

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/exoscale/egoscale v0.17.2
 	github.com/fatih/camelcase v1.0.0
 	github.com/go-ini/ini v1.42.0
+	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jtolds/gls v4.2.1+incompatible // indirect


### PR DESCRIPTION
## cmd/kube_create.go

- Add the template-filter option

## cmd/template.go

- Add a validateTemplateFilter function to validate the
  --template-filter parameter
- Rewrite getTemplateByName to support template-filter

## cmd/template_show.go

- Add the template-filter option
- Add a zone option (useful for custom templates)

## cmd/vm_create.go

- Add the template-filter option

## cmd/vm_reset.go

- Add the template-filter option