### PR TITLE
zone: honor command output formatting options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ UNRELEASED
 
 - Fix network retrieval by name (#175)
 - `exo vm serviceoffering`: show the ID (#178)
+- `exo zone`: honor command output formatting options (#179)
 
 1.5.0
 -----


### PR DESCRIPTION
This change fixes the `exo zone` command to honor user custom output
formatting options.

Fixes #176.