### PR TITLE
fix: "iam apikey operations" command output

### DIFF
--- a/cmd/iam_apikey_operations.go
+++ b/cmd/iam_apikey_operations.go
@@ -56,14 +56,14 @@ func listAPIKeyOperations(filters []string) (outputter, error) {
 			}
 		}
 
-		switch true {
-		case strings.Contains(result, "compute"):
+		switch {
+		case strings.HasPrefix(result, "compute/"):
 			out.Compute = append(out.Compute, o)
-		case strings.Contains(result, "dns"):
+		case strings.HasPrefix(result, "dns/"):
 			out.DNS = append(out.DNS, o)
-		case strings.Contains(result, "iam"):
+		case strings.HasPrefix(result, "iam/"):
 			out.IAM = append(out.IAM, o)
-		case strings.Contains(result, "sos"):
+		case strings.HasPrefix(result, "sos/"):
 			out.SOS = append(out.SOS, o)
 		}
 	}

--- a/cmd/iam_apikey_operations.go
+++ b/cmd/iam_apikey_operations.go
@@ -58,13 +58,13 @@ func listAPIKeyOperations(filters []string) (outputter, error) {
 
 		switch true {
 		case strings.Contains(result, "compute"):
-			out.Compute = append(out.Compute, result)
+			out.Compute = append(out.Compute, o)
 		case strings.Contains(result, "dns"):
-			out.DNS = append(out.DNS, result)
+			out.DNS = append(out.DNS, o)
 		case strings.Contains(result, "iam"):
-			out.IAM = append(out.IAM, result)
+			out.IAM = append(out.IAM, o)
 		case strings.Contains(result, "sos"):
-			out.SOS = append(out.SOS, result)
+			out.SOS = append(out.SOS, o)
 		}
 	}
 


### PR DESCRIPTION
This PR changes the output of the `exo iam apikey operations` command.

lower case --> camel case

```
% exo lab iam apikey operations "iam"

┼─────────┼──────────────────────────┼
│ Compute │ n/a                      │
│ DNS     │ n/a                      │
│ IAM     │ iam/*                    │
│         │ iam/createApiKey         │
│         │ iam/getApiKey            │
│         │ iam/listApiKeyOperations │
│         │ iam/listApiKeys          │
│         │ iam/revokeApiKey         │
│ SOS     │ n/a                      │
┼─────────┼──────────────────────────┼
```