### PR TITLE
Remove unused cmd/version.go file

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,4 +1,0 @@
-package cmd
-
-// Version represents the cli latest version
-const Version = "1.0.1"


### PR DESCRIPTION
Looks like this is not used anymore... `¯\_(ツ)_/¯`