### PR TITLE
vm: require confirmation on stop/reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ UNRELEASED
 - Display zone in `template (list|show)` commands (#153)
 - Set a custom User-Agent (#154)
 - Fix SOS upload large file corruption bug (#137)
+- Require confirmation for `vm stop`/`vm reboot` commands (#155)
 - Update egoscale to 0.18.1
 
 1.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ UNRELEASED
 - Display zone in `template (list|show)` commands (#153)
 - Set a custom User-Agent (#154)
 - Fix SOS upload large file corruption bug (#137)
-- Require confirmation for `vm stop`/`vm reboot` commands (#155)
+- Require confirmation for `vm stop`/`vm reboot` commands (#156)
 - Update egoscale to 0.18.1
 
 1.3.0

--- a/cmd/vm_reboot.go
+++ b/cmd/vm_reboot.go
@@ -18,8 +18,19 @@ var vmRebootCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 
+		force, err := cmd.Flags().GetBool("force")
+		if err != nil {
+			return err
+		}
+
 		errs := []error{}
 		for _, v := range args {
+			if !force {
+				if !askQuestion(fmt.Sprintf("Are you sure you want to reboot virtual machine %q?", v)) {
+					return nil
+				}
+			}
+
 			if err := rebootVirtualMachine(v); err != nil {
 				errs = append(errs, fmt.Errorf("could not reboot %q: %s", v, err))
 			}
@@ -59,5 +70,6 @@ func rebootVirtualMachine(vmName string) error {
 }
 
 func init() {
+	vmRebootCmd.Flags().BoolP("force", "f", false, "Attempt to reboot vitual machine without prompting for confirmation")
 	vmCmd.AddCommand(vmRebootCmd)
 }

--- a/cmd/vm_reboot.go
+++ b/cmd/vm_reboot.go
@@ -70,6 +70,6 @@ func rebootVirtualMachine(vmName string) error {
 }
 
 func init() {
-	vmRebootCmd.Flags().BoolP("force", "f", false, "Attempt to reboot vitual machine without prompting for confirmation")
+	vmRebootCmd.Flags().BoolP("force", "f", false, "Attempt to reboot virtual machine without prompting for confirmation")
 	vmCmd.AddCommand(vmRebootCmd)
 }

--- a/cmd/vm_stop.go
+++ b/cmd/vm_stop.go
@@ -18,8 +18,19 @@ var vmStopCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 
+		force, err := cmd.Flags().GetBool("force")
+		if err != nil {
+			return err
+		}
+
 		errs := []error{}
 		for _, v := range args {
+			if !force {
+				if !askQuestion(fmt.Sprintf("Are you sure you want to stop virtual machine %q?", v)) {
+					return nil
+				}
+			}
+
 			if err := stopVirtualMachine(v); err != nil {
 				errs = append(errs, fmt.Errorf("could not stop %q: %s", v, err))
 			}
@@ -59,5 +70,6 @@ func stopVirtualMachine(vmName string) error {
 }
 
 func init() {
+	vmStopCmd.Flags().BoolP("force", "f", false, "Attempt to stop vitual machine without prompting for confirmation")
 	vmCmd.AddCommand(vmStopCmd)
 }

--- a/cmd/vm_stop.go
+++ b/cmd/vm_stop.go
@@ -70,6 +70,6 @@ func stopVirtualMachine(vmName string) error {
 }
 
 func init() {
-	vmStopCmd.Flags().BoolP("force", "f", false, "Attempt to stop vitual machine without prompting for confirmation")
+	vmStopCmd.Flags().BoolP("force", "f", false, "Attempt to stop virtual machine without prompting for confirmation")
 	vmCmd.AddCommand(vmStopCmd)
 }


### PR DESCRIPTION
This change adds a confirmation request on a `vm stop/reboot`
commands, as for the `delete` and `reset` commands.