### PR TITLE
config: fix account selector

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -131,7 +131,7 @@ func configCmdRun(cmd *cobra.Command, args []string) error {
 			return saveConfig(viper.ConfigFileUsed(), nil)
 		}
 
-		return addConfigAccount(false)
+		return nil
 	}
 
 	fmt.Println("No Exoscale CLI configuration found")


### PR DESCRIPTION
This change fixes a bug where the configuration account selector would
prompt for a new account input where the user selects the account that
is already the default account in the list (i.e. no change).