### PR TITLE
Dockerfile: Make Docker image smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION
 ARG VCS_REF
 
 ENV CGO_ENABLED=0
-RUN go build -mod vendor -o exo \
+RUN go build -a -mod vendor -o exo \
         -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${VCS_REF}"
 
 FROM alpine:3.12.0 as ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-buster as builder
+FROM golang:1.14.4-alpine as builder
 
 ADD . /src
 WORKDIR /src
@@ -10,7 +10,14 @@ ENV CGO_ENABLED=0
 RUN go build -mod vendor -o exo \
         -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${VCS_REF}"
 
-FROM linuxkit/ca-certificates:v0.8
+FROM alpine:3.12.0 as ca-certificates
+
+RUN apk add ca-certificates
+
+FROM scratch
+
+WORKDIR /
+COPY --from=ca-certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ARG VERSION
 ARG VCS_REF

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.4-alpine as builder
+FROM golang:1.14-alpine as builder
 
 ADD . /src
 WORKDIR /src
@@ -12,7 +12,7 @@ RUN go build -a -mod vendor -o exo \
 
 FROM alpine:3.12.0 as ca-certificates
 
-RUN apk add ca-certificates
+RUN apk add --no-cache ca-certificates
 
 FROM scratch
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ WORKDIR /src
 ARG VERSION
 ARG VCS_REF
 
-ENV CGO_ENABLED=1
+ENV CGO_ENABLED=0
 RUN go build -mod vendor -o exo \
         -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${VCS_REF}"
 
-FROM ubuntu:eoan
+FROM linuxkit/ca-certificates:v0.8
 
 ARG VERSION
 ARG VCS_REF
@@ -25,15 +25,6 @@ LABEL org.label-schema.build-date=${BUILD_DATE} \
       org.label-schema.description="Exoscale CLI" \
       org.label-schema.url="https://exoscale.github.io/cli" \
       org.label-schema.schema-version="1.0"
-
-RUN set -xe \
- && apt-get update -q \
- && apt-get upgrade -q -y \
- && apt-get install -q -y \
-        ca-certificates \
- && apt-get autoremove -y \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /src/exo /
 ENTRYPOINT ["/exo"]

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ x-cmd:
 
 .PHONY: docker
 docker:
-	docker build -f $< \
+	docker build  \
 		-t exoscale/cli \
 		--build-arg VERSION="${VERSION}" \
 		--build-arg VCS_REF="${GIT_REVISION}" \


### PR DESCRIPTION
This PR referring to https://github.com/exoscale/cli/pull/254, to make the docker image size smaller.
Fix #254 