### PR TITLE
add releases for arm 32 and 64 bits

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,18 @@ builds:
 
     goarch:
       - amd64
+      - arm
+      - arm64
+
+    goarm:
+      - 6
+      - 7
+
+    ignore:
+      - goos: openbsd
+        goarch: arm
+      - goos: openbsd
+        goarch: arm64
 
     hooks:
       pre: make manpages completions


### PR DESCRIPTION
This PR enables to run `exo` binary on ARM 6 and ARM 7 (A-xx ) series for 32 bits as well as ARM 64 bits

tested to run on Raspbian, Armbian and similar