### PR TITLE
Show Private Networks in "exo vm show" (ch-6418)

### DIFF
--- a/cmd/vm_show.go
+++ b/cmd/vm_show.go
@@ -90,7 +90,7 @@ func showVM(name string) (outputter, error) {
 		SSHKey:             vm.KeyPair,
 		SecurityGroups:     make([]string, len(vm.SecurityGroup)),
 		AntiAffinityGroups: make([]string, len(vm.AffinityGroup)),
-		PrivateNetworks:    make([]string, len(vm.Nic)),
+		PrivateNetworks:    make([]string, 0, len(vm.Nic)-1),
 	}
 
 	for i, sg := range vm.SecurityGroup {
@@ -101,12 +101,12 @@ func showVM(name string) (outputter, error) {
 		out.AntiAffinityGroups[i] = aag.Name
 	}
 
-	for i, nic := range vm.Nic {
+	for _, nic := range vm.Nic {
 		if nic.ID == vm.DefaultNic().ID {
 			continue
 		}
 
-		out.PrivateNetworks[i] = nic.NetworkName
+		out.PrivateNetworks = append(out.PrivateNetworks, nic.NetworkName)
 	}
 
 	if username, ok := template.Details["username"]; ok {

--- a/cmd/vm_show.go
+++ b/cmd/vm_show.go
@@ -90,7 +90,7 @@ func showVM(name string) (outputter, error) {
 		SSHKey:             vm.KeyPair,
 		SecurityGroups:     make([]string, len(vm.SecurityGroup)),
 		AntiAffinityGroups: make([]string, len(vm.AffinityGroup)),
-		PrivateNetworks:    make([]string, 0, len(vm.Nic)-1),
+		PrivateNetworks:    make([]string, 0),
 	}
 
 	for i, sg := range vm.SecurityGroup {
@@ -102,7 +102,7 @@ func showVM(name string) (outputter, error) {
 	}
 
 	for _, nic := range vm.Nic {
-		if nic.ID == vm.DefaultNic().ID {
+		if nic.IsDefault {
 			continue
 		}
 

--- a/cmd/vm_show.go
+++ b/cmd/vm_show.go
@@ -23,6 +23,7 @@ type vmShowOutput struct {
 	SSHKey             string   `json:"ssh_key"`
 	SecurityGroups     []string `json:"security_groups,omitempty"`
 	AntiAffinityGroups []string `json:"antiaffinity_groups,omitempty" outputLabel:"Anti-Affinity Groups"`
+	PrivateNetworks    []string `json:"private_networks,omitempty"`
 }
 
 func (o *vmShowOutput) Type() string { return "Instance" }
@@ -89,6 +90,7 @@ func showVM(name string) (outputter, error) {
 		SSHKey:             vm.KeyPair,
 		SecurityGroups:     make([]string, len(vm.SecurityGroup)),
 		AntiAffinityGroups: make([]string, len(vm.AffinityGroup)),
+		PrivateNetworks:    make([]string, len(vm.Nic)),
 	}
 
 	for i, sg := range vm.SecurityGroup {
@@ -97,6 +99,14 @@ func showVM(name string) (outputter, error) {
 
 	for i, aag := range vm.AffinityGroup {
 		out.AntiAffinityGroups[i] = aag.Name
+	}
+
+	for i, nic := range vm.Nic {
+		if nic.ID == vm.DefaultNic().ID {
+			continue
+		}
+
+		out.PrivateNetworks[i] = nic.NetworkName
 	}
 
 	if username, ok := template.Details["username"]; ok {


### PR DESCRIPTION
Currently the `exo vm show` command doesn't show the Private Networks the instance is attached to, although this information is show in the portal equivalent view.