### PR TITLE
Add de-muc-1 to zones list. Servus!

### DIFF
--- a/cmd/zone.go
+++ b/cmd/zone.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	zoneHelp = "<zone name | id> (ch-dk-2|ch-gva-2|at-vie-1|de-fra-1|bg-sof-1)"
+	zoneHelp = "<zone name | id> (ch-dk-2|ch-gva-2|at-vie-1|de-fra-1|bg-sof-1|de-muc-1)"
 )
 
 // zoneCmd represents the zone command


### PR DESCRIPTION
This only affects the help text - "exo zones" listed de-muc-1 already.