### PR TITLE
mod: upgrade egoscale to 0.20.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/cpuguy83/go-md2man v1.0.8 // indirect
 	github.com/dustin/go-humanize v1.0.0
-	github.com/exoscale/egoscale v0.20.0
+	github.com/exoscale/egoscale v0.20.1
 	github.com/fatih/camelcase v1.0.0
 	github.com/go-ini/ini v1.42.0
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/exoscale/egoscale v0.20.0 h1:IOzwUAUq/XtaQvxk1mUlP7MXrow0jNDaWp+KHJxHcDM=
 github.com/exoscale/egoscale v0.20.0/go.mod h1:hRo78jkjkCDKpivQdRBEpNYF5+cVpCJCPDg2/r45KaY=
+github.com/exoscale/egoscale v0.20.1 h1:lK4YonpKUGlJZ2M4CKt4oIRZaFlDBGPioFkNzz81k0g=
+github.com/exoscale/egoscale v0.20.1/go.mod h1:hRo78jkjkCDKpivQdRBEpNYF5+cVpCJCPDg2/r45KaY=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.20.1
+------
+
+- fix: update the `ListAPIKeysResponse` field (#415)
+
 0.20.0
 ------
 

--- a/vendor/github.com/exoscale/egoscale/iam_apikey.go
+++ b/vendor/github.com/exoscale/egoscale/iam_apikey.go
@@ -39,7 +39,7 @@ type ListAPIKeys struct {
 // ListAPIKeysResponse represents a list of API keys
 type ListAPIKeysResponse struct {
 	Count   int      `json:"count"`
-	APIKeys []APIKey `json:"apikeys"`
+	APIKeys []APIKey `json:"apikey"`
 }
 
 // Response returns the struct to unmarshal

--- a/vendor/github.com/exoscale/egoscale/version.go
+++ b/vendor/github.com/exoscale/egoscale/version.go
@@ -1,4 +1,4 @@
 package egoscale
 
 // Version of the library
-const Version = "0.20.0"
+const Version = "0.20.1"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -54,7 +54,7 @@ github.com/dlclark/regexp2
 github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.0
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.20.0
+# github.com/exoscale/egoscale v0.20.1
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/admin
 # github.com/fatih/camelcase v1.0.0


### PR DESCRIPTION
This change upgrades the egoscale dependency to version 0.20.1, fixing a change in IAM API response format.