### PR TITLE
nlb: support referencing resources by name or ID

### DIFF
--- a/cmd/nlb.go
+++ b/cmd/nlb.go
@@ -1,6 +1,12 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"context"
+	"fmt"
+
+	"github.com/exoscale/egoscale"
+	"github.com/spf13/cobra"
+)
 
 var nlbCmd = &cobra.Command{
 	Use:   "nlb",
@@ -9,4 +15,20 @@ var nlbCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(nlbCmd)
+}
+
+// lookupNLB attempts to look up an NLB resource by name or ID.
+func lookupNLB(ctx context.Context, zone, ref string) (*egoscale.NetworkLoadBalancer, error) {
+	nlbs, err := cs.ListNetworkLoadBalancers(ctx, zone)
+	if err != nil {
+		return nil, fmt.Errorf("unable to list Network Load Balancers in zone %s: %v", zone, err)
+	}
+
+	for _, nlb := range nlbs {
+		if nlb.ID == ref || nlb.Name == ref {
+			return nlb, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Network Load Balancer %q not found", ref)
 }

--- a/cmd/nlb.go
+++ b/cmd/nlb.go
@@ -30,5 +30,5 @@ func lookupNLB(ctx context.Context, zone, ref string) (*egoscale.NetworkLoadBala
 		}
 	}
 
-	return nil, fmt.Errorf("Network Load Balancer %q not found", ref)
+	return nil, fmt.Errorf("Network Load Balancer %q not found", ref) // nolint:golint
 }

--- a/cmd/nlb_create.go
+++ b/cmd/nlb_create.go
@@ -42,7 +42,7 @@ var nlbCreateCmd = &cobra.Command{
 		}
 
 		if !gQuiet {
-			return output(showNLB(nlb.ID, zone))
+			return output(showNLB(zone, nlb.ID))
 		}
 
 		return nil

--- a/cmd/nlb_service_add.go
+++ b/cmd/nlb_service_add.go
@@ -10,7 +10,7 @@ import (
 )
 
 var nlbServiceAddCmd = &cobra.Command{
-	Use:   "add <NLB ID> <name>",
+	Use:   "add <NLB name | ID> <service name>",
 	Short: "Add a service to a Network Load Balancer",
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 2 {
@@ -32,8 +32,8 @@ var nlbServiceAddCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var (
-			nlbID = args[0]
-			name  = args[1]
+			nlbRef = args[0]
+			name   = args[1]
 		)
 
 		zone, err := cmd.Flags().GetString("zone")
@@ -107,8 +107,8 @@ var nlbServiceAddCmd = &cobra.Command{
 			return err
 		}
 
-		ctx := apiv2.WithEndpoint(gContext, apiv2.NewReqEndpoint(gCurrentAccount.Environment, ""))
-		nlb, err := cs.GetNetworkLoadBalancer(ctx, zone, nlbID)
+		ctx := apiv2.WithEndpoint(gContext, apiv2.NewReqEndpoint(gCurrentAccount.Environment, zone))
+		nlb, err := lookupNLB(ctx, zone, nlbRef)
 		if err != nil {
 			return err
 		}
@@ -135,7 +135,7 @@ var nlbServiceAddCmd = &cobra.Command{
 		}
 
 		if !gQuiet {
-			return output(showNLBService(nlbID, svc.ID, zone))
+			return output(showNLBService(zone, nlb.ID, svc.ID))
 		}
 
 		return nil

--- a/cmd/nlb_service_delete.go
+++ b/cmd/nlb_service_delete.go
@@ -9,7 +9,7 @@ import (
 )
 
 var nlbServiceDeleteCmd = &cobra.Command{
-	Use:     "delete <NLB ID> <ID>",
+	Use:     "delete <NLB name | ID> <service name | ID>",
 	Short:   "Delete a Network Load Balancer service",
 	Aliases: gRemoveAlias,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -23,8 +23,8 @@ var nlbServiceDeleteCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var (
-			nlbID = args[0]
-			svcID = args[1]
+			nlbRef = args[0]
+			svcRef = args[1]
 		)
 
 		zone, err := cmd.Flags().GetString("zone")
@@ -43,13 +43,14 @@ var nlbServiceDeleteCmd = &cobra.Command{
 			}
 		}
 
-		ctx := apiv2.WithEndpoint(gContext, apiv2.NewReqEndpoint(gCurrentAccount.Environment, ""))
-		nlb, err := cs.GetNetworkLoadBalancer(ctx, zone, nlbID)
+		ctx := apiv2.WithEndpoint(gContext, apiv2.NewReqEndpoint(gCurrentAccount.Environment, zone))
+		nlb, err := lookupNLB(ctx, zone, nlbRef)
 		if err != nil {
 			return err
 		}
+
 		for _, svc := range nlb.Services {
-			if svc.ID == svcID {
+			if svc.ID == svcRef || svc.Name == svcRef {
 				if err := nlb.DeleteService(ctx, svc); err != nil {
 					return err
 				}

--- a/cmd/nlb_service_show.go
+++ b/cmd/nlb_service_show.go
@@ -85,7 +85,7 @@ func (o *nlbServiceShowOutput) toTable() {
 }
 
 var nlbServiceShowCmd = &cobra.Command{
-	Use:   "show <NLB ID> <ID>",
+	Use:   "show <NLB name | ID> <service name | ID>",
 	Short: "Show a Network Load Balancer service details",
 	Long: fmt.Sprintf(`This command shows a Network Load Balancer service details.
 
@@ -107,20 +107,21 @@ Supported output template annotations: %s`,
 			return err
 		}
 
-		return output(showNLBService(args[0], args[1], zone))
+		return output(showNLBService(zone, args[0], args[1]))
 	},
 }
 
-func showNLBService(nlbID, svcID, zone string) (outputter, error) {
+func showNLBService(zone, nlbRef, svcRef string) (outputter, error) {
 	var svc *egoscale.NetworkLoadBalancerService
 
-	ctx := apiv2.WithEndpoint(gContext, apiv2.NewReqEndpoint(gCurrentAccount.Environment, ""))
-	nlb, err := cs.GetNetworkLoadBalancer(ctx, zone, nlbID)
+	ctx := apiv2.WithEndpoint(gContext, apiv2.NewReqEndpoint(gCurrentAccount.Environment, zone))
+	nlb, err := lookupNLB(ctx, zone, nlbRef)
 	if err != nil {
 		return nil, err
 	}
+
 	for _, s := range nlb.Services {
-		if s.ID == svcID {
+		if s.ID == svcRef || s.Name == svcRef {
 			svc = s
 			break
 		}

--- a/cmd/nlb_show.go
+++ b/cmd/nlb_show.go
@@ -55,7 +55,7 @@ func (o *nlbShowOutput) toTable() {
 }
 
 var nlbShowCmd = &cobra.Command{
-	Use:   "show <ID>",
+	Use:   "show <name | ID>",
 	Short: "Show a Network Load Balancer details",
 	Long: fmt.Sprintf(`This command shows a Network Load Balancer details.
 
@@ -77,13 +77,13 @@ Supported output template annotations: %s`,
 			return err
 		}
 
-		return output(showNLB(args[0], zone))
+		return output(showNLB(zone, args[0]))
 	},
 }
 
-func showNLB(id, zone string) (outputter, error) {
-	ctx := apiv2.WithEndpoint(gContext, apiv2.NewReqEndpoint(gCurrentAccount.Environment, ""))
-	nlb, err := cs.GetNetworkLoadBalancer(ctx, zone, id)
+func showNLB(zone, ref string) (outputter, error) {
+	ctx := apiv2.WithEndpoint(gContext, apiv2.NewReqEndpoint(gCurrentAccount.Environment, zone))
+	nlb, err := lookupNLB(ctx, zone, ref)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/nlb_update.go
+++ b/cmd/nlb_update.go
@@ -8,7 +8,7 @@ import (
 )
 
 var nlbUpdateCmd = &cobra.Command{
-	Use:   "update <ID>",
+	Use:   "update <name | ID>",
 	Short: "Update a Network Load Balancer",
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
@@ -20,15 +20,13 @@ var nlbUpdateCmd = &cobra.Command{
 		return cmdCheckRequiredFlags(cmd, []string{"zone"})
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		var nlbID = args[0]
-
 		zone, err := cmd.Flags().GetString("zone")
 		if err != nil {
 			return err
 		}
 
-		ctx := apiv2.WithEndpoint(gContext, apiv2.NewReqEndpoint(gCurrentAccount.Environment, ""))
-		nlb, err := cs.GetNetworkLoadBalancer(ctx, zone, nlbID)
+		ctx := apiv2.WithEndpoint(gContext, apiv2.NewReqEndpoint(gCurrentAccount.Environment, zone))
+		nlb, err := lookupNLB(ctx, zone, args[0])
 		if err != nil {
 			return err
 		}
@@ -54,7 +52,7 @@ var nlbUpdateCmd = &cobra.Command{
 		}
 
 		if !gQuiet {
-			return output(showNLB(nlb.ID, zone))
+			return output(showNLB(zone, nlb.ID))
 		}
 
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/danielgtaylor/openapi-cli-generator v0.0.0-20200228065623-fa97dc37f943
 	github.com/deepmap/oapi-codegen v1.3.8 // indirect
 	github.com/dustin/go-humanize v1.0.0
-	github.com/exoscale/egoscale v0.26.4
+	github.com/exoscale/egoscale v0.26.5
 	github.com/fatih/camelcase v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-ini/ini v1.42.0

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,8 @@ github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/exoscale/egoscale v0.26.4 h1:9jLDI4xCq1/HUJLgGhX1d26ZimvgNmNKBmbaP8Ykcxc=
-github.com/exoscale/egoscale v0.26.4/go.mod h1:WThejIJgwf32NoUfOhIHIH7GfD6ZU4QK9mC1s8inIaU=
+github.com/exoscale/egoscale v0.26.5 h1:DYtjAIb6ESbUZlUcjD0TxB5nZDkEvYM436yyN4QKkiI=
+github.com/exoscale/egoscale v0.26.5/go.mod h1:WThejIJgwf32NoUfOhIHIH7GfD6ZU4QK9mC1s8inIaU=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.26.5
+------
+
+- fix: bug in the ListNetworkLoadBalancers call (#435)
+
 0.26.4
 ------
 

--- a/vendor/github.com/exoscale/egoscale/version.go
+++ b/vendor/github.com/exoscale/egoscale/version.go
@@ -1,4 +1,4 @@
 package egoscale
 
 // Version of the library
-const Version = "0.26.4"
+const Version = "0.26.5"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -70,7 +70,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.0
 ## explicit
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.26.4
+# github.com/exoscale/egoscale v0.26.5
 ## explicit
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/admin


### PR DESCRIPTION
This change improves the `exo nlb` commands by allowing users to
reference NLB instances (and services) by their name or ID.