### PR TITLE
config: improve account creation with restricted keys

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -373,7 +373,7 @@ func importCloudstackINI(option, csPath, cfgPath string) error {
 			csAccount.Name = name
 		}
 
-		defaultZone, err := chooseZone(csAccount.Name, csClient)
+		defaultZone, err := chooseZone(csClient, nil)
 		if err != nil {
 			return err
 		}
@@ -493,26 +493,27 @@ func getAccountByName(name string) *account {
 	return nil
 }
 
-func chooseZone(accountName string, cs *egoscale.Client) (string, error) {
-	zonesResp, err := cs.ListWithContext(gContext, &egoscale.Zone{})
-	if err != nil {
-		return "", err
-	}
+func chooseZone(cs *egoscale.Client, zones []string) (string, error) {
+	if zones == nil {
+		zonesResp, err := cs.ListWithContext(gContext, &egoscale.Zone{})
+		if err != nil {
+			return "", err
+		}
 
-	if len(zonesResp) == 0 {
-		return "", fmt.Errorf("no zones were found")
-	}
+		if len(zonesResp) == 0 {
+			return "", fmt.Errorf("no zones were found")
+		}
 
-	zones := make([]string, len(zonesResp))
-
-	for i, z := range zonesResp {
-		zone := z.(*egoscale.Zone)
-		zName := strings.ToLower(zone.Name)
-		zones[i] = zName
+		zones = make([]string, len(zonesResp))
+		for i, z := range zonesResp {
+			zone := z.(*egoscale.Zone)
+			zName := strings.ToLower(zone.Name)
+			zones[i] = zName
+		}
 	}
 
 	prompt := promptui.Select{
-		Label: fmt.Sprintf("Choose the default zone for %q", accountName),
+		Label: "Default zone",
 		Items: zones,
 	}
 
@@ -521,8 +522,6 @@ func chooseZone(accountName string, cs *egoscale.Client) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("prompt failed %v", err)
 	}
-
-	fmt.Printf("You chose %q\n", result)
 
 	return result, nil
 }

--- a/cmd/config_add.go
+++ b/cmd/config_add.go
@@ -12,13 +12,9 @@ import (
 
 func init() {
 	configCmd.AddCommand(&cobra.Command{
-		Use:   "add <account name>",
+		Use:   "add",
 		Short: "Add a new account to configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) < 1 {
-				return cmd.Usage()
-			}
-
 			newAccount, err := promptAccountInformation()
 			if err != nil {
 				return err
@@ -110,13 +106,13 @@ func promptAccountInformation() (*account, error) {
 		resp, err := client.GetWithContext(gContext, egoscale.Account{})
 		if err != nil {
 			if egoerr, ok := err.(*egoscale.ErrorResponse); ok && egoerr.ErrorCode == egoscale.ErrorCode(403) {
-				fmt.Print(`failure.
+				fmt.Print(`
 
-Please enter your account information.
+Unable to retrieve information, please enter your account details:
 
 `)
 				for {
-					acc, err := readInput(reader, "Account", account.Account)
+					acc, err := readInput(reader, "Account name", account.Account)
 					if err != nil {
 						return nil, err
 					}
@@ -165,11 +161,11 @@ Let's start over.
 		account.Name = name
 	}
 
-	account.DefaultZone, err = chooseZone(account.Name, client)
+	account.DefaultZone, err = chooseZone(client, nil)
 	if err != nil {
 		if egoerr, ok := err.(*egoscale.ErrorResponse); ok && egoerr.ErrorCode == egoscale.ErrorCode(403) {
 			for {
-				defaultZone, err := readInput(reader, "Zone", account.DefaultZone)
+				defaultZone, err := chooseZone(cs, zones)
 				if err != nil {
 					return nil, err
 				}

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -29,7 +29,7 @@ var configSetCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Println("Default profile set to", args[0])
+		fmt.Printf("Default profile set to [%s]\n", args[0])
 
 		return nil
 	},

--- a/cmd/zone.go
+++ b/cmd/zone.go
@@ -12,6 +12,16 @@ const (
 	zoneHelp = "<zone name | id> (ch-dk-2|ch-gva-2|at-vie-1|de-fra-1|bg-sof-1|de-muc-1)"
 )
 
+// zones represents the list of known Exoscale zones, in case we need it without performing API lookup.
+var zones = []string{
+	"at-vie-1",
+	"bg-sof-1",
+	"ch-dk-2",
+	"ch-gva-2",
+	"de-fra-1",
+	"de-muc-1",
+}
+
 type zoneListItemOutput struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`


### PR DESCRIPTION
This change improves the UX of account creation when using IAM
restricted keys preventing us to retrieve the information matching the
API credentials provided by the user: instead of prompting the user with
a free-form text input for the zone, we offer a selection using
built-in zones list.