### PR TITLE
Bump calico version to 3.12.0

### DIFF
--- a/cmd/kube_create.go
+++ b/cmd/kube_create.go
@@ -24,7 +24,7 @@ const (
 	kubeDockerVersion = "18.06"
 
 	// kubeCalicoVersion is the version of Calico installed
-	kubeCalicoVersion = "3.6"
+	kubeCalicoVersion = "3.12.0"
 
 	// kubeDefaultTemplate is the template to install Kubernetes on.
 	kubeDefaultTemplate = defaultTemplate
@@ -176,9 +176,7 @@ sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf apply \
 		-f https://docs.projectcalico.org/v{{ .CalicoVersion }}/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
 {{ else }}
 sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf apply \
-		-f https://docs.projectcalico.org/v{{ .CalicoVersion }}/getting-started/kubernetes/installation/hosted/etcd.yaml
-sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf apply \
-		-f https://docs.projectcalico.org/v{{ .CalicoVersion }}/getting-started/kubernetes/installation/hosted/calico.yaml
+        -f https://docs.projectcalico.org/manifests/calico-etcd.yaml
 {{ end }}`,
 	},
 }


### PR DESCRIPTION
Bump calico version to 3.12.0 and update URLs of calico's manifest.

This should fix issue #224

## Testing done

```bash
./exo lab kube create bundes                                                                                                                       <<<
Creating private SSH key
Deploying "bundes" ⠼                                                                                done!
Bootstrapping Kubernetes cluster (can take up to several minutes):
Instance system upgrade... success!
Docker Engine installation... success!
Kubernetes cluster node installation... success!
Kubernetes cluster node initialization... success!

Your Kubernetes cluster is ready. What do now?

1. Install the "kubectl" command, if you don't have it already:

    https://kubernetes.io/docs/tasks/tools/install-kubectl/

2. Execute the following command:

    eval $(exo lab kube env "bundes")

You might want to persist this change by adding it to your shell startup
configuration (e.g. ~/.bashrc, ~/.zshrc).

3. Check that your cluster is reachable:

    kubectl cluster-info

4. When you're done with your cluster, you can either:
* stop it using the "exo lab kube stop" command
* restart it later using the "exo lab kube start" command
* delete it permanently using the "exo lab kube delete" command

 ~/source/cli $ eval $(exo lab kube env "bundes")
 ~/source/cli $ kubectl cluster-info
Kubernetes master is running at https://185.150.8.7:6443
KubeDNS is running at https://185.150.8.7:6443/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy