### PR TITLE
sos: fix empty files upload hanging bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ UNRELEASED
 - Fix `sos list` command panic if SOS returns bogus entries
 - Fix `lab kube create` node instance upgrade stage (#166)
 - Fix `affinitygroup delete` command confirmation prompt bug (#169)
+- Fix `sos upload` issue with empty files (#173)
 
 1.4.1
 -----

--- a/cmd/sos_upload.go
+++ b/cmd/sos_upload.go
@@ -196,6 +196,13 @@ var sosUploadCmd = &cobra.Command{
 				if upErr != nil {
 					log.Fatal(upErr)
 				}
+
+				// Workaround required to avoid the io.Reader from hanging when uploading empty files
+				// (see https://github.com/vbauerster/mpb/issues/7#issuecomment-518756758)
+				if fileInfo.Size() == 0 {
+					bar.SetTotal(100, true)
+				}
+
 				<-workerSem
 			}()
 		}


### PR DESCRIPTION
This change fixes a bug where the CLI progress bar would hang after
uploading an empty file. The fix is actually a workaround as the problem
is located in upstream minio-go library:

https://github.com/vbauerster/mpb/issues/7#issuecomment-518756758
https://github.com/minio/minio-go/issues/1146

Fixes #138.