### PR TITLE
Print SOS link when adding canned public ACL

### DIFF
--- a/cmd/sos_acl.go
+++ b/cmd/sos_acl.go
@@ -108,7 +108,20 @@ var sosAddACLCmd = &cobra.Command{
 		}
 
 		// Copy object call
-		return sosClient.CopyObject(dst, src)
+		err = sosClient.CopyObject(dst, src)
+		if err != nil {
+			return err
+		}
+
+		acl, err := getDefaultCannedACL(cmd)
+		if err != nil {
+			return err
+		}
+		if acl == publicReadWrite || acl == publicRead {
+			fmt.Printf("https://sos-%s.exo.io/%s/%s\n", location, bucket, object)
+		}
+
+		return nil
 	},
 }
 

--- a/cmd/sos_acl.go
+++ b/cmd/sos_acl.go
@@ -113,12 +113,15 @@ var sosAddACLCmd = &cobra.Command{
 			return err
 		}
 
-		acl, err := getDefaultCannedACL(cmd)
-		if err != nil {
-			return err
-		}
-		if acl == publicReadWrite || acl == publicRead {
-			fmt.Printf("https://sos-%s.exo.io/%s/%s\n", location, bucket, object)
+		if !gQuiet {
+			acl, err := getDefaultCannedACL(cmd)
+			if err != nil {
+				return err
+			}
+
+			if acl == publicReadWrite || acl == publicRead {
+				fmt.Printf("https://sos-%s.exo.io/%s/%s\n", location, bucket, object)
+			}
 		}
 
 		return nil


### PR DESCRIPTION
In an overwhelming majority of cases, users setting ACLs to
--public-read or --public-read-write will want to share the link to that
ressource via HTTP.

This saves the users a couple of clicks by printing the link to the file
they just uploaded to stdout.

No other canned ACLs are impacted.

Example run:

```
$ ./exo sos acl add sharing-is-caring blah.jpg --public-read
https://sos-ch-dk-2.exo.io/sharing-is-caring/blah.jpg
```