### PR TITLE
ssh: fix bug with username-less templates

### DIFF
--- a/cmd/vm_create.go
+++ b/cmd/vm_create.go
@@ -168,13 +168,13 @@ var vmCreateCmd = &cobra.Command{
 
 		if !gQuiet {
 			fmt.Printf(`
-What do now?
+What to do now?
 
 1. Connect to the machine
 
 > exo ssh %s
 `, r[0].Name)
-			printSSHConnectSTR(sshinfo)
+			fmt.Println(strings.Join(buildSSHCommand(sshinfo), " "))
 			fmt.Printf(`
 2. Put the SSH configuration into ".ssh/config"
 


### PR DESCRIPTION
This change fixes a bug in the SSH-related sections of the CLI, where an
error message was reported when dealing with Compute instances based on
a custom template for which a username is not set in its metadata
(setting a username is not mandatory).

Before:

    $ exo ssh --print my-instance
    error: missing username information in Template "58f032e5-20db-425c-8108-37f0b764cd1a"

After:

    $ exo ssh --print my-instance
    ssh -i "/Users/marc/.exoscale/instances/8bc37224-03af-46c5-9e30-ca4cac62a887/id_rsa" 159.100.242.169

And for instances using a template specifying a username:

    $ exo ssh --print vm
    ssh -i "/Users/marc/.exoscale/instances/811d7ce7-b8e8-401c-b9ed-797859e885f0/id_rsa" -l ubuntu 185.19.29.144

Also, a bit of refactoring in `ssh` related commands.