### PR TITLE
config: improve account listing UX

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -95,7 +95,7 @@ var configCmd = &cobra.Command{
 
 func configCmdRun(cmd *cobra.Command, args []string) error {
 	var (
-		defaultAccountMark = promptui.Styler(promptui.FGBold, promptui.FGYellow)("*")
+		defaultAccountMark = promptui.Styler(promptui.FGYellow)("*")
 		newAccountLabel    = "<Configure a new account>"
 	)
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -94,18 +94,22 @@ var configCmd = &cobra.Command{
 }
 
 func configCmdRun(cmd *cobra.Command, args []string) error {
-	var defaultAccountMark = "*"
+	var (
+		defaultAccountMark = promptui.Styler(promptui.FGBold, promptui.FGYellow)("*")
+		newAccountLabel    = "<Configure a new account>"
+	)
 
 	if gConfigFilePath == "" && gCurrentAccount.Key != "" {
 		log.Fatalf("remove ENV credentials variables to use %s", cmd.CalledAs())
 	}
 
 	if gConfigFilePath != "" && gCurrentAccount.Key != "" {
-		fmt.Println("To configure a new account, run `exo config add`")
-
+		accounts := listAccounts(defaultAccountMark)
+		accounts = append(accounts, newAccountLabel)
 		prompt := promptui.Select{
 			Label: fmt.Sprintf("Configured accounts (%s = default account)", defaultAccountMark),
-			Items: listAccounts(defaultAccountMark),
+			Items: accounts,
+			Size:  len(accounts),
 		}
 		_, selectedAccount, err := prompt.Run()
 		if err != nil {
@@ -117,13 +121,14 @@ func configCmdRun(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		if strings.TrimSuffix(selectedAccount, defaultAccountMark) != gAllAccount.DefaultAccount {
-			viper.Set("defaultAccount", selectedAccount)
-			if err := saveConfig(viper.ConfigFileUsed(), nil); err != nil {
-				return err
-			}
+		if selectedAccount == newAccountLabel {
+			return addConfigAccount(false)
+		}
 
-			fmt.Printf("Default account set to [%s]\n", selectedAccount)
+		if strings.TrimSuffix(selectedAccount, defaultAccountMark) != gAllAccount.DefaultAccount {
+			fmt.Printf("Setting default account to [%s]\n", selectedAccount)
+			viper.Set("defaultAccount", selectedAccount)
+			return saveConfig(viper.ConfigFileUsed(), nil)
 		}
 
 		return addConfigAccount(false)
@@ -514,6 +519,7 @@ func chooseZone(accountName string, cs *egoscale.Client) (string, error) {
 	prompt := promptui.Select{
 		Label: fmt.Sprintf("Choose the default zone for %q", accountName),
 		Items: zones,
+		Size:  len(zones),
 	}
 
 	_, result, err := prompt.Run()
@@ -521,8 +527,6 @@ func chooseZone(accountName string, cs *egoscale.Client) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("prompt failed %v", err)
 	}
-
-	fmt.Printf("You chose %q\n", result)
 
 	return result, nil
 }

--- a/cmd/config_add.go
+++ b/cmd/config_add.go
@@ -36,30 +36,34 @@ func init() {
 }
 
 func addConfigAccount(firstRun bool) error {
-	var config config
+	var (
+		config config
+		err    error
+	)
+
+	filePath := viper.ConfigFileUsed()
 
 	if firstRun {
-		filePath, err := createConfigFile(defaultConfigFileName)
-		if err != nil {
+		if filePath, err = createConfigFile(defaultConfigFileName); err != nil {
 			return err
 		}
 
 		viper.SetConfigFile(filePath)
-
-		newAccount, err := promptAccountInformation()
-		if err != nil {
-			return err
-		}
-		config.DefaultAccount = newAccount.Name
-		config.Accounts = []account{*newAccount}
-		viper.Set("defaultAccount", newAccount.Name)
 	}
+
+	newAccount, err := promptAccountInformation()
+	if err != nil {
+		return err
+	}
+	config.DefaultAccount = newAccount.Name
+	config.Accounts = []account{*newAccount}
+	viper.Set("defaultAccount", newAccount.Name)
 
 	if len(config.Accounts) == 0 {
 		return nil
 	}
 
-	return saveConfig(viper.ConfigFileUsed(), &config)
+	return saveConfig(filePath, &config)
 }
 
 func promptAccountInformation() (*account, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -276,8 +276,8 @@ func initConfig() {
 		}
 	}
 
-	if gCurrentAccount == nil {
-		log.Fatalf("could't find any account with name: %q", gAccountName)
+	if gCurrentAccount.Name == "" {
+		log.Fatalf("error: could't find any configured account named %q", gAccountName)
 	}
 
 	if gCurrentAccount.Endpoint == "" {


### PR DESCRIPTION
This change improves the UX of listing configured accounts and adds a
new shortcut to create a new one directly from the list.

Also fixes a bug where a non-existent account name would not be detected
properly.

```console
$ ./exo config
Use the arrow keys to navigate: ↓ ↑ → ←
? Configured accounts (* = default account):
  ▸ alice*
    bob
    <Configure a new account>
```