### PR TITLE
iam: improve apikey commands output UX

### DIFF
--- a/cmd/iam_apikey.go
+++ b/cmd/iam_apikey.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
@@ -49,6 +50,8 @@ func getAPIKeyByName(name string) (*egoscale.APIKey, error) {
 	case count > 1:
 		return nil, fmt.Errorf(`more than one element found: %d`, count)
 	}
+
+	sort.Strings(apiKeys[0].Operations)
 
 	return &apiKeys[0], nil
 }

--- a/cmd/iam_apikey_create.go
+++ b/cmd/iam_apikey_create.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/exoscale/egoscale"
@@ -56,6 +57,7 @@ var apiKeyCreateCmd = &cobra.Command{
 		}
 
 		apiKey := resp.(*egoscale.APIKey)
+		sort.Strings(apiKey.Operations)
 
 		if !gQuiet {
 			o := apiKeyCreateItemOutput{

--- a/cmd/iam_apikey_list.go
+++ b/cmd/iam_apikey_list.go
@@ -9,11 +9,9 @@ import (
 )
 
 type apiKeyItem struct {
-	Name       string `json:"name"`
-	Key        string `json:"key"`
-	Operations string `json:"operations,omitempty"`
-	Resources  string `json:"resources,omitempty"`
-	Type       string `json:"type"`
+	Key  string `json:"key"`
+	Name string `json:"name"`
+	Type string `json:"type"`
 }
 
 type apiKeyListItemOutput []apiKeyItem
@@ -42,11 +40,9 @@ var apiKeyListCmd = &cobra.Command{
 		o := make(apiKeyListItemOutput, 0, r.Count)
 		for _, i := range r.APIKeys {
 			o = append(o, apiKeyItem{
-				Name:       i.Name,
-				Key:        i.Key,
-				Operations: strings.Join(i.Operations, ", "),
-				Resources:  strings.Join(i.Resources, ", "),
-				Type:       string(i.Type),
+				Name: i.Name,
+				Key:  i.Key,
+				Type: string(i.Type),
 			})
 		}
 


### PR DESCRIPTION
This change improves the UX of the `iam apikey` commands:

- Sort operations list in alphabetical order
- Don't display the operations in the `apikey list` view, as a long list
  of operations produces ugly results