### PR TITLE
config: fix subcommand config settings leaking

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -15,7 +15,6 @@ import (
 	"github.com/go-ini/ini"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 type config struct {
@@ -128,8 +127,8 @@ func configCmdRun(cmd *cobra.Command, args []string) error {
 
 		if strings.TrimSuffix(selectedAccount, defaultAccountMark) != gAllAccount.DefaultAccount {
 			fmt.Printf("Setting default account to [%s]\n", selectedAccount)
-			viper.Set("defaultAccount", selectedAccount)
-			return saveConfig(viper.ConfigFileUsed(), nil)
+			gConfig.Set("defaultAccount", selectedAccount)
+			return saveConfig(gConfig.ConfigFileUsed(), nil)
 		}
 
 		return nil
@@ -234,16 +233,16 @@ func saveConfig(filePath string, newAccounts *config) error {
 		}
 	}
 
-	viper.SetConfigType("toml")
-	viper.SetConfigFile(filePath)
+	gConfig.SetConfigType("toml")
+	gConfig.SetConfigFile(filePath)
 
-	viper.Set("accounts", accounts)
+	gConfig.Set("accounts", accounts)
 
-	if err := viper.WriteConfig(); err != nil {
+	if err := gConfig.WriteConfig(); err != nil {
 		return err
 	}
 
-	conf.DefaultAccount = viper.Get("defaultAccount").(string)
+	conf.DefaultAccount = gConfig.Get("defaultAccount").(string)
 	gAllAccount = conf
 
 	return nil
@@ -330,7 +329,7 @@ func importCloudstackINI(option, csPath, cfgPath string) error {
 
 		if option == "some" {
 			if !askQuestion(fmt.Sprintf("Do you want to import [%s] %s?", acc.Name(), acc.Key("key").String())) {
-				if viper.Get("defaultAccount") == nil {
+				if gConfig.Get("defaultAccount") == nil {
 					setdefaultAccount = i + 1
 				}
 				continue
@@ -396,7 +395,7 @@ func importCloudstackINI(option, csPath, cfgPath string) error {
 
 		if i == setdefaultAccount || isDefault {
 			config.DefaultAccount = csAccount.Name
-			viper.Set("defaultAccount", csAccount.Name)
+			gConfig.Set("defaultAccount", csAccount.Name)
 		}
 		gAllAccount = config
 	}
@@ -414,7 +413,7 @@ func createConfigFile(fileName string) (string, error) {
 
 	filepath := path.Join(gConfigFolder, fileName+".toml")
 
-	if viper.ConfigFileUsed() == "" {
+	if gConfig.ConfigFileUsed() == "" {
 		if _, err := os.Stat(filepath); !os.IsNotExist(err) {
 			return "", fmt.Errorf("%q exists already", filepath)
 		}

--- a/cmd/config_add.go
+++ b/cmd/config_add.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func init() {
@@ -23,10 +22,10 @@ func init() {
 			config := &config{Accounts: []account{*newAccount}}
 			if askQuestion("Set [" + newAccount.Name + "] as default account?") {
 				config.DefaultAccount = newAccount.Name
-				viper.Set("defaultAccount", newAccount.Name)
+				gConfig.Set("defaultAccount", newAccount.Name)
 			}
 
-			return saveConfig(viper.ConfigFileUsed(), config)
+			return saveConfig(gConfig.ConfigFileUsed(), config)
 		},
 	})
 }
@@ -37,14 +36,14 @@ func addConfigAccount(firstRun bool) error {
 		err    error
 	)
 
-	filePath := viper.ConfigFileUsed()
+	filePath := gConfig.ConfigFileUsed()
 
 	if firstRun {
 		if filePath, err = createConfigFile(defaultConfigFileName); err != nil {
 			return err
 		}
 
-		viper.SetConfigFile(filePath)
+		gConfig.SetConfigFile(filePath)
 	}
 
 	newAccount, err := promptAccountInformation()
@@ -53,7 +52,7 @@ func addConfigAccount(firstRun bool) error {
 	}
 	config.DefaultAccount = newAccount.Name
 	config.Accounts = []account{*newAccount}
-	viper.Set("defaultAccount", newAccount.Name)
+	gConfig.Set("defaultAccount", newAccount.Name)
 
 	if len(config.Accounts) == 0 {
 		return nil

--- a/cmd/config_delete.go
+++ b/cmd/config_delete.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // deleteCmd represents the delete command
@@ -48,7 +47,7 @@ var configDeleteCmd = &cobra.Command{
 
 		gAllAccount.Accounts = append(gAllAccount.Accounts[:pos], gAllAccount.Accounts[pos+1:]...)
 
-		if err := saveConfig(viper.ConfigFileUsed(), nil); err != nil {
+		if err := saveConfig(gConfig.ConfigFileUsed(), nil); err != nil {
 			return err
 		}
 

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // setCmd represents the set command
@@ -16,16 +15,16 @@ var configSetCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 		if gAllAccount == nil {
-			return fmt.Errorf("no accounts are defined")
+			return fmt.Errorf("no accounts configured")
 		}
 
 		if a := getAccountByName(args[0]); a == nil {
 			return fmt.Errorf("account %q does not exist", args[0])
 		}
 
-		viper.Set("defaultAccount", args[0])
+		gConfig.Set("defaultAccount", args[0])
 
-		if err := saveConfig(viper.ConfigFileUsed(), nil); err != nil {
+		if err := saveConfig(gConfig.ConfigFileUsed(), nil); err != nil {
 			return err
 		}
 

--- a/cmd/config_show.go
+++ b/cmd/config_show.go
@@ -35,7 +35,7 @@ Supported output template annotations: %s`,
 		Aliases: gShowAlias,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if gAllAccount == nil {
-				return fmt.Errorf("no accounts are defined")
+				return fmt.Errorf("no accounts configured")
 			}
 			name := gCurrentAccount.AccountName()
 


### PR DESCRIPTION
This change fixes a bug where the `exo x` subcommand's config registry
settings where leaking into the main CLI's one.