### PR TITLE
Add output customization to create commands

### DIFF
--- a/cmd/affinitygroup_show.go
+++ b/cmd/affinitygroup_show.go
@@ -34,17 +34,17 @@ Supported output template annotations: %s`,
 				return cmd.Usage()
 			}
 
-			return output(showAffinityGroup(args[0]))
+			ag, err := getAffinityGroupByName(args[0])
+			if err != nil {
+				return err
+			}
+
+			return output(showAffinityGroup(ag))
 		},
 	})
 }
 
-func showAffinityGroup(name string) (outputter, error) {
-	ag, err := getAffinityGroupByName(name)
-	if err != nil {
-		return nil, err
-	}
-
+func showAffinityGroup(ag *egoscale.AffinityGroup) (outputter, error) {
 	out := affinityGroupShowOutput{
 		ID:          ag.ID.String(),
 		Name:        ag.Name,

--- a/cmd/iam_apikey_create.go
+++ b/cmd/iam_apikey_create.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/exoscale/egoscale"
@@ -71,7 +72,7 @@ var apiKeyCreateCmd = &cobra.Command{
 			}
 		}
 
-		fmt.Print(`
+		fmt.Fprint(os.Stderr, `
 /!\  Ensure to save your API Secret somewhere,   /!\
 /!\ as there is no way to recover it afterwards. /!\
 

--- a/cmd/privnet_create.go
+++ b/cmd/privnet_create.go
@@ -71,12 +71,7 @@ var privnetCreateCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 
-		newNet, err := privnetCreate(name, desc, zone, startIP.Value(), endIP.Value(), netmask.Value())
-		if err != nil {
-			return err
-		}
-
-		return privnetShow(*newNet)
+		return output(createPrivnet(name, desc, zone, startIP.Value(), endIP.Value(), netmask.Value()))
 	},
 }
 
@@ -89,7 +84,7 @@ func isEmptyArgs(args ...string) bool {
 	return false
 }
 
-func privnetCreate(name, desc, zoneName string, startIP, endIP, netmask net.IP) (*egoscale.Network, error) {
+func createPrivnet(name, desc, zoneName string, startIP, endIP, netmask net.IP) (outputter, error) {
 	zone, err := getZoneByName(zoneName)
 
 	if err != nil {
@@ -114,7 +109,11 @@ func privnetCreate(name, desc, zoneName string, startIP, endIP, netmask net.IP) 
 		return nil, err
 	}
 
-	return resp.(*egoscale.Network), nil
+	if !gQuiet {
+		return showPrivnet(resp.(*egoscale.Network))
+	}
+
+	return nil, nil
 }
 
 func init() {

--- a/cmd/privnet_show.go
+++ b/cmd/privnet_show.go
@@ -34,17 +34,17 @@ Supported output template annotations: %s`,
 				return cmd.Usage()
 			}
 
-			return output(showPrivnet(args[0]))
+			privnet, err := getNetwork(args[0], nil)
+			if err != nil {
+				return err
+			}
+
+			return output(showPrivnet(privnet))
 		},
 	})
 }
 
-func showPrivnet(name string) (outputter, error) {
-	privnet, err := getNetwork(name, nil)
-	if err != nil {
-		return nil, err
-	}
-
+func showPrivnet(privnet *egoscale.Network) (outputter, error) {
 	out := privnetShowOutput{
 		ID:   privnet.ID.String(),
 		Name: privnet.Name,

--- a/cmd/snapshot_delete.go
+++ b/cmd/snapshot_delete.go
@@ -33,7 +33,7 @@ var snapshotDeleteCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			t := task{egoscale.DeleteSnapshot{ID: volume.ID}, fmt.Sprintf("Deleting snapshot %q", volume.Name)}
+			t := task{egoscale.DeleteSnapshot{ID: volume.ID}, fmt.Sprintf("Deleting snapshot %s", volume.ID.String())}
 			tasks = append(tasks, t)
 		}
 

--- a/cmd/snapshot_show.go
+++ b/cmd/snapshot_show.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	humanize "github.com/dustin/go-humanize"
+	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
 )
 
@@ -34,24 +35,22 @@ Supported output template annotations: %s`,
 				return cmd.Usage()
 			}
 
-			return output(showSnapshot(args[0]))
+			snapshot, err := getSnapshotWithNameOrID(args[0])
+			if err != nil {
+				return err
+			}
+
+			return output(showSnapshot(snapshot))
 		},
 	})
 }
 
-func showSnapshot(id string) (outputter, error) {
-	snapshot, err := getSnapshotWithNameOrID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	out := snapshotShowOutput{
+func showSnapshot(snapshot *egoscale.Snapshot) (outputter, error) {
+	return &snapshotShowOutput{
 		ID:       snapshot.ID.String(),
 		Instance: snapshotVMName(*snapshot),
 		Date:     snapshot.Created,
 		State:    snapshot.State,
 		Size:     humanize.IBytes(uint64(snapshot.Size)),
-	}
-
-	return &out, nil
+	}, nil
 }

--- a/cmd/snapshot_show.go
+++ b/cmd/snapshot_show.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	humanize "github.com/dustin/go-humanize"
+	"github.com/spf13/cobra"
+)
+
+type snapshotShowOutput struct {
+	ID       string `json:"id"`
+	Date     string `json:"date"`
+	Instance string `json:"instance"`
+	State    string `json:"state"`
+	Size     string `json:"size"`
+}
+
+func (o *snapshotShowOutput) Type() string { return "Snapshot" }
+func (o *snapshotShowOutput) toJSON()      { outputJSON(o) }
+func (o *snapshotShowOutput) toText()      { outputText(o) }
+func (o *snapshotShowOutput) toTable()     { outputTable(o) }
+
+func init() {
+	snapshotCmd.AddCommand(&cobra.Command{
+		Use:   "show <ID>",
+		Short: "Show a snapshot details",
+		Long: fmt.Sprintf(`This command shows a snapshot details.
+
+Supported output template annotations: %s`,
+			strings.Join(outputterTemplateAnnotations(&snapshotShowOutput{}), ", ")),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return cmd.Usage()
+			}
+
+			return output(showSnapshot(args[0]))
+		},
+	})
+}
+
+func showSnapshot(id string) (outputter, error) {
+	snapshot, err := getSnapshotWithNameOrID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	out := snapshotShowOutput{
+		ID:       snapshot.ID.String(),
+		Instance: snapshotVMName(*snapshot),
+		Date:     snapshot.Created,
+		State:    snapshot.State,
+		Size:     humanize.IBytes(uint64(snapshot.Size)),
+	}
+
+	return &out, nil
+}


### PR DESCRIPTION
This change adds support for output customization through the use of
global `--output-format` flag to all `create|add` commands when possible.