### PR TITLE
use go 1.13 and rely on os.UserConfigDir to find config location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: go
 
 go:
-  - "1.10.x"
-  - "1.11.x"
-  - "1.12.x"
   - "1.13.x"
   - tip
 
@@ -19,20 +16,20 @@ script:
 jobs:
   include:
     - stage: golangci-lint
-      go: "1.12.x"
+      go: "1.13.x"
       script:
         - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v${GOLANGCI_LINT_VERSION}
         - GO111MODULE=off golangci-lint run ./...
         - go test -v -mod=vendor ./...
         - go build -mod=vendor
     - stage: goreleaser
-      go: "1.12.x"
+      go: "1.13.x"
       script:
         - curl -sL https://git.io/goreleaser | head -n -2 | bash
         - tar -xf /tmp/goreleaser.tar.gz -C $GOPATH/bin
         - goreleaser --snapshot --skip-sign
     - stage: gh-pages
-      go: "1.11.x"
+      go: "1.13.x"
       if: branch = master AND type = push
       script: |
         cd website

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-stretch as builder
+FROM golang:1.13-stretch as builder
 
 ADD . /src
 WORKDIR /src

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -200,18 +200,11 @@ func initConfig() {
 		}
 	}
 
-	xdgHome, found := os.LookupEnv("XDG_CONFIG_HOME")
-	if found {
-		gConfigFolder = path.Join(xdgHome, "exoscale")
-	} else {
-		home, found := os.LookupEnv("HOME")
-		if found {
-			gConfigFolder = path.Join(home, ".config", "exoscale")
-		} else {
-			// The XDG spec specifies a default XDG_CONFIG_HOME in $HOME/.config
-			gConfigFolder = path.Join(usr.HomeDir, ".config", "exoscale")
-		}
+	cfgdir, err := os.UserConfigDir()
+	if err != nil {
+		log.Fatalf("could not find configuration directory: %s", err)
 	}
+	gConfigFolder = path.Join(cfgdir, "exoscale")
 
 	// Snap packages use $HOME/.exoscale (as negotiated with the snap store)
 	if _, snap := os.LookupEnv("SNAP_USER_COMMON"); snap {


### PR DESCRIPTION
This should fix failures to find the config file's location on
Windows. As per a recommendation from @greut, thanks!

Somewhat related to #197 though it might not fix the issue.