### PR TITLE
refactor: Use alpine as cli base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,9 @@ ENV CGO_ENABLED=0
 RUN go build -a -mod vendor -o exo \
         -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${VCS_REF}"
 
-FROM alpine:3.12.0 as ca-certificates
-
-RUN apk add --no-cache ca-certificates
-
-FROM scratch
+FROM alpine:3.12
 
 WORKDIR /
-COPY --from=ca-certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ARG VERSION
 ARG VCS_REF
@@ -32,6 +27,8 @@ LABEL org.label-schema.build-date=${BUILD_DATE} \
       org.label-schema.description="Exoscale CLI" \
       org.label-schema.url="https://exoscale.github.io/cli" \
       org.label-schema.schema-version="1.0"
+
+RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /src/exo /
 ENTRYPOINT ["/exo"]


### PR DESCRIPTION
The alpine base image still provides a shell in the container. This
makes it much easier to use the image in a CI environment or as an init
container in a k8s pod.
The added utility should be worth the extra 6Mb in image size.

```
REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
cli                                test                d9c1593fd3bf        5 minutes ago       26.7MB
exoscale/cli                       latest              ec194dd39256        19 hours ago        20.8MB
```