### PR TITLE
sos: delete: add "--recursive" flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 UNRELEASED
 ----------
 
-- Add new flag `--recursive` to the `sos delete` command to empty a bucket before deleting it (#164)
+- Add new flag `--recursive` to the `sos delete` command to empty a bucket before deleting it (#172)
 - Add "quiet" mode (#171)
 - Require protocol to be specified if a port is provided when adding a Security Group rule
 - Require a user-data maximum length of 32Kb during instance creation (#168)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 UNRELEASED
 ----------
 
+- Add new flag `--recursive` to the `sos delete` command to empty a bucket before deleting it (#164)
 - Add "quiet" mode (#171)
 - Require protocol to be specified if a port is provided when adding a Security Group rule
 - Require a user-data maximum length of 32Kb during instance creation (#168)

--- a/cmd/sos_delete.go
+++ b/cmd/sos_delete.go
@@ -58,7 +58,7 @@ var sosDeleteCmd = &cobra.Command{
 			for rmObjErr := range minioClient.RemoveObjectsWithContext(gContext, bucket, objectsCh) {
 				if rmObjErr.Err != nil {
 					fmt.Fprintf(os.Stderr, "error: %s: %s\n", rmObjErr.ObjectName, rmObjErr.Err)
-					continue
+					os.Exit(1)
 				}
 			}
 		}

--- a/cmd/sos_delete.go
+++ b/cmd/sos_delete.go
@@ -67,7 +67,9 @@ var sosDeleteCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Printf("Bucket %q deleted successfully\n", bucket)
+		if !gQuiet {
+			fmt.Printf("Bucket %q deleted successfully\n", bucket)
+		}
 
 		return nil
 	},

--- a/cmd/sos_delete.go
+++ b/cmd/sos_delete.go
@@ -49,7 +49,7 @@ var sosDeleteCmd = &cobra.Command{
 				for obj := range minioClient.ListObjectsV2(bucket, "", true, gContext.Done()) {
 					if obj.Err != nil {
 						fmt.Fprintf(os.Stderr, "error: %s: %s\n", obj.Key, obj.Err)
-						continue
+						os.Exit(1)
 					}
 					objectsCh <- obj.Key
 				}

--- a/cmd/sos_delete.go
+++ b/cmd/sos_delete.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"fmt"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -16,12 +18,19 @@ var sosDeleteCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 
+		bucket := args[0]
+
+		recursive, err := cmd.Flags().GetBool("recursive")
+		if err != nil {
+			return err
+		}
+
 		minioClient, err := newMinioClient(sosZone)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		zone, err := minioClient.GetBucketLocation(args[0])
+		zone, err := minioClient.GetBucketLocation(bucket)
 		if err != nil {
 			return err
 		}
@@ -31,10 +40,40 @@ var sosDeleteCmd = &cobra.Command{
 			return err
 		}
 
-		return minioClient.RemoveBucket(args[0])
+		if recursive { // Remove all files stored in the bucket before deleting it
+			objectsCh := make(chan string)
+
+			go func() {
+				defer close(objectsCh)
+
+				for obj := range minioClient.ListObjectsV2(bucket, "", true, gContext.Done()) {
+					if obj.Err != nil {
+						fmt.Fprintf(os.Stderr, "error: %s: %s\n", obj.Key, obj.Err)
+						continue
+					}
+					objectsCh <- obj.Key
+				}
+			}()
+
+			for rmObjErr := range minioClient.RemoveObjectsWithContext(gContext, bucket, objectsCh) {
+				if rmObjErr.Err != nil {
+					fmt.Fprintf(os.Stderr, "error: %s: %s\n", rmObjErr.ObjectName, rmObjErr.Err)
+					continue
+				}
+			}
+		}
+
+		if err = minioClient.RemoveBucket(bucket); err != nil {
+			return err
+		}
+
+		fmt.Printf("Bucket %q deleted successfully\n", bucket)
+
+		return nil
 	},
 }
 
 func init() {
+	sosDeleteCmd.Flags().BoolP("recursive", "r", false, "Attempt to empty the bucket before deleting it")
 	sosCmd.AddCommand(sosDeleteCmd)
 }


### PR DESCRIPTION
This change introduces a new `--recursive` option flag to the `sos delete` command, allowing to empty the targeted bucket before deleting it.

Fixes #164.