### PR TITLE
Fix Snapcraft packaging

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,8 +38,12 @@ parts:
     plugin: make
     source: .
     artifacts:
-      - exo
+      - bin/exo
     build-snaps:
       - go
     build-packages:
       - git
+    make-parameters: [build]
+    override-build: |
+      git submodule update --init --recursive go.mk
+      snapcraftctl build


### PR DESCRIPTION
This change fixes the Snapcraft packaging method which was broken since
the switch to go.mk.

```console
$ snapcraft
Pulling exo
Building exo
Submodule 'go.mk' (https://github.com/exoscale/go.mk.git) registered for path 'go.mk'
Cloning into '/home/marc/cli/parts/exo/build/go.mk'...
Submodule path 'go.mk': checked out '5b6c0ef1a35e89820cdfb6c62ce4514ac86d240f'
make build -j1
test -d /home/marc/cli/parts/exo/build/bin || mkdir /home/marc/cli/parts/exo/build/bin
test -d vendor || mkdir vendor
go mod vendor
/snap/bin/go build                                       \
	                        \
	-ldflags "-X main.commit=4b82b89 -X main.branch=master -X main.buildDate=2020-05-05T08:06:07+0000 -X main.version=1.12.0"                                \
	                                    \
	-mod vendor                         \
	-o /home/marc/cli/parts/exo/build/bin/exo \
	.
Staging exo
Priming exo
Determining the version from the project repo (version: git).
The version has been set to 'v1.12.0-dirty'
Snapping 'exoscale-cli' |
Snapped exoscale-cli_v1.12.0-dirty_amd64.snap
```