### PR TITLE
lab kube: fix node instance upgrade stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ UNRELEASED
 
 - Require protocol to be specified if a port is provided when adding a Security Group rule
 - Fix `sos list` command panic if SOS returns bogus entries
+- Fix `lab kube create` node instance upgrade stage (#166)
 
 1.4.1
 -----

--- a/cmd/kube_create.go
+++ b/cmd/kube_create.go
@@ -59,6 +59,11 @@ var kubeBootstrapSteps = []kubeBootstrapStep{
 set -xe
 
 sudo -E DEBIAN_FRONTEND=noninteractive apt-get update
+
+while true; do
+	sudo lsof /var/lib/dpkg/lock-frontend > /dev/null && (echo "Waiting for apt/dpkg to finish..."; sleep 10) || break
+done
+
 sudo -E DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" upgrade -y
 sudo -E DEBIAN_FRONTEND=noninteractive apt-get install -y \
 	apt-transport-https \


### PR DESCRIPTION
This change fixes a race condition happening in the node instance upgrade stage of the `lab kube create` command, where the command would try to run `apt` related commands while a `unattended-upgrades` process was already running: we now wait until the lock on the `/var/lib/dpkg/lock-frontend` is removed before starting the upgrade procedure.

Fixes #166