### PR TITLE
listServiceOffering: show the ID

### DIFF
--- a/cmd/serviceoffering.go
+++ b/cmd/serviceoffering.go
@@ -25,7 +25,7 @@ func listServiceOffering() error {
 	}
 
 	table := table.NewTable(os.Stdout)
-	table.SetHeader([]string{"Name", "cpu", "ram"})
+	table.SetHeader([]string{"ID", "Name", "cpu", "ram"})
 
 	for _, soff := range serviceOffering {
 		f := soff.(*egoscale.ServiceOffering)
@@ -37,7 +37,7 @@ func listServiceOffering() error {
 			ram = fmt.Sprintf("%d MB", f.Memory)
 		}
 
-		table.Append([]string{f.Name, fmt.Sprintf("%d× %d MHz", f.CPUNumber, f.CPUSpeed), ram})
+		table.Append([]string{f.ID.String(), f.Name, fmt.Sprintf("%d× %d MHz", f.CPUNumber, f.CPUSpeed), ram})
 	}
 
 	table.Render()


### PR DESCRIPTION
Some Exoscale calls needs the service offering ID.
This commit adds the ID in the `exo vm serviceoffering` output:

```
./exo vm serviceoffering
┼──────────────────────────────────────┼─────────────────────┼──────────────┼────────┼
│                  ID                  │        NAME         │     CPU      │  RAM   │
┼──────────────────────────────────────┼─────────────────────┼──────────────┼────────┼
│ 7c12e6df-6096-43e6-b9e4-3cb7b4e3f4c8 │ Micro               │ 1× 2198 MHz  │ 512 MB │
│ 84925525-7825-418b-845b-1aed179bbc40 │ Tiny                │ 1× 2198 MHz  │ 1 GB   │
│ f5c533d9-d8db-45b4-89c8-04eed02662ba │ Small               │ 2× 2198 MHz  │ 2 GB   │
│ 5e5fb3c6-e076-429d-9b6c-b71f7b27760b │ Medium              │ 2× 2198 MHz  │ 4 GB   │
│ f875f4dd-dbd4-48ad-a151-a7ba9d303008 │ Large               │ 4× 2198 MHz  │ 8 GB   │
│ 6c38a19f-cb29-498e-a645-1cc112d30f51 │ Extra-large         │ 4× 2198 MHz  │ 16 GB  │
│ 26f1e90b-8faa-466f-a4c1-0a54bdcb9ff2 │ Huge                │ 8× 2198 MHz  │ 32 GB  │
│ 6003dc8b-76cd-48de-a739-f03c42c571b5 │ Mega                │ 12× 2198 MHz │ 64 GB  │
│ 6ba6f3cf-6229-4a99-9058-1255b233830a │ Titan               │ 16× 2198 MHz │ 128 GB │
│ ba09daec-7642-40f3-9a71-031ee7117063 │ GPU-small           │ 12× 2198 MHz │ 60 GB  │
│ d75913f8-5e32-4ab5-8d55-fdf4fad7e63e │ GPU-huge            │ 48× 2198 MHz │ 225 GB │
│ 7e93ff07-4788-49ea-a48c-f051830138ff │ GPU-large           │ 36× 2198 MHz │ 180 GB │
│ f58ba3aa-c899-400d-b626-6a37de69b920 │ GPU-medium          │ 24× 2198 MHz │ 120 GB │
│ c01239ac-8bfd-46cb-9364-45f72e10588d │ Jumbo               │ 24× 2198 MHz │ 225 GB │
│ b1191d3e-63aa-458b-ab00-0548748638c2 │ Storage-extra-large │ 4× 2198 MHz  │ 16 GB  │
│ 6c60de9b-fb9c-4795-adfe-3d9ba941dcef │ Storage-huge        │ 8× 2198 MHz  │ 32 GB  │
│ 05fb37c2-3831-4005-b388-7a065e57575d │ Storage-tega        │ 12× 2198 MHz │ 64 GB  │
│ 65b5f7df-6155-4287-8713-b1d3ec3206fb │ Storage-titan       │ 16× 2198 MHz │ 128 GB │
│ 42f0e424-2de6-4a4f-94de-359f31a35648 │ Storage-jumbo       │ 24× 2198 MHz │ 225 GB │
│ c00fb106-419f-4a9d-8c59-01eb8cea9cc9 │ GPU2-small          │ 12× 2198 MHz │ 56 GB  │
│ 583862ce-e4f8-4304-8e42-6a3a3433f9a5 │ GPU2-medium         │ 16× 2198 MHz │ 90 GB  │
│ 39acc6ea-c9e4-4b25-b946-12950d40aca9 │ GPU2-large          │ 24× 2198 MHz │ 120 GB │
│ 25dc5e60-1be8-428a-ad34-f4a37b722690 │ GPU2-huge           │ 48× 2198 MHz │ 225 GB │
┼──────────────────────────────────────┼─────────────────────┼──────────────┼────────┼
```