### PR TITLE
template register: support output customization

### DIFF
--- a/cmd/template_register.go
+++ b/cmd/template_register.go
@@ -94,7 +94,7 @@ func templateRegister(registerTemplate egoscale.RegisterCustomTemplate, zone str
 	}
 	registerTemplate.ZoneID = z.ID
 
-	resp, err := asyncRequest(registerTemplate, fmt.Sprintf("Registering the template"))
+	resp, err := asyncRequest(registerTemplate, "Registering the template")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/template_show.go
+++ b/cmd/template_show.go
@@ -61,7 +61,12 @@ Supported output template annotations: %s`,
 				return err
 			}
 
-			return output(showTemplate(name, templateFilter, zone.ID))
+			template, err := getTemplateByName(zone.ID, name, templateFilter)
+			if err != nil {
+				return err
+			}
+
+			return output(showTemplate(template))
 		},
 	}
 
@@ -70,12 +75,7 @@ Supported output template annotations: %s`,
 	templateCmd.AddCommand(templateShowCmd)
 }
 
-func showTemplate(id, templateFilter string, zone *egoscale.UUID) (outputter, error) {
-	template, err := getTemplateByName(zone, id, templateFilter)
-	if err != nil {
-		return nil, err
-	}
-
+func showTemplate(template *egoscale.Template) (outputter, error) {
 	out := templateShowOutput{
 		ID:           template.ID.String(),
 		Name:         template.Name,


### PR DESCRIPTION
This change adds support for `vm template register` command output
customization via the global `--output-format` flag. Also, async
commands output support messages (e.g. command waiter message &
termination status) are now written to stderr instead of stdout so
that they can be discarded independently from standard commands
output.