### PR TITLE
sos: fix TLS certificate issue on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/spf13/viper v1.3.1
 	github.com/vbauerster/mpb/v4 v4.8.4
 	golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5
+	golang.org/x/net v0.0.0-20190522155817-f3200d17e092
 	gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c // indirect
 )
 


### PR DESCRIPTION
This change introduces a workaround to a bug in the Microsoft Windows
support in Go (https://github.com/golang/go/issues/16736). Some
heavily-chained certificates such as Exoscale SOS API's one are not
recognized as being signed by a trusted Certificate Authority.

Until the bug is fixed upstream, Windows users are required to use the
`--certs-file` flag with a path to a local file containing Exoscale SOS
API's certificate chain to the `exo sos` commands.

Fixes #189.