### PR TITLE
template: display zone in list/show commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 -----
 
 - Support template-filter in various commands
+- Display zone in `template (list|show)` commands
 
 1.3.0
 -----

--- a/cmd/template_list.go
+++ b/cmd/template_list.go
@@ -53,7 +53,7 @@ var templateListCmd = &cobra.Command{
 		if !(community || featured || mine) {
 			featured = true
 		}
-		t.SetHeader([]string{"Operating System", "Disk", "Release Date", "ID", "Category"})
+		t.SetHeader([]string{"Operating System", "Disk", "Release Date", "ID", "Zone", "Category"})
 
 		if community {
 			err = listTemplates(t, "community", args)
@@ -113,7 +113,7 @@ func listTemplates(t *table.Table, templateFilter string, filters []string) erro
 		if sz == "10" && strings.HasPrefix(template.Name, "Linux") {
 			sz = ""
 		}
-		t.Append([]string{template.Name, sz, template.Created, template.ID.String(), templateFilter})
+		t.Append([]string{template.Name, sz, template.Created, template.ID.String(), template.ZoneName, templateFilter})
 	}
 
 	return nil

--- a/cmd/template_show.go
+++ b/cmd/template_show.go
@@ -54,6 +54,7 @@ var templateShowCmd = &cobra.Command{
 		t.Append([]string{"Name", template.Name})
 		t.Append([]string{"OS Type", template.OsTypeName})
 		t.Append([]string{"Created", template.Created})
+		t.Append([]string{"Zone", template.ZoneName})
 		t.Append([]string{"Size", fmt.Sprintf("%d", template.Size>>30)})
 
 		if usernameOk {


### PR DESCRIPTION
This change adds the template zone to displayed information:

```console
$ ./exo vm template list --mine
┼──────────────────┼──────┼──────────────┼──────────────────────────────────────┼──────────┼──────────┼
│ OPERATING SYSTEM │ DISK │ RELEASE DATE │                  ID                  │   ZONE   │ CATEGORY │
┼──────────────────┼──────┼──────────────┼──────────────────────────────────────┼──────────┼──────────┼
│ mybuntu          │ 10   │ 2019-05-03   │ e08ca8e4-c778-4ec8-b163-16471dca895a │ ch-gva-2 │ self     │
┼──────────────────┼──────┼──────────────┼──────────────────────────────────────┼──────────┼──────────┼

$ ./exo vm template show e08ca8e4-c778-4ec8-b163-16471dca895a
┼───────────┼──────────────────────────────────────┼
│  MYBUNTU  │                                      │
┼───────────┼──────────────────────────────────────┼
│ ID        │ e08ca8e4-c778-4ec8-b163-16471dca895a │
│ Name      │ mybuntu                              │
│ OS Type   │ Other (64-bit)                       │
│ Created   │ 2019-05-03T16:38:14+0200             │
│ Zone      │ ch-gva-2                             │
│ Size      │ 10                                   │
│ Username  │ ubuntu                               │
│ Password? │ true                                 │
┼───────────┼──────────────────────────────────────┼
```