### PR TITLE
travis: build on go 1.13

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,19 +20,20 @@ builds:
     hooks:
       pre: make manpages completions
 
-sign:
-  cmd: gpg
-  args: ["-u", "ops@exoscale.ch", "--detach-sign", "${artifact}"]
-  artifacts: all
+signs:
+  - cmd: gpg
+    args: ["-u", "ops@exoscale.ch", "--detach-sign", "${artifact}"]
+    artifacts: all
 
-archive:
-  format_overrides:
-    - goos: windows
-      format: zip
-  files:
-    - LICENSE
-    - contrib/completion/**/*
-    - manpage/*
+archives:
+  - id: windows
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - LICENSE
+      - contrib/completion/**/*
+      - manpage/*
 
 release:
   github:
@@ -40,28 +41,27 @@ release:
     name: cli
   draft: true
 
-nfpm:
-  vendor: Exoscale
-  homepage: https://www.exoscale.com/
-  maintainer: Exoscale Support <support@exoscale.com>
-  description: Manage (almost) everything at Exoscale from the command line.
-  license: Apache 2.0
-  formats:
-    - deb
-    - rpm
+nfpms:
+  - vendor: Exoscale
+    homepage: https://www.exoscale.com/
+    maintainer: Exoscale Support <support@exoscale.com>
+    description: Manage (almost) everything at Exoscale from the command line.
+    license: Apache 2.0
+    formats:
+      - deb
+      - rpm
+    files:
+      "./manpage/exo*.1": "/usr/share/man/man1"
+      "./contrib/completion/bash/exo": "/etc/bash_completion.d/exo"
 
-  files:
-    "./manpage/exo*.1": "/usr/share/man/man1"
-    "./contrib/completion/bash/exo": "/etc/bash_completion.d/exo"
-
-brew:
-  github:
-    owner: exoscale
-    name: homebrew-tap
-  folder: Formula
-  homepage: "https://exoscale.github.io/cli/"
-  description: Manage (almost) everything at Exoscale from the command line.
-  install: |
-    bin.install "exo"
-    man1.install Dir["manpage/exo*.1"]
-    bash_completion.install "contrib/completion/bash/exo"
+brews:
+  - github:
+      owner: exoscale
+      name: homebrew-tap
+    folder: Formula
+    homepage: "https://exoscale.github.io/cli/"
+    description: Manage (almost) everything at Exoscale from the command line.
+    install: |
+      bin.install "exo"
+      man1.install Dir["manpage/exo*.1"]
+      bash_completion.install "contrib/completion/bash/exo"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,13 @@ go:
   - "1.10.x"
   - "1.11.x"
   - "1.12.x"
+  - "1.13.x"
   - tip
 
 cache: apt
 
-addons:
-  apt:
-    update: true
-    packages:
-      - rpm
-
 env:
-  - GO111MODULE=on HUGO_VERSION=0.54.0 GOLANGCI_LINT_VERSION=1.15.0
+  - GO111MODULE=on HUGO_VERSION=0.58.3 GOLANGCI_LINT_VERSION=1.21.0
 
 script:
   - '[ "$(echo "$TRAVIS_GO_VERSION" | perl -pe "s/\\.[x\\d]+$//")" = "1.10" ] && go test -v ./... || go test -mod vendor -v ./...'
@@ -24,14 +19,14 @@ script:
 jobs:
   include:
     - stage: golangci-lint
-      go: "1.11.x"
+      go: "1.12.x"
       script:
         - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v${GOLANGCI_LINT_VERSION}
         - GO111MODULE=off golangci-lint run ./...
         - go test -v -mod=vendor ./...
         - go build -mod=vendor
     - stage: goreleaser
-      go: "1.11.x"
+      go: "1.12.x"
       script:
         - curl -sL https://git.io/goreleaser | head -n -2 | bash
         - tar -xf /tmp/goreleaser.tar.gz -C $GOPATH/bin


### PR DESCRIPTION
- bump versions
- latest goreleaser doesn't need rpm