### PR TITLE
vm template: fix bug in "list" command

### DIFF
--- a/cmd/template_list.go
+++ b/cmd/template_list.go
@@ -26,6 +26,7 @@ func init() {
 	templateListCmd.Flags().BoolP("community", "", false, "List community templates")
 	templateListCmd.Flags().BoolP("featured", "", false, "List featured templates")
 	templateListCmd.Flags().BoolP("mine", "", false, "List your templates")
+	templateListCmd.Flags().StringP("zone", "", "", "Name of the zone (default: current account's default zone)")
 	templateCmd.AddCommand(templateListCmd)
 }
 
@@ -39,6 +40,15 @@ Supported output template annotations: %s`,
 	Aliases: gListAlias,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var templateFilter string
+
+		zone, err := cmd.Flags().GetString("zone")
+		if err != nil {
+			return err
+		}
+
+		if zone == "" {
+			zone = gCurrentAccount.DefaultZone
+		}
 
 		community, err := cmd.Flags().GetBool("community")
 		if err != nil {
@@ -58,12 +68,12 @@ Supported output template annotations: %s`,
 			templateFilter = "featured"
 		}
 
-		return output(listTemplates(templateFilter, args))
+		return output(listTemplates(templateFilter, zone, args))
 	},
 }
 
-func listTemplates(templateFilter string, filters []string) (outputter, error) {
-	zoneID, err := getZoneIDByName(gCurrentAccount.DefaultZone)
+func listTemplates(templateFilter, zone string, filters []string) (outputter, error) {
+	zoneID, err := getZoneIDByName(zone)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change fixes a bug in the `vm template list` command where a user could not see private templates registered in a different zone that the default zone of the current account: the new `--zone` allows the user to specify the zone to list the templates from.