### PR TITLE
cmd: add quiet mode global flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 UNRELEASED
 ----------
 
+- Add "quiet" mode (#171)
 - Require protocol to be specified if a port is provided when adding a Security Group rule
 - Require a user-data maximum length of 32Kb during instance creation (#168)
 - Fix `sos list` command panic if SOS returns bogus entries

--- a/cmd/affinitygroup_create.go
+++ b/cmd/affinitygroup_create.go
@@ -35,10 +35,13 @@ func createAffinityGroup(name, desc string) error {
 
 	affinityGroup := resp.(*egoscale.AffinityGroup)
 
-	table := table.NewTable(os.Stdout)
-	table.SetHeader([]string{"Name", "Description", "ID"})
-	table.Append([]string{affinityGroup.Name, affinityGroup.Description, affinityGroup.ID.String()})
-	table.Render()
+	if !gQuiet {
+		table := table.NewTable(os.Stdout)
+		table.SetHeader([]string{"Name", "Description", "ID"})
+		table.Append([]string{affinityGroup.Name, affinityGroup.Description, affinityGroup.ID.String()})
+		table.Render()
+	}
+
 	return nil
 }
 

--- a/cmd/dns_create.go
+++ b/cmd/dns_create.go
@@ -21,7 +21,10 @@ var dnsCreateCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Printf("Domain %q was created successfully\n", resp.Name)
+		if !gQuiet {
+			fmt.Printf("Domain %q was created successfully\n", resp.Name)
+		}
+
 		return nil
 	},
 }

--- a/cmd/dns_delete.go
+++ b/cmd/dns_delete.go
@@ -31,7 +31,10 @@ var dnsDeleteCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Printf("Domain %q was deleted successfully\n", args[0])
+		if !gQuiet {
+			fmt.Printf("Domain %q was deleted successfully\n", args[0])
+		}
+
 		return nil
 	},
 }

--- a/cmd/dns_records_add.go
+++ b/cmd/dns_records_add.go
@@ -724,7 +724,11 @@ var dnsSRVCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Record %q was created successfully to %q\n", cmd.Name(), args[0])
+
+		if !gQuiet {
+			fmt.Printf("Record %q was created successfully to %q\n", cmd.Name(), args[0])
+		}
+
 		return nil
 	},
 }

--- a/cmd/dns_records_update.go
+++ b/cmd/dns_records_update.go
@@ -52,7 +52,11 @@ func init() {
 				if err != nil {
 					return err
 				}
-				fmt.Printf("Record %q was updated successfully to %q\n", cmd.Name(), args[0])
+
+				if !gQuiet {
+					fmt.Printf("Record %q was updated successfully to %q\n", cmd.Name(), args[0])
+				}
+
 				return nil
 			},
 		}

--- a/cmd/dns_remove.go
+++ b/cmd/dns_remove.go
@@ -27,11 +27,14 @@ var dnsRemoveCmd = &cobra.Command{
 			}
 		}
 
-		id, err := removeRecord(args[0], args[1])
-		if err != nil {
+		if _, err = removeRecord(args[0], args[1]); err != nil {
 			return err
 		}
-		fmt.Println(id)
+
+		if !gQuiet {
+			fmt.Printf("Record %q removed successfully from %q\n", args[1], args[0])
+		}
+
 		return nil
 	},
 }

--- a/cmd/eip_create.go
+++ b/cmd/eip_create.go
@@ -75,12 +75,13 @@ func associateIPAddress(associateIPAddress egoscale.AssociateIPAddress, zone str
 
 	ipResp := resp.(*egoscale.IPAddress)
 
-	table := table.NewTable(os.Stdout)
-	table.SetHeader([]string{"Zone", "IP", "ID"})
+	if !gQuiet {
+		table := table.NewTable(os.Stdout)
+		table.SetHeader([]string{"Zone", "IP", "ID"})
+		table.Append([]string{ipResp.ZoneName, ipResp.IPAddress.String(), ipResp.ID.String()})
+		table.Render()
+	}
 
-	table.Append([]string{ipResp.ZoneName, ipResp.IPAddress.String(), ipResp.ID.String()})
-
-	table.Render()
 	return nil
 }
 

--- a/cmd/eip_update.go
+++ b/cmd/eip_update.go
@@ -75,12 +75,13 @@ func updateIPAddress(associateIPAddress egoscale.UpdateIPAddress) error {
 
 	ip := resp.(*egoscale.IPAddress)
 
-	table := table.NewTable(os.Stdout)
-	table.SetHeader([]string{"Zone", "IP", "ID"})
+	if !gQuiet {
+		table := table.NewTable(os.Stdout)
+		table.SetHeader([]string{"Zone", "IP", "ID"})
+		table.Append([]string{ip.ZoneName, ip.IPAddress.String(), ip.ID.String()})
+		table.Render()
+	}
 
-	table.Append([]string{ip.ZoneName, ip.IPAddress.String(), ip.ID.String()})
-
-	table.Render()
 	return nil
 }
 

--- a/cmd/firewall_create.go
+++ b/cmd/firewall_create.go
@@ -36,25 +36,15 @@ var firewallCreateCmd = &cobra.Command{
 			return errors[0]
 		}
 
-		description := (desc != "")
-
-		table := table.NewTable(os.Stdout)
-		if !description {
-			table.SetHeader([]string{"Name", "ID"})
-		} else {
-			table.SetHeader([]string{"Name", "Description", "ID"})
-		}
-
-		for _, resp := range taskResponses {
-			r := resp.resp.(*egoscale.SecurityGroup)
-
-			if description {
-				table.Append([]string{r.Name, r.ID.String()})
-				continue
+		if !gQuiet {
+			table := table.NewTable(os.Stdout)
+			table.SetHeader([]string{"ID", "Name", "Description"})
+			for _, resp := range taskResponses {
+				r := resp.resp.(*egoscale.SecurityGroup)
+				table.Append([]string{r.ID.String(), r.Name, r.Description})
 			}
-			table.Append([]string{r.Name, r.Description, r.ID.String()})
+			table.Render()
 		}
-		table.Render()
 
 		return nil
 	},

--- a/cmd/kube_create.go
+++ b/cmd/kube_create.go
@@ -322,7 +322,8 @@ var kubeCreateCmd = &cobra.Command{
 			return fmt.Errorf("cluster bootstrap failed: %s", err)
 		}
 
-		fmt.Printf(`
+		if !gQuiet {
+			fmt.Printf(`
 Your Kubernetes cluster is ready. What do now?
 
 1. Install the "kubectl" command, if you don't have it already:
@@ -345,7 +346,8 @@ configuration (e.g. ~/.bashrc, ~/.zshrc).
 * restart it later using the "exo lab kube start" command
 * delete it permanently using the "exo lab kube delete" command
 `,
-			clusterName)
+				clusterName)
+		}
 
 		return nil
 	},

--- a/cmd/privnet_associate.go
+++ b/cmd/privnet_associate.go
@@ -33,6 +33,8 @@ var privnetAssociateCmd = &cobra.Command{
 		fmt.Fprintf(w, "Zone:\t%s\n", network.ZoneName)           // nolint: errcheck
 		fmt.Fprintf(w, "IP Range:\t%s\n", dhcp)                   // nolint: errcheck
 
+		// FIXME: this implementation mixes side effects with user reporting,
+		// this is not great and should be split.
 		table := table.NewTable(os.Stdout)
 		table.SetHeader([]string{"Virtual Machine", "IP Address"})
 		for i := 1; i < len(args); i++ {
@@ -61,7 +63,11 @@ var privnetAssociateCmd = &cobra.Command{
 				nicIP(*nic)})
 		}
 		w.Flush() // nolint: errcheck
-		table.Render()
+
+		if !gQuiet {
+			table.Render()
+		}
+
 		return nil
 	},
 }

--- a/cmd/privnet_update.go
+++ b/cmd/privnet_update.go
@@ -109,14 +109,17 @@ func privnetUpdate(id, name, desc string, startIP, endIP, netmask net.IP) (*egos
 }
 
 func privnetShow(network egoscale.Network) error {
-	table := table.NewTable(os.Stdout)
-	table.SetHeader([]string{"Name", "Description", "ID", "DHCP"})
-	table.Append([]string{
-		network.Name,
-		network.DisplayText,
-		network.ID.String(),
-		dhcpRange(network)})
-	table.Render()
+	if !gQuiet {
+		table := table.NewTable(os.Stdout)
+		table.SetHeader([]string{"Name", "Description", "ID", "DHCP"})
+		table.Append([]string{
+			network.Name,
+			network.DisplayText,
+			network.ID.String(),
+			dhcpRange(network)})
+		table.Render()
+	}
+
 	return nil
 }
 

--- a/cmd/request.go
+++ b/cmd/request.go
@@ -30,17 +30,28 @@ type taskResponse struct {
 }
 
 func asyncTasks(tasks []task) []taskResponse {
+	var (
+		progress *mpb.Progress
+		taskWG   sync.WaitGroup
+		workerWG sync.WaitGroup
+	)
+
 	//init results
 	responses := make([]taskResponse, len(tasks))
 
 	//create task Progress
 	taskBars := make([]*mpb.Bar, len(tasks))
 	maximum := 1 << 30
-	var taskWG sync.WaitGroup
-	progress := mpb.NewWithContext(gContext, mpb.WithWaitGroup(&taskWG))
+
+	if gQuiet {
+		progress = mpb.NewWithContext(gContext, mpb.WithWaitGroup(&taskWG), mpb.WithOutput(nil))
+	} else {
+		progress = mpb.NewWithContext(gContext, mpb.WithWaitGroup(&taskWG))
+
+	}
+
 	taskWG.Add(len(tasks))
 
-	var workerWG sync.WaitGroup
 	workerWG.Add(len(tasks))
 	workerSem := make(chan int, parallelTask)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,6 +68,8 @@ var versionCmd = &cobra.Command{
 var (
 	gOutputFormat   string
 	gOutputTemplate string
+
+	gQuiet bool
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -103,8 +105,9 @@ func Execute(version, commit string) {
 func init() {
 	RootCmd.PersistentFlags().StringVarP(&gConfigFilePath, "config", "C", "", "Specify an alternate config file [env EXOSCALE_CONFIG]")
 	RootCmd.PersistentFlags().StringVarP(&gAccountName, "use-account", "A", "", "Account to use in config file [env EXOSCALE_ACCOUNT]")
-	RootCmd.PersistentFlags().StringVarP(&gOutputFormat, "output-format", "O", "", "Output format, can be table|json|text")
+	RootCmd.PersistentFlags().StringVarP(&gOutputFormat, "output-format", "O", "", "Output format (table|json|text)")
 	RootCmd.PersistentFlags().StringVar(&gOutputTemplate, "output-template", "", "Template to use if output format is \"text\"")
+	RootCmd.PersistentFlags().BoolVarP(&gQuiet, "quiet", "Q", false, "Quiet mode (disable non-essential command output")
 	RootCmd.AddCommand(versionCmd)
 
 	cobra.OnInitialize(initConfig, buildClient)

--- a/cmd/runstatus_create.go
+++ b/cmd/runstatus_create.go
@@ -31,7 +31,10 @@ var runstatusCreateCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Runstat.us page %q created:\n - %s\n", result.Subdomain, result.PublicURL)
+
+			if !gQuiet {
+				fmt.Printf("Runstat.us page %q created:\n - %s\n", result.Subdomain, result.PublicURL)
+			}
 		}
 
 		return nil

--- a/cmd/runstatus_delete.go
+++ b/cmd/runstatus_delete.go
@@ -18,6 +18,7 @@ var runstatusDeleteCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 		for _, arg := range args {
+			// TODO: add "--force" flag
 			if !askQuestion(fmt.Sprintf("sure you want to delete %q runstat.us page", arg)) {
 				continue
 			}
@@ -30,7 +31,10 @@ var runstatusDeleteCmd = &cobra.Command{
 			if err := csRunstatus.DeleteRunstatusPage(gContext, *runstatusPage); err != nil {
 				return err
 			}
-			fmt.Printf("Page %q successfully deleted\n", arg)
+
+			if !gQuiet {
+				fmt.Printf("Page %q successfully deleted\n", arg)
+			}
 		}
 
 		return nil

--- a/cmd/runstatus_incident_remove.go
+++ b/cmd/runstatus_incident_remove.go
@@ -44,13 +44,16 @@ var runstatusIncidentRemoveCmd = &cobra.Command{
 			return err
 		}
 
+		// TODO: add "--force" flag
 		if !askQuestion(fmt.Sprintf("sure you want to delete %q incident", incidentName)) {
 			return nil
 		}
 		if err := csRunstatus.DeleteRunstatusIncident(gContext, *incident); err != nil {
 			return fmt.Errorf("error removing %q:\n%v", incidentName, err)
 		}
+
 		fmt.Printf("Incident %q successfully removed\n", incidentName)
+
 		return nil
 	},
 }

--- a/cmd/runstatus_maintenance_remove.go
+++ b/cmd/runstatus_maintenance_remove.go
@@ -45,6 +45,7 @@ var runstatusMaintenanceRemoveCmd = &cobra.Command{
 			return err
 		}
 
+		// TODO: add "--force" flag
 		if !askQuestion(fmt.Sprintf("Remove maintenance %q (%d) from %q?", maintenance.Title, maintenance.ID, pageName)) {
 			return nil
 		}

--- a/cmd/runstatus_service_create.go
+++ b/cmd/runstatus_service_create.go
@@ -48,7 +48,9 @@ var runstatusServiceCreateCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Printf("Service %q successfully created\n", s.Name)
+		if !gQuiet {
+			fmt.Printf("Service %q successfully created\n", s.Name)
+		}
 
 		return nil
 	},

--- a/cmd/runstatus_service_delete.go
+++ b/cmd/runstatus_service_delete.go
@@ -44,6 +44,7 @@ var runstatusServiceDeleteCmd = &cobra.Command{
 			return err
 		}
 
+		// TODO: add "--force" flag
 		if !askQuestion(fmt.Sprintf("sure you want to delete %q service", serviceName)) {
 			return nil
 		}

--- a/cmd/sshkey_create.go
+++ b/cmd/sshkey_create.go
@@ -22,7 +22,11 @@ var sshCreateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		displayResult(keyPair)
+
+		if !gQuiet {
+			displayResult(keyPair)
+		}
+
 		return nil
 	},
 }

--- a/cmd/sshkey_upload.go
+++ b/cmd/sshkey_upload.go
@@ -38,10 +38,14 @@ func uploadSSHKey(name, publicKeyPath string) error {
 	}
 
 	keyPair := resp.(*egoscale.SSHKeyPair)
-	table := table.NewTable(os.Stdout)
-	table.SetHeader([]string{"Name", "Fingerprint"})
-	table.Append([]string{keyPair.Name, keyPair.Fingerprint})
-	table.Render()
+
+	if !gQuiet {
+		table := table.NewTable(os.Stdout)
+		table.SetHeader([]string{"Name", "Fingerprint"})
+		table.Append([]string{keyPair.Name, keyPair.Fingerprint})
+		table.Render()
+	}
+
 	return nil
 }
 

--- a/cmd/template_register.go
+++ b/cmd/template_register.go
@@ -98,13 +98,14 @@ func templateRegister(registerTemplate egoscale.RegisterCustomTemplate, zone str
 
 	templates := resp.(*[]egoscale.Template)
 
-	table := table.NewTable(os.Stdout)
-	table.SetHeader([]string{"Zone", "Name", "ID"})
-	for _, template := range *templates {
-		table.Append([]string{template.ZoneName, template.Name, template.ID.String()})
+	if !gQuiet {
+		table := table.NewTable(os.Stdout)
+		table.SetHeader([]string{"Zone", "Name", "ID"})
+		for _, template := range *templates {
+			table.Append([]string{template.ZoneName, template.Name, template.ID.String()})
+		}
+		table.Render()
 	}
-
-	table.Render()
 
 	return nil
 }

--- a/cmd/vm_create.go
+++ b/cmd/vm_create.go
@@ -174,29 +174,27 @@ var vmCreateCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Printf(`
+		if !gQuiet {
+			fmt.Printf(`
 What do now?
 
 1. Connect to the machine
 
 > exo ssh %s
 `, r[0].Name)
-
-		printSSHConnectSTR(sshinfo)
-
-		fmt.Printf(`
+			printSSHConnectSTR(sshinfo)
+			fmt.Printf(`
 2. Put the SSH configuration into ".ssh/config"
 
 > exo ssh %s --info
 `, r[0].Name)
-
-		printSSHInfo(sshinfo)
-
-		fmt.Print(`
+			printSSHInfo(sshinfo)
+			fmt.Print(`
 Tip of the day:
 	You're the sole owner of the private key.
 	Be cautious with it.
 `)
+		}
 
 		return nil
 	},

--- a/cmd/vm_firewall.go
+++ b/cmd/vm_firewall.go
@@ -147,21 +147,23 @@ func setVirtualMachineSecurityGroups(vm *egoscale.VirtualMachine, sgs []egoscale
 
 // printVirtualMachineSecurityGroups prints a virtual machine instance security groups to standard output.
 func printVirtualMachineSecurityGroups(vm *egoscale.VirtualMachine) error {
-	// Refresh the vm object to ensure its properties are up-to-date
-	vm, err := getVirtualMachineByNameOrID(vm.ID.String())
-	if err != nil {
-		return err
-	}
+	if !gQuiet {
+		// Refresh the vm object to ensure its properties are up-to-date
+		vm, err := getVirtualMachineByNameOrID(vm.ID.String())
+		if err != nil {
+			return err
+		}
 
-	sgs := []string{}
-	for _, sgN := range vm.SecurityGroup {
-		sgs = append(sgs, sgN.Name)
-	}
+		sgs := []string{}
+		for _, sgN := range vm.SecurityGroup {
+			sgs = append(sgs, sgN.Name)
+		}
 
-	table := table.NewTable(os.Stdout)
-	table.SetHeader([]string{vm.Name})
-	table.Append([]string{"Security Groups", strings.Join(sgs, " - ")})
-	table.Render()
+		table := table.NewTable(os.Stdout)
+		table.SetHeader([]string{vm.Name})
+		table.Append([]string{"Security Groups", strings.Join(sgs, " - ")})
+		table.Render()
+	}
 
 	return nil
 }

--- a/cmd/vm_reset.go
+++ b/cmd/vm_reset.go
@@ -42,6 +42,7 @@ var vmResetCmd = &cobra.Command{
 			return err
 		}
 
+		// FIXME: this should be refactored using asyncTasks()
 		errs := []error{}
 		for _, v := range args {
 			if err := resetVirtualMachine(v, diskValue, template, templateFilter, force); err != nil {

--- a/cmd/zone.go
+++ b/cmd/zone.go
@@ -21,6 +21,7 @@ var zoneCmd = &cobra.Command{
 	},
 }
 
+// FIXME: this should be reimplemented using an outputter interface
 func listZones() error {
 	zones, err := cs.ListWithContext(gContext, &egoscale.Zone{})
 	if err != nil {


### PR DESCRIPTION
This change introduces a "quiet" mode (global flag `--quiet`|`-Q`, which
when specified disabled non-essential command outputs and can be better
suited for running bulk `exo` commands in shell scripts.