### PR TITLE
Make certificates work on Windows again

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,7 +30,7 @@ builds:
         goarch: arm64
 
     hooks:
-      pre: make manpages completions
+      pre: make manpages completions certificates
 
 archives:
   - id: windows
@@ -38,6 +38,7 @@ archives:
       - goos: windows
         format: zip
     files:
+      - sos-certs.pem
       - LICENSE
       - contrib/completion/**/*
       - manpage/*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,7 +30,7 @@ builds:
         goarch: arm64
 
     hooks:
-      pre: make manpages completions certificates
+      pre: make manpages completions sos-certificates
 
 archives:
   - id: windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 
 
+## 1.12.0
+
+### New
+
+* Add [`go.mk`](https://github.com/exoscale/go.mk) support for exo cli (#233)
+* Add `exo vm snapshot export` command to export an instant snapshot of a volume (#234)
+* Add `exo limits` command to show the safety limits currently enforced on your account (#232)
+* Add support to run `exo` binary on arm architecture 32/64 bits (#230)
+
+### Bug Fixes
+
+* Fix account selector in `exo config` (#241)
+* Fix panic when `--quiet` flag is used (#236)
+
+### Changes
+
+* The `--output-format|-O` flag is no longer required with the `--output-template` flag (#239)
+* Improve `apikey` commands output UX (#231)
+
+
 ## 1.11.0
 
 ### New

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ include go.mk/init.mk
 
 GO_BIN_OUTPUT_NAME := exo
 
+GORELEASER_EXTRA_ARGS ?=
+
 .PHONY: docker
 docker:
 	docker build -f $< \
@@ -15,8 +17,13 @@ docker:
 docker-push:
 	docker push exoscale/cli:latest && docker push exoscale/cli:${VERSION}
 
-certificates:
-    curl https://www.exoscale.com/static/files/sos-certs.pem --output sos-certs.pem
+.PHONY: sos-certificates
+sos-certificates:
+	curl -sL --output sos-certs.pem https://www.exoscale.com/static/files/sos-certs.pem
+
+.PHONY: release
+release: sos-certificates
+	goreleaser run --rm-dist $(GORELEASER_EXTRA_ARGS)
 
 manpage:
 	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ docker:
 docker-push:
 	docker push exoscale/cli:latest && docker push exoscale/cli:${VERSION}
 
+certificates:
+    curl https://www.exoscale.com/static/files/sos-certs.pem --output sos-certs.pem
+
 manpage:
 	mkdir -p $@
 

--- a/cmd/sos.go
+++ b/cmd/sos.go
@@ -74,7 +74,7 @@ func newSOSClient(certsFile string) (*sosClient, error) {
 	if certsFile == "" && runtime.GOOS == "windows" {
 		// Check if the directory of the "exo" executable contains a file named "sos-certs.pem"
 		// to load the certificate chain from. This is done to work around Golang issue #16736
-		// on Windows ( https://github.com/golang/go/issues/16736 )
+		// on Windows (https://github.com/golang/go/issues/16736)
 		path, err := os.Executable()
 		if err == nil {
 			dir, err := filepath.Abs(filepath.Dir(path))

--- a/cmd/sos.go
+++ b/cmd/sos.go
@@ -90,7 +90,7 @@ executable. Please run the "exo sos help" command for more information.`
 	}
 
 	tmpCertsFile := filepath.Join(dir, "sos-certs.pem")
-	if stat, err := os.Stat(tmpCertsFile); err != nil || stat.IsDir() != false {
+	if stat, err := os.Stat(tmpCertsFile); err != nil || stat.IsDir() {
 		_, _ = fmt.Fprintln(os.Stderr, warningMessage)
 		os.Exit(1)
 	}

--- a/cmd/sos.go
+++ b/cmd/sos.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"github.com/labstack/gommon/log"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -66,9 +65,10 @@ type sosClient struct {
 }
 
 func sosCmdWindowsCertFileError() {
-	log.Warn(
-		"It seems you are running on Windows and your sos-certs.pem file is missing.\n" +
-			"Please download and extract all files from the exo cli release, not just the executable.\n" +
+	fmt.Fprintln(os.Stderr,
+		"*** WARNING ***\n"+
+			"It seems you are running on Windows and your sos-certs.pem file is missing.\n"+
+			"Please download and extract all files from the exo cli release, not just the executable.\n"+
 			"Please see the 'exo sos help' command for more details.")
 }
 
@@ -81,15 +81,15 @@ func sosCmdGetWindowsCertFile(certsFile string) string {
 	}
 	path, err := os.Executable()
 	if err != nil {
-		log.Warn("Could not determine executable path, continuing without cert path.")
-		log.Warn(err)
+		fmt.Fprintln(os.Stderr, "Could not determine executable path, continuing without cert path.")
+		fmt.Fprintln(os.Stderr, err)
 		return certsFile
 	}
 
 	dir, err := filepath.Abs(filepath.Dir(path))
 	if err != nil {
 		sosCmdWindowsCertFileError()
-		log.Warn(err)
+		fmt.Fprintln(os.Stderr, err)
 		return certsFile
 	}
 
@@ -97,7 +97,7 @@ func sosCmdGetWindowsCertFile(certsFile string) string {
 	stat, err := os.Stat(tmpCertsFile)
 	if err != nil || stat.IsDir() != false {
 		sosCmdWindowsCertFileError()
-		log.Warn(err)
+		fmt.Fprintln(os.Stderr, err)
 		return certsFile
 	}
 

--- a/cmd/sos.go
+++ b/cmd/sos.go
@@ -58,11 +58,14 @@ func newSOSClient(certsFile string) (*sosClient, error) {
 	)
 
 	if certsFile == "" {
+		// Check if the directory of the "exo" executable contains a file named "sos-certs.pem"
+		// to load the certificate chain from. This is done to work around Golang issue #16736
+		// on Windows ( https://github.com/golang/go/issues/16736 )
 		path, err := os.Executable()
 		if err == nil {
 			dir, err := filepath.Abs(filepath.Dir(path))
 			if err == nil {
-				tmpCertsFile := filepath.FromSlash(dir + "/sos-certs.pem")
+				tmpCertsFile := filepath.Join(dir, "sos-certs.pem")
 				fmt.Println(tmpCertsFile)
 				stat, err := os.Stat(tmpCertsFile)
 				if err == nil && stat.IsDir() == false {

--- a/cmd/sos.go
+++ b/cmd/sos.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -57,7 +58,7 @@ func newSOSClient(certsFile string) (*sosClient, error) {
 		err error
 	)
 
-	if certsFile == "" {
+	if certsFile == "" && runtime.GOOS == "windows" {
 		// Check if the directory of the "exo" executable contains a file named "sos-certs.pem"
 		// to load the certificate chain from. This is done to work around Golang issue #16736
 		// on Windows ( https://github.com/golang/go/issues/16736 )

--- a/cmd/sos.go
+++ b/cmd/sos.go
@@ -34,7 +34,7 @@ var sosCmdLongHelp = func() string {
 IMPORTANT: Due to a bug in the Microsoft Windows support in the Go
 programming language ( https://github.com/golang/go/issues/16736 ) Windows
 users are required to extract the sos-certs.pem file next to their exo.exe
-file from the archive. You can obtain a fresh copy of the exo cli from
+file from the archive. You can obtain a fresh copy of the exo CLI from
 this address:
 
     https://github.com/exoscale/cli/releases

--- a/cmd/sos.go
+++ b/cmd/sos.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -55,6 +56,21 @@ func newSOSClient(certsFile string) (*sosClient, error) {
 		c   sosClient
 		err error
 	)
+
+	if certsFile == "" {
+		path, err := os.Executable()
+		if err == nil {
+			dir, err := filepath.Abs(filepath.Dir(path))
+			if err == nil {
+				tmpCertsFile := filepath.FromSlash(dir + "/sos-certs.pem")
+				fmt.Println(tmpCertsFile)
+				stat, err := os.Stat(tmpCertsFile)
+				if err == nil && stat.IsDir() == false {
+					certsFile = tmpCertsFile
+				}
+			}
+		}
+	}
 
 	if certsFile != "" {
 		c.certPool = x509.NewCertPool()

--- a/cmd/sos.go
+++ b/cmd/sos.go
@@ -26,7 +26,7 @@ const (
 )
 
 // sosCmd represents the sos command
-var long = func() string {
+var sosCmdLongHelp = func() string {
 	var long = "Manage Exoscale Object Storage (SOS)"
 
 	if runtime.GOOS == "windows" {

--- a/cmd/sos.go
+++ b/cmd/sos.go
@@ -65,7 +65,7 @@ type sosClient struct {
 }
 
 func sosCmdWindowsCertFileError() {
-	fmt.Fprintln(os.Stderr,
+	_, _ = fmt.Fprintln(os.Stderr,
 		"*** WARNING ***\n"+
 			"It seems you are running on Windows and your sos-certs.pem file is missing.\n"+
 			"Please download and extract all files from the exo cli release, not just the executable.\n"+
@@ -81,15 +81,15 @@ func sosCmdGetWindowsCertFile(certsFile string) string {
 	}
 	path, err := os.Executable()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Could not determine executable path, continuing without cert path.")
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, "Could not determine executable path, continuing without cert path.")
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		return certsFile
 	}
 
 	dir, err := filepath.Abs(filepath.Dir(path))
 	if err != nil {
 		sosCmdWindowsCertFileError()
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		return certsFile
 	}
 
@@ -97,7 +97,7 @@ func sosCmdGetWindowsCertFile(certsFile string) string {
 	stat, err := os.Stat(tmpCertsFile)
 	if err != nil || stat.IsDir() != false {
 		sosCmdWindowsCertFileError()
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		return certsFile
 	}
 


### PR DESCRIPTION
This pull request implements checking the directory of the `exo` binary for a file named `sos-certs.pem` and load that if no `--certs-file` flag has been supplied.

This works around golang/go#16736 which prevents `exo sos` commands from working without explicitly passing a certificate chain.

~~Note that the build system still needs to be adapted to bundle `sos-certs.pem` into the ZIP file on Windows.~~

A separate PR #245 has been submitted as well which only warns the user.