### PR TITLE
firewall: check for CIDR or SG when adding a rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 - Require a CIDR or a Security Group when adding a Security Group rule
+- Require protocol to be specified if a port is provided when adding a Security Group rule
 
 1.4.1
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 UNRELEASED
 ----------
 
-- Require a CIDR or a Security Group when adding a Security Group rule
 - Require protocol to be specified if a port is provided when adding a Security Group rule
 
 1.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+UNRELEASED
+----------
+
+- Require a CIDR or a Security Group when adding a Security Group rule
+
 1.4.1
 -----
 

--- a/cmd/firewall_add.go
+++ b/cmd/firewall_add.go
@@ -119,6 +119,10 @@ A set of predefined commands exists, such a ssh, ping or minecraft.
 			return errors.New(`either one of "--cidr", "--my-ip" or "--security-group" must be specified`)
 		}
 
+		if port != "" && protocol == "" {
+			return errors.New(`"--port" can only be specified with "--protocol"`)
+		}
+
 		var ip *egoscale.CIDR
 		if isMyIP {
 			cidr, cirdErr := getMyCIDR(isIpv6)

--- a/cmd/firewall_add.go
+++ b/cmd/firewall_add.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -112,6 +113,10 @@ A set of predefined commands exists, such a ssh, ping or minecraft.
 		isMyIP, err := cmd.Flags().GetBool("my-ip")
 		if err != nil {
 			return err
+		}
+
+		if cidrList == "" && sg == "" && !isMyIP {
+			return errors.New(`either one of "--cidr", "--my-ip" or "--security-group" must be specified`)
 		}
 
 		var ip *egoscale.CIDR

--- a/cmd/firewall_add.go
+++ b/cmd/firewall_add.go
@@ -115,10 +115,6 @@ A set of predefined commands exists, such a ssh, ping or minecraft.
 			return err
 		}
 
-		if cidrList == "" && sg == "" && !isMyIP {
-			return errors.New(`either one of "--cidr", "--my-ip" or "--security-group" must be specified`)
-		}
-
 		if port != "" && protocol == "" {
 			return errors.New(`"--port" can only be specified with "--protocol"`)
 		}


### PR DESCRIPTION
This change requires a CIDR or a Security Group to be specified when
adding a rule.