### PR TITLE
config: add a dedicated account creation command

### DIFF
--- a/cmd/config_add.go
+++ b/cmd/config_add.go
@@ -1,0 +1,190 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/exoscale/egoscale"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func init() {
+	configCmd.AddCommand(&cobra.Command{
+		Use:   "add <account name>",
+		Short: "Add a new account to configuration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return cmd.Usage()
+			}
+
+			newAccount, err := promptAccountInformation()
+			if err != nil {
+				return err
+			}
+
+			config := &config{Accounts: []account{*newAccount}}
+			if askQuestion("Set [" + newAccount.Name + "] as default account?") {
+				config.DefaultAccount = newAccount.Name
+				viper.Set("defaultAccount", newAccount.Name)
+			}
+
+			return saveConfig(viper.ConfigFileUsed(), config)
+		},
+	})
+}
+
+func addConfigAccount(firstRun bool) error {
+	var config config
+
+	if firstRun {
+		filePath, err := createConfigFile(defaultConfigFileName)
+		if err != nil {
+			return err
+		}
+
+		viper.SetConfigFile(filePath)
+
+		newAccount, err := promptAccountInformation()
+		if err != nil {
+			return err
+		}
+		config.DefaultAccount = newAccount.Name
+		config.Accounts = []account{*newAccount}
+		viper.Set("defaultAccount", newAccount.Name)
+	}
+
+	if len(config.Accounts) == 0 {
+		return nil
+	}
+
+	return saveConfig(viper.ConfigFileUsed(), &config)
+}
+
+func promptAccountInformation() (*account, error) {
+	var client *egoscale.Client
+
+	reader := bufio.NewReader(os.Stdin)
+	account := &account{
+		Endpoint: defaultEndpoint,
+		Key:      "",
+		Secret:   "",
+	}
+
+	for i := 0; ; i++ {
+		if i > 0 {
+			endpoint, err := readInput(reader, "API Endpoint", account.Endpoint)
+			if err != nil {
+				return nil, err
+			}
+			if endpoint != account.Endpoint {
+				account.Endpoint = endpoint
+			}
+		}
+
+		apiKey, err := readInput(reader, "API Key", account.Key)
+		if err != nil {
+			return nil, err
+		}
+		if apiKey != account.Key {
+			account.Key = apiKey
+		}
+
+		secret := account.APISecret()
+		secretShow := account.APISecret()
+		if secret != "" && len(secret) > 10 {
+			secretShow = secret[0:7] + "..."
+		}
+		secretKey, err := readInput(reader, "Secret Key", secretShow)
+		if err != nil {
+			return nil, err
+		}
+		if secretKey != secret && secretKey != secretShow {
+			account.Secret = secretKey
+		}
+
+		client = egoscale.NewClient(account.Endpoint, account.Key, account.APISecret())
+
+		fmt.Printf("Retrieving account information...")
+		resp, err := client.GetWithContext(gContext, egoscale.Account{})
+		if err != nil {
+			if egoerr, ok := err.(*egoscale.ErrorResponse); ok && egoerr.ErrorCode == egoscale.ErrorCode(403) {
+				fmt.Print(`failure.
+
+Please enter your account information.
+
+`)
+				for {
+					acc, err := readInput(reader, "Account", account.Account)
+					if err != nil {
+						return nil, err
+					}
+					if acc != "" {
+						account.Account = acc
+						break
+					}
+				}
+
+				break
+			}
+
+			fmt.Print(` failure.
+
+Let's start over.
+
+`)
+		} else {
+			fmt.Print(" done!\n\n")
+			acc := resp.(*egoscale.Account)
+			account.Name = acc.Name
+			account.Account = acc.Name
+			break
+		}
+	}
+
+	name, err := readInput(reader, "Name", account.Name)
+	if err != nil {
+		return nil, err
+	}
+	if name != "" {
+		account.Name = name
+	}
+
+	for {
+		if a := getAccountByName(account.Name); a == nil {
+			break
+		}
+
+		fmt.Printf("Name [%s] already exist\n", name)
+		name, err = readInput(reader, "Name", account.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		account.Name = name
+	}
+
+	account.DefaultZone, err = chooseZone(account.Name, client)
+	if err != nil {
+		if egoerr, ok := err.(*egoscale.ErrorResponse); ok && egoerr.ErrorCode == egoscale.ErrorCode(403) {
+			for {
+				defaultZone, err := readInput(reader, "Zone", account.DefaultZone)
+				if err != nil {
+					return nil, err
+				}
+				if defaultZone != "" {
+					account.DefaultZone = defaultZone
+					break
+				}
+			}
+		} else {
+			return nil, err
+		}
+	}
+
+	account.DNSEndpoint = strings.Replace(account.Endpoint, "/compute", "/dns", 1)
+
+	return account, nil
+}

--- a/cmd/config_delete.go
+++ b/cmd/config_delete.go
@@ -10,7 +10,7 @@ import (
 // deleteCmd represents the delete command
 var configDeleteCmd = &cobra.Command{
 	Use:     "delete <account name>",
-	Short:   "Delete an account from config file",
+	Short:   "Delete an account from configuration",
 	Aliases: gDeleteAlias,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
@@ -48,7 +48,7 @@ var configDeleteCmd = &cobra.Command{
 
 		gAllAccount.Accounts = append(gAllAccount.Accounts[:pos], gAllAccount.Accounts[pos+1:]...)
 
-		if err := addAccount(viper.ConfigFileUsed(), nil); err != nil {
+		if err := saveConfig(viper.ConfigFileUsed(), nil); err != nil {
 			return err
 		}
 

--- a/cmd/config_list.go
+++ b/cmd/config_list.go
@@ -54,6 +54,10 @@ Supported output template annotations: %s`,
 func listConfigs() outputter {
 	out := configListOutput{}
 
+	if gAllAccount == nil {
+		return &out
+	}
+
 	for _, a := range gAllAccount.Accounts {
 		out = append(out, configListItemOutput{
 			Name:    a.Name,

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -25,7 +25,7 @@ var configSetCmd = &cobra.Command{
 
 		viper.Set("defaultAccount", args[0])
 
-		if err := addAccount(viper.ConfigFileUsed(), nil); err != nil {
+		if err := saveConfig(viper.ConfigFileUsed(), nil); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
This change introduces an explicit `exo config add` command allowing
users to create a CLI configuration accounts. Includes some light
internal refactoring to make code more readable.

```console
$ ./exo config add blah
[+] API Key [none]: EXOxxxxxxxxxxxxxxxxxxxxxxx
[+] Secret Key [none]: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
Retrieving account information... done!

[+] Name [xxxxxx@exoscale.com]: blah
✔ ch-gva-2
You chose "ch-gva-2"
[+] Set [blah] as default account? [yN]: y

$ ./exo config
To configure a new account, run `exo config add`
Use the arrow keys to navigate: ↓ ↑ → ←
? Configured accounts (* = default account):
  ▸ alice
    bob
    carl
    blah*
```