### PR TITLE
Graduate instancepool to a non-lab feature.

### DIFF
--- a/cmd/instance_pool.go
+++ b/cmd/instance_pool.go
@@ -13,7 +13,7 @@ var instancePoolCmd = &cobra.Command{
 }
 
 func init() {
-	labCmd.AddCommand(instancePoolCmd)
+	RootCmd.AddCommand(instancePoolCmd)
 }
 
 func getInstancePoolByID(id, zone *egoscale.UUID) (*egoscale.InstancePool, error) {


### PR DESCRIPTION
Since instance pools are now generally available, they don't need to sit
behind the "lab" section of the CLI tool.