### PR TITLE
sos: don't log upload activity by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 UNRELEASED
 ----------
 
-- sos: disable upload logging by default
+- sos: disable upload logging by default (#160)
 
 1.4.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+UNRELEASED
+----------
+
+- sos: disable upload logging by default
+
 1.4.0
 -----
 


### PR DESCRIPTION
This change disables SOS upload transfer logging activity, which now can
be enabled by passing the `--log|-l` flag.