### PR TITLE
affinitygroup: fix delete confirmation prompt bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ UNRELEASED
 - Require protocol to be specified if a port is provided when adding a Security Group rule
 - Fix `sos list` command panic if SOS returns bogus entries
 - Fix `lab kube create` node instance upgrade stage (#166)
+- Fix `affinitygroup delete` command confirmation prompt bug (#169)
 
 1.4.1
 -----

--- a/cmd/affinitygroup_delete.go
+++ b/cmd/affinitygroup_delete.go
@@ -29,17 +29,16 @@ var affinitygroupDeleteCmd = &cobra.Command{
 				return err
 			}
 
-			tasks = append(tasks, task{
-				cmd,
-				fmt.Sprintf("delete %q affinity group", cmd.Name),
-			})
-
 			if !force {
 				if !askQuestion(fmt.Sprintf("sure you want to delete %q affinity group", arg)) {
 					continue
 				}
 			}
 
+			tasks = append(tasks, task{
+				cmd,
+				fmt.Sprintf("delete %q affinity group", cmd.Name),
+			})
 		}
 
 		resps := asyncTasks(tasks)

--- a/cmd/affinitygroup_delete.go
+++ b/cmd/affinitygroup_delete.go
@@ -37,7 +37,7 @@ var affinitygroupDeleteCmd = &cobra.Command{
 
 			tasks = append(tasks, task{
 				cmd,
-				fmt.Sprintf("delete %q affinity group", cmd.Name),
+				fmt.Sprintf("deleting %q affinity group", cmd.Name),
 			})
 		}
 


### PR DESCRIPTION
This change fixes a bug in the `affinitygroup delete` command, where user confirmation prompt reply would not have no effect and items would be deleted anyway.