### PR TITLE
bug: adding a restricted key to config

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -243,13 +243,20 @@ func getAccount() (*account, error) {
 		resp, err := client.GetWithContext(gContext, egoscale.Account{})
 		if err != nil {
 			if isRestricted {
-				fmt.Print(" can't get account!\n\n")
-				acc, err := readInput(reader, "Account", account.Account)
-				if err != nil {
-					return nil, err
-				}
-				if acc != "" {
-					account.Account = acc
+				fmt.Print(` can't get account!
+
+Please enter your account name.
+
+				`)
+				for {
+					acc, err := readInput(reader, "Account", account.Account)
+					if err != nil {
+						return nil, err
+					}
+					if acc != "" {
+						account.Account = acc
+						break
+					}
 				}
 
 				break
@@ -294,12 +301,15 @@ Let's start over.
 	account.DefaultZone, err = chooseZone(account.Name, client)
 	if err != nil {
 		if isRestricted {
-			defaultZone, err := readInput(reader, "Zone", account.DefaultZone)
-			if err != nil {
-				return nil, err
-			}
-			if defaultZone != "" {
-				account.DefaultZone = defaultZone
+			for {
+				defaultZone, err := readInput(reader, "Zone", account.DefaultZone)
+				if err != nil {
+					return nil, err
+				}
+				if defaultZone != "" {
+					account.DefaultZone = defaultZone
+					break
+				}
 			}
 		} else {
 			return nil, err

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -233,11 +233,15 @@ func getAccount() (*account, error) {
 
 		client = egoscale.NewClient(account.Endpoint, account.Key, account.APISecret())
 
-		fmt.Printf("Checking the credentials of %q...", account.Key)
+		fmt.Printf("Retrieving account information of %q...", account.Key)
 		resp, err := client.GetWithContext(gContext, egoscale.Account{})
 		if err != nil {
 			if egoerr, ok := err.(*egoscale.ErrorResponse); ok && egoerr.ErrorCode == egoscale.ErrorCode(403) {
-				fmt.Println("This key is restricted, Please enter your account name.")
+				fmt.Print(`failure.
+				
+Please enter your account information.
+
+`)
 				for {
 					acc, err := readInput(reader, "Account", account.Account)
 					if err != nil {
@@ -258,7 +262,7 @@ Let's start over.
 
 `)
 		} else {
-			fmt.Print(" success!\n\n")
+			fmt.Print(" done!\n\n")
 			acc := resp.(*egoscale.Account)
 			account.Name = acc.Name
 			account.Account = acc.Name

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -246,8 +246,7 @@ func getAccount() (*account, error) {
 				fmt.Print(` can't get account!
 
 Please enter your account name.
-
-				`)
+`)
 				for {
 					acc, err := readInput(reader, "Account", account.Account)
 					if err != nil {

--- a/cmd/iam_apikey_create.go
+++ b/cmd/iam_apikey_create.go
@@ -133,13 +133,10 @@ func addAPIKeyInConfigFile(apiKey *egoscale.APIKey) error {
 		newAccount.DNSEndpoint = strings.Replace(newAccount.Endpoint, "/compute", "/dns", 1)
 
 		config.Accounts = append(config.Accounts, *newAccount)
-		if askQuestion("Make [" + newAccount.Name + "] your default profile?") {
-			config.DefaultAccount = newAccount.Name
-			viper.Set("defaultAccount", newAccount.Name)
-		}
 
 		return addAccount(viper.ConfigFileUsed(), config)
 	}
+
 	return nil
 }
 

--- a/cmd/iam_apikey_create.go
+++ b/cmd/iam_apikey_create.go
@@ -121,12 +121,15 @@ func addAPIKeyInConfigFile(apiKey *egoscale.APIKey) error {
 			newAccount.Name = name
 		}
 
-		defaultZone, err := chooseZone(newAccount.Name, cs)
+		zonesResp, err := cs.ListWithContext(gContext, &egoscale.Zone{ID: acc.DefaultZoneID})
 		if err != nil {
 			return err
 		}
 
-		newAccount.DefaultZone = defaultZone
+		zone := zonesResp[0].(*egoscale.Zone)
+		zName := strings.ToLower(zone.Name)
+
+		newAccount.DefaultZone = zName
 		newAccount.DNSEndpoint = strings.Replace(newAccount.Endpoint, "/compute", "/dns", 1)
 
 		config.Accounts = append(config.Accounts, *newAccount)

--- a/cmd/iam_apikey_revoke.go
+++ b/cmd/iam_apikey_revoke.go
@@ -9,7 +9,7 @@ import (
 
 // apiKeyRevokeCmd represents an API key revocation command
 var apiKeyRevokeCmd = &cobra.Command{
-	Use:     "revoke <key>+",
+	Use:     "revoke <key | name>+",
 	Short:   "Revoke API keys",
 	Aliases: gRevokeAlias,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -30,7 +30,12 @@ var apiKeyRevokeCmd = &cobra.Command{
 				}
 			}
 
-			cmd := &egoscale.RevokeAPIKey{Key: arg}
+			apiKey, err := getAPIKeyByName(arg)
+			if err != nil {
+				return err
+			}
+
+			cmd := &egoscale.RevokeAPIKey{Key: apiKey.Key}
 			tasks = append(tasks, task{
 				cmd,
 				fmt.Sprintf("Revoking API key %q", cmd.Key),


### PR DESCRIPTION
This PR removes the function of being able to add an API key in the config file after its creation & adds the function of adding a restricted API key in the config file with the command `exo config`