### PR TITLE
privnet delete: do not set the forced parameter

### DIFF
--- a/cmd/privnet_delete.go
+++ b/cmd/privnet_delete.go
@@ -24,7 +24,7 @@ var privnetDeleteCmd = &cobra.Command{
 
 		tasks := make([]task, 0, len(args))
 		for _, arg := range args {
-			cmd, err := deletePrivnet(arg, force)
+			cmd, err := deletePrivnet(arg)
 			if err != nil {
 				return err
 			}
@@ -50,7 +50,7 @@ var privnetDeleteCmd = &cobra.Command{
 	},
 }
 
-func deletePrivnet(name string, force bool) (*egoscale.DeleteNetwork, error) {
+func deletePrivnet(name string) (*egoscale.DeleteNetwork, error) {
 	addrReq := &egoscale.DeleteNetwork{}
 	var err error
 	network, err := getNetworkByName(name)
@@ -58,7 +58,6 @@ func deletePrivnet(name string, force bool) (*egoscale.DeleteNetwork, error) {
 		return nil, err
 	}
 	addrReq.ID = network.ID
-	addrReq.Forced = &force
 	return addrReq, nil
 }
 


### PR DESCRIPTION
The `forced` parameter should not be passed to the `deleteNetwork`
call.

```
$ exo privnet create aaaa
┼──────┼─────────────┼──────────────────────────────────────┼──────┼
│ NAME │ DESCRIPTION │                  ID                  │ DHCP │
┼──────┼─────────────┼──────────────────────────────────────┼──────┼
│ aaaa │             │ ec8c555b-cc3f-4639-8696-4a2f95970b0c │ n/a  │
┼──────┼─────────────┼──────────────────────────────────────┼──────┼
$ ./exo privnet delete --force aaaa
delete "ec8c555b-cc3f-4639-8696-4a2f95970b0c" privnet ⠙                         done!
$ exo privnet create aaaa
┼──────┼─────────────┼──────────────────────────────────────┼──────┼
│ NAME │ DESCRIPTION │                  ID                  │ DHCP │
┼──────┼─────────────┼──────────────────────────────────────┼──────┼
│ aaaa │             │ cf251f6c-6b6d-4479-a40e-20e1cc9fce5e │ n/a  │
┼──────┼─────────────┼──────────────────────────────────────┼──────┼
$ ./exo privnet delete aaaa
[+] sure you want to delete "aaaa" private network [yN]: y
delete "cf251f6c-6b6d-4479-a40e-20e1cc9fce5e" privnet ⠙                         done!
````