### PR TITLE
vm: new "update" command

### DIFF
--- a/cmd/instance_pool_create.go
+++ b/cmd/instance_pool_create.go
@@ -113,13 +113,9 @@ Supported output template annotations: %s`,
 		userData := ""
 
 		if userDataPath != "" {
-			userData, err = getUserData(userDataPath)
+			userData, err = getUserDataFromFile(userDataPath)
 			if err != nil {
 				return err
-			}
-
-			if len(userData) >= maxUserDataLength {
-				return fmt.Errorf("user-data maximum allowed length is %d bytes", maxUserDataLength)
 			}
 		}
 

--- a/cmd/instance_pool_update.go
+++ b/cmd/instance_pool_update.go
@@ -71,13 +71,9 @@ Supported output template annotations: %s`,
 
 		userData := ""
 		if userDataPath != "" {
-			userData, err = getUserData(userDataPath)
+			userData, err = getUserDataFromFile(userDataPath)
 			if err != nil {
 				return err
-			}
-
-			if len(userData) >= maxUserDataLength {
-				return fmt.Errorf("user-data maximum allowed length is %d bytes", maxUserDataLength)
 			}
 		}
 

--- a/cmd/vm.go
+++ b/cmd/vm.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -10,6 +11,8 @@ import (
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
 )
+
+const maxUserDataLength = 32768
 
 // vmCmd represents the vm command
 var vmCmd = &cobra.Command{
@@ -94,6 +97,20 @@ func deleteKeyPair(vmID egoscale.UUID) error {
 	}
 
 	return nil
+}
+
+func getUserDataFromFile(path string) (string, error) {
+	buf, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	userData := base64.StdEncoding.EncodeToString(buf)
+
+	if len(userData) >= maxUserDataLength {
+		return "", fmt.Errorf("user-data maximum allowed length is %d bytes", maxUserDataLength)
+	}
+
+	return userData, nil
 }
 
 func init() {

--- a/cmd/vm_create.go
+++ b/cmd/vm_create.go
@@ -1,17 +1,14 @@
 package cmd
 
 import (
-	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"strings"
 
-	"github.com/exoscale/cli/utils"
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
-)
 
-const maxUserDataLength = 32768
+	"github.com/exoscale/cli/utils"
+)
 
 // vmCreateCmd represents the create command
 var vmCreateCmd = &cobra.Command{
@@ -31,21 +28,16 @@ var vmCreateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
 		userDataPath, err := cmd.Flags().GetString("cloud-init-file")
 		if err != nil {
 			return err
 		}
-
 		userData := ""
-
 		if userDataPath != "" {
-			userData, err = getUserData(userDataPath)
+			userData, err = getUserDataFromFile(userDataPath)
 			if err != nil {
 				return err
-			}
-
-			if len(userData) >= maxUserDataLength {
-				return fmt.Errorf("user-data maximum allowed length is %d bytes", maxUserDataLength)
 			}
 		}
 
@@ -264,15 +256,6 @@ func getAffinityGroup(params []string) ([]egoscale.UUID, error) {
 	}
 
 	return ids, nil
-}
-
-func getUserData(userDataPath string) (string, error) {
-	buff, err := ioutil.ReadFile(userDataPath)
-	if err != nil {
-		return "", err
-	}
-
-	return base64.StdEncoding.EncodeToString(buff), nil
 }
 
 func createVM(deploys []egoscale.DeployVirtualMachine) ([]egoscale.VirtualMachine, []error) {

--- a/cmd/vm_edit.go
+++ b/cmd/vm_edit.go
@@ -57,9 +57,11 @@ var vmEditCmd = &cobra.Command{
 			if !gQuiet {
 				fmt.Println("Virtual machine updated successfully")
 			}
+
+			return nil
 		}
 
-		return nil
+		return cmd.Usage()
 	},
 }
 

--- a/cmd/vm_edit.go
+++ b/cmd/vm_edit.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/exoscale/egoscale"
+	"github.com/spf13/cobra"
+)
+
+var vmEditCmd = &cobra.Command{
+	Use:   "edit <name|ID>",
+	Short: "Edit virtual machine properties",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var (
+			vmEdit egoscale.UpdateVirtualMachine
+			edited bool
+		)
+
+		if len(args) != 1 {
+			return cmd.Usage()
+		}
+
+		vm, err := getVirtualMachineByNameOrID(args[0])
+		if err != nil {
+			return err
+		}
+		vmEdit.ID = vm.ID
+
+		name, err := cmd.Flags().GetString("name")
+		if err != nil {
+			return err
+		}
+		if cmd.Flags().Changed("name") {
+			vmEdit.Name = name
+			vmEdit.DisplayName = name
+			edited = true
+		}
+
+		userDataPath, err := cmd.Flags().GetString("cloud-init-file")
+		if err != nil {
+			return err
+		}
+		if userDataPath != "" {
+			vmEdit.UserData, err = getUserDataFromFile(userDataPath)
+			if err != nil {
+				return err
+			}
+			edited = true
+		}
+
+		if edited {
+			_, err = cs.RequestWithContext(gContext, &vmEdit)
+			if err != nil {
+				return fmt.Errorf("unable to update virtual machine: %s", err)
+			}
+
+			if !gQuiet {
+				fmt.Println("Virtual machine updated successfully")
+			}
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	vmEditCmd.Flags().String("name", "", "display name")
+	vmEditCmd.Flags().String("cloud-init-file", "", "path to a cloud-init user data file")
+	vmCmd.AddCommand(vmEditCmd)
+}

--- a/cmd/vm_update.go
+++ b/cmd/vm_update.go
@@ -7,9 +7,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var vmEditCmd = &cobra.Command{
-	Use:   "edit <name|ID>",
-	Short: "Edit virtual machine properties",
+var vmUpdateCmd = &cobra.Command{
+	Use:   "update <name|ID>",
+	Short: "Update virtual machine properties",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var (
 			vmEdit egoscale.UpdateVirtualMachine
@@ -66,7 +66,7 @@ var vmEditCmd = &cobra.Command{
 }
 
 func init() {
-	vmEditCmd.Flags().String("name", "", "display name")
-	vmEditCmd.Flags().String("cloud-init-file", "", "path to a cloud-init user data file")
-	vmCmd.AddCommand(vmEditCmd)
+	vmUpdateCmd.Flags().String("name", "", "display name")
+	vmUpdateCmd.Flags().String("cloud-init-file", "", "path to a cloud-init user data file")
+	vmCmd.AddCommand(vmUpdateCmd)
 }


### PR DESCRIPTION
This change introduces a new `exo vm update` command enabling users to
edit some Compute instance properties, such as the display/hostname and
the cloud-init user data.

Besides, a new `exo vm show --user-data` flag now returns the current cloud-init user data configuration of a Compute instance.