### PR TITLE
help: add explicit reference to custom output doc

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -106,7 +106,7 @@ func Execute(version, commit string) {
 func init() {
 	RootCmd.PersistentFlags().StringVarP(&gConfigFilePath, "config", "C", "", "Specify an alternate config file [env EXOSCALE_CONFIG]")
 	RootCmd.PersistentFlags().StringVarP(&gAccountName, "use-account", "A", "", "Account to use in config file [env EXOSCALE_ACCOUNT]")
-	RootCmd.PersistentFlags().StringVarP(&gOutputFormat, "output-format", "O", "", "Output format (table|json|text)")
+	RootCmd.PersistentFlags().StringVarP(&gOutputFormat, "output-format", "O", "", "Output format (table|json|text), see \"exo output --help\" for more information")
 	RootCmd.PersistentFlags().StringVar(&gOutputTemplate, "output-template", "", "Template to use if output format is \"text\"")
 	RootCmd.PersistentFlags().BoolVarP(&gQuiet, "quiet", "Q", false, "Quiet mode (disable non-essential command output")
 	RootCmd.AddCommand(versionCmd)


### PR DESCRIPTION
This change adds an explicit reference to the `exo output --help`
internal reference to custom output usage documentation.