### PR TITLE
ssh: fix bogus SSH private key file quoting

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -126,7 +126,7 @@ func buildSSHCommand(info *sshInfo) []string {
 	cmd := []string{"ssh"}
 
 	if _, err := os.Stat(info.sshKeys); err == nil {
-		cmd = append(cmd, "-i", fmt.Sprintf("%q", info.sshKeys))
+		cmd = append(cmd, "-i", info.sshKeys)
 	}
 
 	if info.opts != "" {


### PR DESCRIPTION
This change fixes a bug in the `exo ssh` command where the path to the
SSH private key was misquoted, resulting in the generated ssh command
not able to use the file.