### PR TITLE
vm: create: check for maximum user-data length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 - Require protocol to be specified if a port is provided when adding a Security Group rule
+- Require a user-data maximum length of 32Kb during instance creation (#168)
 - Fix `sos list` command panic if SOS returns bogus entries
 - Fix `lab kube create` node instance upgrade stage (#166)
 

--- a/cmd/vm_create.go
+++ b/cmd/vm_create.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const maxUserDataLength = 32768
+
 // vmCreateCmd represents the create command
 var vmCreateCmd = &cobra.Command{
 	Use:     "create <vm name>+",
@@ -40,6 +42,10 @@ var vmCreateCmd = &cobra.Command{
 			userData, err = getUserData(userDataPath)
 			if err != nil {
 				return err
+			}
+
+			if len(userData) >= maxUserDataLength {
+				return fmt.Errorf("user-data maximum allowed length is %d bytes", maxUserDataLength)
 			}
 		}
 


### PR DESCRIPTION
This change checks for maximum allowed user-data length before sending
the instance creation request:

```console
$ base64 -w0 userdata.txt | wc -c
32768

$ ./exo vm create test --cloud-init-file=userdata.txt
error: user-data maximum allowed length is 32768 bytes
```