### PR TITLE
Add "exo environment" documentation command

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -80,7 +80,7 @@ const (
 	apiVersion               = "v1"
 	defaultEndpoint          = "https://api.exoscale.ch/" + apiVersion
 	defaultConfigFileName    = "exoscale"
-	defaultTemplate          = "Linux Ubuntu 18.04 LTS 64-bit"
+	defaultTemplate          = "Linux Ubuntu 20.04 LTS 64-bit"
 	defaultSosEndpoint       = "https://sos-{zone}.exo.io"
 	defaultRunstatusEndpoint = "https://api.runstatus.com"
 	defaultZone              = "ch-dk-2"

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(&cobra.Command{
+		Use:   "environment",
+		Short: "Environment variables usage",
+		Long: `The exo CLI tool allows users to override some account configuration settings
+by specifying shell environment variables. Here is the list of environment
+variables supported:
+
+  * EXOSCALE_API_KEY: the Exoscale client API key
+  * EXOSCALE_API_SECRET: the Exoscale client API secret
+  * EXOSCALE_API_ENDPOINT: the Exoscale (Compute) API endpoint to use
+
+Note: to override the current profile API credentials, *both* EXOSCALE_API_KEY
+and EXOSCALE_API_SECRET variables have to be set.
+`},
+	)
+
+	RootCmd.AddCommand(&cobra.Command{
+		Use:    "env",
+		Hidden: true,
+		Run: func(_ *cobra.Command, _ []string) {
+			fmt.Printf("export EXOSCALE_API_KEY=%q\n", gCurrentAccount.Key)
+			fmt.Printf("export EXOSCALE_API_SECRET=%q\n", gCurrentAccount.Secret)
+			fmt.Printf("export EXOSCALE_API_ENDPOINT=%q\n", gCurrentAccount.Endpoint)
+		},
+	})
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,34 +138,35 @@ func initConfig() {
 		}
 	}
 
-	// an attempt to mimic existing behaviours
-
 	envEndpoint := readFromEnv(
+		"EXOSCALE_API_ENDPOINT",
+		"EXOSCALE_COMPUTE_API_ENDPOINT",
 		"EXOSCALE_ENDPOINT",
 		"EXOSCALE_COMPUTE_ENDPOINT",
 		"CLOUDSTACK_ENDPOINT")
 
 	envKey := readFromEnv(
-		"EXOSCALE_KEY",
 		"EXOSCALE_API_KEY",
+		"EXOSCALE_KEY",
 		"CLOUDSTACK_KEY",
 		"CLOUDSTACK_API_KEY",
 	)
 
 	envSecret := readFromEnv(
-		"EXOSCALE_SECRET",
 		"EXOSCALE_API_SECRET",
+		"EXOSCALE_SECRET",
 		"EXOSCALE_SECRET_KEY",
 		"CLOUDSTACK_SECRET",
 		"CLOUDSTACK_SECRET_KEY",
 	)
 
 	envSosEndpoint := readFromEnv(
+		"EXOSCALE_STORAGE_API_ENDPOINT",
 		"EXOSCALE_SOS_ENDPOINT",
 	)
 
 	if envKey != "" && envSecret != "" {
-		gCurrentAccount.Name = "environment variables"
+		gCurrentAccount.Name = "<environment variables>"
 		gCurrentAccount.Account = "unknown"
 		gCurrentAccount.Key = envKey
 		gCurrentAccount.Secret = envSecret


### PR DESCRIPTION
This change introduces a new `exo environment` command describing the
supported environment variables and their behavior, as well as an
undocumented `exo env` command that can be used to export environment
variables using the configured account profiles.