### PR TITLE
template register: Add --from-snapshot flag & change --name flag to an argument

### DIFF
--- a/cmd/nlb_create.go
+++ b/cmd/nlb_create.go
@@ -9,7 +9,7 @@ import (
 )
 
 var nlbCreateCmd = &cobra.Command{
-	Use:     "create <name> [flags]",
+	Use:     "create <name>",
 	Short:   "Create a Network Load Balancer",
 	Aliases: gCreateAlias,
 	PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/nlb_create.go
+++ b/cmd/nlb_create.go
@@ -9,7 +9,7 @@ import (
 )
 
 var nlbCreateCmd = &cobra.Command{
-	Use:     "create <name>",
+	Use:     "create <name> [flags]",
 	Short:   "Create a Network Load Balancer",
 	Aliases: gCreateAlias,
 	PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/template_register.go
+++ b/cmd/template_register.go
@@ -24,16 +24,16 @@ Supported output template annotations: %s`,
 
 		cmdSetZoneFlagFromDefault(cmd)
 
-		if !cmd.Flags().Changed("from-snapshot") {
+		if cmd.Flags().Changed("from-snapshot") {
 			return cmdCheckRequiredFlags(cmd, []string{
 				"zone",
-				"url",
-				"checksum",
 			})
 		}
 
 		return cmdCheckRequiredFlags(cmd, []string{
 			"zone",
+			"url",
+			"checksum",
 		})
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/template_register.go
+++ b/cmd/template_register.go
@@ -142,14 +142,14 @@ func templateRegister(registerTemplate egoscale.RegisterCustomTemplate, zone str
 
 func init() {
 	templateRegisterCmd.Flags().StringP("checksum", "c", "", "MD5 checksum value of the template")
-	templateRegisterCmd.Flags().StringP("description", "d", "", "Template description")
+	templateRegisterCmd.Flags().StringP("description", "d", "", "template description")
 	templateRegisterCmd.Flags().StringP("zone", "z", "", "ID or name of the zone the template is to be hosted on")
-	templateRegisterCmd.Flags().StringP("username", "u", "", "Default username of the template")
+	templateRegisterCmd.Flags().StringP("username", "u", "", "default username of the template")
 	templateRegisterCmd.Flags().String("url", "", "URL of where the template is hosted")
-	templateRegisterCmd.Flags().String("boot-mode", "legacy", "Template boot mode (legacy|uefi)")
+	templateRegisterCmd.Flags().String("boot-mode", "legacy", "template boot mode (legacy|uefi)")
 	templateRegisterCmd.Flags().String("from-snapshot", "", "ID of a Compute instance snapshot to register as a new template")
-	templateRegisterCmd.Flags().Bool("disable-password", false, "Disable password-based authentication")
-	templateRegisterCmd.Flags().Bool("disable-ssh-key", false, "Disable SSH key-based authentication")
+	templateRegisterCmd.Flags().Bool("disable-password", false, "disable password-based authentication")
+	templateRegisterCmd.Flags().Bool("disable-ssh-key", false, "disable SSH key-based authentication")
 
 	templateCmd.AddCommand(templateRegisterCmd)
 }

--- a/cmd/template_register.go
+++ b/cmd/template_register.go
@@ -144,7 +144,7 @@ func init() {
 	templateRegisterCmd.Flags().StringP("username", "u", "", "The default username of the template")
 	templateRegisterCmd.Flags().String("url", "", "the URL of where the template is hosted")
 	templateRegisterCmd.Flags().String("boot-mode", "legacy", "The template boot mode (legacy/uefi)")
-	templateRegisterCmd.Flags().String("from-snapshot", "", "")
+	templateRegisterCmd.Flags().String("from-snapshot", "", "the ID of a snapshot to export it and then reuse the returned snapshot file URL and checksum to register a new custom template")
 	templateRegisterCmd.Flags().Bool("disable-password", false, "true if the template does not support password authentication; default is false")
 	templateRegisterCmd.Flags().Bool("disable-ssh-key", false, "true if the template does not support ssh key authentication; default is false")
 

--- a/cmd/template_register.go
+++ b/cmd/template_register.go
@@ -141,15 +141,15 @@ func templateRegister(registerTemplate egoscale.RegisterCustomTemplate, zone str
 }
 
 func init() {
-	templateRegisterCmd.Flags().StringP("checksum", "c", "", "the MD5 checksum value of the template")
-	templateRegisterCmd.Flags().StringP("description", "d", "", "the template description")
-	templateRegisterCmd.Flags().StringP("zone", "z", "", "the ID or name of the zone the template is to be hosted on")
-	templateRegisterCmd.Flags().StringP("username", "u", "", "The default username of the template")
-	templateRegisterCmd.Flags().String("url", "", "the URL of where the template is hosted")
-	templateRegisterCmd.Flags().String("boot-mode", "legacy", "The template boot mode (legacy/uefi)")
-	templateRegisterCmd.Flags().String("from-snapshot", "", "the ID of a snapshot to export it and then reuse the returned snapshot file URL and checksum to register a new custom template")
-	templateRegisterCmd.Flags().Bool("disable-password", false, "true if the template does not support password authentication; default is false")
-	templateRegisterCmd.Flags().Bool("disable-ssh-key", false, "true if the template does not support ssh key authentication; default is false")
+	templateRegisterCmd.Flags().StringP("checksum", "c", "", "MD5 checksum value of the template")
+	templateRegisterCmd.Flags().StringP("description", "d", "", "Template description")
+	templateRegisterCmd.Flags().StringP("zone", "z", "", "ID or name of the zone the template is to be hosted on")
+	templateRegisterCmd.Flags().StringP("username", "u", "", "Default username of the template")
+	templateRegisterCmd.Flags().String("url", "", "URL of where the template is hosted")
+	templateRegisterCmd.Flags().String("boot-mode", "legacy", "Template boot mode (legacy|uefi)")
+	templateRegisterCmd.Flags().String("from-snapshot", "", "ID of a Compute instance snapshot to register as a new template")
+	templateRegisterCmd.Flags().Bool("disable-password", false, "Disable password-based authentication")
+	templateRegisterCmd.Flags().Bool("disable-ssh-key", false, "Disable SSH key-based authentication")
 
 	templateCmd.AddCommand(templateRegisterCmd)
 }

--- a/cmd/template_register.go
+++ b/cmd/template_register.go
@@ -57,6 +57,11 @@ Supported output template annotations: %s`,
 			return err
 		}
 
+		username, err := cmd.Flags().GetString("username")
+		if err != nil {
+			return err
+		}
+
 		disablePassword, err := cmd.Flags().GetBool("disable-password")
 		if err != nil {
 			return err
@@ -91,22 +96,20 @@ Supported output template annotations: %s`,
 			BootMode:        bootmode,
 		}
 
-		if username, _ := cmd.Flags().GetString("username"); username != "" {
+		if username != "" {
 			req.Details = make(map[string]string)
 			req.Details["username"] = username
 		}
 
-		if snapshotID == "" {
-			return output(templateRegister(req, zone))
-		}
+		if snapshotID != "" {
+			snapshot, err := exportSnapshot(snapshotID)
+			if err != nil {
+				return err
+			}
 
-		snapshot, err := exportSnapshot(snapshotID)
-		if err != nil {
-			return err
+			req.Checksum = snapshot.MD5sum
+			req.URL = snapshot.PresignedURL
 		}
-
-		req.Checksum = snapshot.MD5sum
-		req.URL = snapshot.PresignedURL
 
 		return output(templateRegister(req, zone))
 	},


### PR DESCRIPTION
```
exo vm template register test --from-snapshot 6804dd0f-d33f-49fc-a153-ecd74095575a
Exporting snapshot "6804dd0f-d33f-49fc-a153-ecd74095575a". success
Registering the template............................. success
┼───────────────┼──────────────────────────────────────┼
│   TEMPLATE    │                                      │
┼───────────────┼──────────────────────────────────────┼
│ ID            │ 5950d719-e81e-47b0-83ff-f6ffbdcb438b │
│ Name          │ test                                 │
│ OS Type       │ Other (64-bit)                       │
│ Creation Date │ 2020-07-09T09:48:30Z                 │
│ Zone          │ ch-dk-2                              │
│ Disk Size     │ 50 GiB                               │
│ Username      │                                      │
│ Password?     │ true                                 │
│ Boot Mode     │ legacy                               │
┼───────────────┼──────────────────────────────────────┼
```

```
exo vm template register -h
This command registers a new Compute instance template.

Supported output template annotations: .ID, .Name, .OSType, .CreationDate, .Zone, .DiskSize, .Username, .Password, .BootMode

Usage:
  exo vm template register <name> [flags]

Aliases:
  register, add

Flags:
      --boot-mode string       template boot mode (legacy|uefi) (default "legacy")
  -c, --checksum string        MD5 checksum value of the template
  -d, --description string     template description
      --disable-password       disable password-based authentication
      --disable-ssh-key        disable SSH key-based authentication
      --from-snapshot string   ID of a Compute instance snapshot to register as a new template
  -h, --help                   help for register
      --url string             URL of where the template is hosted
  -u, --username string        default username of the template
  -z, --zone string            ID or name of the zone the template is to be hosted on

Global Flags:
  -C, --config string            Specify an alternate config file [env EXOSCALE_CONFIG]
  -O, --output-format string     Output format (table|json|text), see "exo output --help" for more information
      --output-template string   Template to use if output format is "text"
  -Q, --quiet                    Quiet mode (disable non-essential command output)
  -A, --use-account string       Account to use in config file [env EXOSCALE_ACCOUNT]
```