### PR TITLE
Use non EOL Ubuntu as based distro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV CGO_ENABLED=1
 RUN go build -mod vendor -o exo \
         -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${VCS_REF}"
 
-FROM ubuntu:cosmic
+FROM ubuntu:eoan
 
 ARG VERSION
 ARG VCS_REF


### PR DESCRIPTION
As Ubuntu 18.10 is EOL, we can't install packages using exoscale/cli as base image because Ubuntu mirrors are not available anymore.