### PR TITLE
network: fix network retrieval by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+UNRELEASED
+----------
+
+- Fix network retrieval by name (#175)
+
 1.5.0
 -----
 

--- a/cmd/privnet.go
+++ b/cmd/privnet.go
@@ -42,12 +42,12 @@ func getNetwork(net string, zoneID *egoscale.UUID) (*egoscale.Network, error) {
 	for _, item := range resp {
 		network := item.(*egoscale.Network)
 
-		// If search criteria is unique ID, return first (i.e. only) match
+		// If search criterion is an unique ID, return the first (i.e. only) match
 		if id != nil && network.ID.Equal(*id) {
 			return network, nil
 		}
 
-		// If search criteria is name, check that there isn't multiple networks named
+		// If search criterion is a name, check that there isn't multiple networks named
 		// identically before returning a match
 		if network.Name == net {
 			// We already found a match before -> multiple results

--- a/cmd/privnet.go
+++ b/cmd/privnet.go
@@ -14,48 +14,38 @@ var privnetCmd = &cobra.Command{
 	Short: "Private networks management",
 }
 
-func getNetworkByName(name string) (*egoscale.Network, error) {
-	net := &egoscale.Network{
-		Type:            "Isolated",
-		CanUseForDeploy: true,
-	}
-
-	id, errUUID := egoscale.ParseUUID(name)
-	if errUUID != nil {
-		net.Name = name
-	} else {
-		net.ID = id
-	}
-
-	resp, err := cs.GetWithContext(gContext, net)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp.(*egoscale.Network), nil
-}
-
-func getNetworkByNameAndZone(name string, zoneID *egoscale.UUID) (*egoscale.Network, error) {
-	net := &egoscale.Network{
+// getNetwork returns a Private Network by name or ID, and optionally a zone to restrict search to.
+// Since the Exoscale API doesn't support searching by unique name, we have to list all networks and
+// match results ourselves.
+func getNetwork(net string, zoneID *egoscale.UUID) (*egoscale.Network, error) {
+	req := &egoscale.Network{
 		ZoneID:          zoneID,
 		Type:            "Isolated",
 		CanUseForDeploy: true,
 	}
 
-	id, errUUID := egoscale.ParseUUID(name)
+	id, errUUID := egoscale.ParseUUID(net)
 	if errUUID != nil {
-		net.Name = name
+		req.Name = net
 	} else {
-		net.ID = id
+		req.ID = id
 	}
 
-	resp, err := cs.GetWithContext(gContext, net)
+	resp, err := cs.ListWithContext(gContext, req)
 	if err != nil {
 		return nil, err
 	}
 
-	return resp.(*egoscale.Network), nil
+	for _, item := range resp {
+		network := item.(*egoscale.Network)
+		if network.Name == net {
+			return network, nil
+		}
+	}
+
+	return nil, fmt.Errorf("network %q not found", net)
 }
+
 func init() {
 	RootCmd.AddCommand(privnetCmd)
 }

--- a/cmd/privnet.go
+++ b/cmd/privnet.go
@@ -38,7 +38,7 @@ func getNetwork(net string, zoneID *egoscale.UUID) (*egoscale.Network, error) {
 
 	for _, item := range resp {
 		network := item.(*egoscale.Network)
-		if network.Name == net {
+		if (id != nil && network.ID.Equal(*id)) || network.Name == net {
 			return network, nil
 		}
 	}

--- a/cmd/privnet_associate.go
+++ b/cmd/privnet_associate.go
@@ -21,7 +21,7 @@ var privnetAssociateCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 
-		network, err := getNetworkByName(args[0])
+		network, err := getNetwork(args[0], nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/privnet_delete.go
+++ b/cmd/privnet_delete.go
@@ -53,7 +53,7 @@ var privnetDeleteCmd = &cobra.Command{
 func deletePrivnet(name string) (*egoscale.DeleteNetwork, error) {
 	addrReq := &egoscale.DeleteNetwork{}
 	var err error
-	network, err := getNetworkByName(name)
+	network, err := getNetwork(name, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/privnet_dissociate.go
+++ b/cmd/privnet_dissociate.go
@@ -22,7 +22,7 @@ var dissociateCmd = &cobra.Command{
 			return err
 		}
 
-		network, err := getNetworkByName(args[0])
+		network, err := getNetwork(args[0], nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/privnet_show.go
+++ b/cmd/privnet_show.go
@@ -40,7 +40,7 @@ Supported output template annotations: %s`,
 }
 
 func showPrivnet(name string) (outputter, error) {
-	privnet, err := getNetworkByName(name)
+	privnet, err := getNetwork(name, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/privnet_update.go
+++ b/cmd/privnet_update.go
@@ -21,7 +21,7 @@ var privnetUpdateCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 
-		network, err := getNetworkByName(args[0])
+		network, err := getNetwork(args[0], nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/vm_create.go
+++ b/cmd/vm_create.go
@@ -241,7 +241,7 @@ func getPrivnetList(commaParameter string, zoneID *egoscale.UUID) ([]egoscale.UU
 	ids := make([]egoscale.UUID, len(sgs))
 
 	for i, sg := range sgs {
-		n, err := getNetworkByNameAndZone(sg, zoneID)
+		n, err := getNetwork(sg, zoneID)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/vm_update_ip.go
+++ b/cmd/vm_update_ip.go
@@ -23,7 +23,7 @@ var vmUpdateIPCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		network, err := getNetworkByName(netName)
+		network, err := getNetwork(netName, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This change improves the Private Network retrieval by name, following a
bug report demonstrating that some CLI operations fail in presence of
multiple similarly prefixed Private Networks since the Exoscale API
doesn't support Network resource search by name.

Before the change:

```console
$ exo privnet list
┼──────────────────────────────────────┼─────────┼──────────┼──────┼───────────┼
│                  ID                  │  NAME   │   ZONE   │ DHCP │ INSTANCES │
┼──────────────────────────────────────┼─────────┼──────────┼──────┼───────────┼
│ 9a67b55f-fe2a-4aab-b988-fcd3e654dbdd │ test100 │ ch-gva-2 │ n/a  │ 0         │
│ 5c80218f-9887-4f02-afc6-fd8d300b837e │ test10  │ ch-gva-2 │ n/a  │ 0         │
│ bcb9d7e3-a997-48ee-bc15-5f45c5a003a3 │ test1   │ ch-gva-2 │ n/a  │ 0         │
┼──────────────────────────────────────┼─────────┼──────────┼──────┼───────────┼

$ exo privnet associate test1 vm0
error: more than one element found: apikey=EXOxxxxxxxxxxxxxxxxxxxxxxxx, canusefordeploy=true, command=listNetworks, keyword=test1, type=Isolated
```

With the change implemented:

```console
$ ./exo privnet associate test1 vm0
Network:     test1
Description:
Zone:        ch-gva-2
IP Range:    n/a
┼─────────────────┼────────────┼
│ VIRTUAL MACHINE │ IP ADDRESS │
┼─────────────────┼────────────┼
│ vm0             │ n/a        │
┼─────────────────┼────────────┼
```