### PR TITLE
Fix Windows configuration path

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"os/user"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/exoscale/egoscale"
@@ -239,7 +240,7 @@ func initConfig() {
 
 	// All the stored data (e.g. ssh keys) will be put next to the config file.
 	gConfigFilePath = viper.ConfigFileUsed()
-	gConfigFolder = path.Dir(gConfigFilePath)
+	gConfigFolder = filepath.Dir(gConfigFilePath)
 
 	if err := viper.Unmarshal(config); err != nil {
 		log.Fatal(fmt.Errorf("couldn't read config: %s", err))


### PR DESCRIPTION
Using `filepath` is more appropriate to manipulate file, folder...etc. instead of `path`

This PR solve the issue on Windows to create the Exoscale CLI configuration in the correct directory.