### PR TITLE
SOS: Add EXOSCALE_TRACE to log sos operations

### DIFF
--- a/cmd/sos.go
+++ b/cmd/sos.go
@@ -70,6 +70,11 @@ func newSOSClient(certsFile string) (*sosClient, error) {
 		return nil, err
 	}
 
+	_, ok := os.LookupEnv("EXOSCALE_TRACE")
+	if ok {
+		c.TraceOn(os.Stderr)
+	}
+
 	return &c, nil
 }
 


### PR DESCRIPTION
Trace on minio when `EXOSCALE_TRACE`  env is set