### PR TITLE
Add dynamic names autocompletion for VM-related commands

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -57,3 +57,13 @@ func cmdExitOnUsageError(cmd *cobra.Command, reason string) {
 	cmd.Usage() // nolint:errcheck
 	os.Exit(1)
 }
+
+// completeVMNames is a Cobra Command.ValidArgsFunction that returns the list of Compute instance names belonging to
+// the current user for shell auto-completion.
+func completeVMNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	list, err := listVMs()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	return list.(*vmListOutput).names(), cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -14,8 +14,9 @@ import (
 
 // sshCmd represents the ssh command
 var sshCmd = &cobra.Command{
-	Use:   "ssh <vm name | id>",
-	Short: "SSH into a virtual machine instance",
+	Use:               "ssh <vm name | id>",
+	Short:             "SSH into a virtual machine instance",
+	ValidArgsFunction: completeVMNames,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return cmd.Usage()

--- a/cmd/vm_delete.go
+++ b/cmd/vm_delete.go
@@ -11,9 +11,10 @@ import (
 
 // deleteCmd represents the delete command
 var vmDeleteCmd = &cobra.Command{
-	Use:     "delete <name | id>+",
-	Short:   "Delete virtual machine instance(s)",
-	Aliases: gDeleteAlias,
+	Use:               "delete <vm name | id>+",
+	Short:             "Delete virtual machine instance(s)",
+	Aliases:           gDeleteAlias,
+	ValidArgsFunction: completeVMNames,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return cmd.Usage()

--- a/cmd/vm_firewall.go
+++ b/cmd/vm_firewall.go
@@ -19,7 +19,7 @@ var vmFirewallCmd = &cobra.Command{
 // vmFirewallSetCmd represents the firewall set command
 var vmFirewallSetCmd = &cobra.Command{
 	Use:   "set <vm name | id> <SG name | id>+",
-	Short: "set the security groups of a virtual machine",
+	Short: "Set the security groups of a virtual machine",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
 			return cmd.Usage()
@@ -46,7 +46,7 @@ var vmFirewallSetCmd = &cobra.Command{
 // vmFirewallAddCmd represents the firewall add command
 var vmFirewallAddCmd = &cobra.Command{
 	Use:   "add <vm name | id> <SG name | id>+",
-	Short: "add security groups to a virtual machine",
+	Short: "Add security groups to a virtual machine",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
 			return cmd.Usage()
@@ -86,7 +86,7 @@ var vmFirewallAddCmd = &cobra.Command{
 // vmFirewallRemoveCmd represents the firewall remove command
 var vmFirewallRemoveCmd = &cobra.Command{
 	Use:   "remove <vm name | id> <SG name | id>+",
-	Short: "remove security groups from a virtual machine",
+	Short: "Remove security groups from a virtual machine",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
 			return cmd.Usage()

--- a/cmd/vm_firewall.go
+++ b/cmd/vm_firewall.go
@@ -18,7 +18,7 @@ var vmFirewallCmd = &cobra.Command{
 
 // vmFirewallSetCmd represents the firewall set command
 var vmFirewallSetCmd = &cobra.Command{
-	Use:   "set <vm name> <SG name> [SG name] ...",
+	Use:   "set <vm name | id> <SG name | id>+",
 	Short: "set the security groups of a virtual machine",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
@@ -45,7 +45,7 @@ var vmFirewallSetCmd = &cobra.Command{
 
 // vmFirewallAddCmd represents the firewall add command
 var vmFirewallAddCmd = &cobra.Command{
-	Use:   "add <vm name> <SG name> [SG name] ...",
+	Use:   "add <vm name | id> <SG name | id>+",
 	Short: "add security groups to a virtual machine",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
@@ -85,7 +85,7 @@ var vmFirewallAddCmd = &cobra.Command{
 
 // vmFirewallRemoveCmd represents the firewall remove command
 var vmFirewallRemoveCmd = &cobra.Command{
-	Use:   "remove <vm name> <SG name> [SG name] ...",
+	Use:   "remove <vm name | id> <SG name | id>+",
 	Short: "remove security groups from a virtual machine",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {

--- a/cmd/vm_list.go
+++ b/cmd/vm_list.go
@@ -22,6 +22,14 @@ type vmListOutput []vmListItemOutput
 func (o *vmListOutput) toJSON()  { outputJSON(o) }
 func (o *vmListOutput) toText()  { outputText(o) }
 func (o *vmListOutput) toTable() { outputTable(o) }
+func (o *vmListOutput) names() []string {
+	names := make([]string, len(*o))
+	for i, item := range *o {
+		names[i] = item.Name
+	}
+
+	return names
+}
 
 func init() {
 	vmCmd.AddCommand(&cobra.Command{

--- a/cmd/vm_reboot.go
+++ b/cmd/vm_reboot.go
@@ -10,8 +10,9 @@ import (
 
 // rebootCmd represents the reboot command
 var vmRebootCmd = &cobra.Command{
-	Use:   "reboot <vm name> [vm name] ...",
-	Short: "Reboot virtual machine instance",
+	Use:               "reboot <vm name | id>+",
+	Short:             "Reboot virtual machine instance",
+	ValidArgsFunction: completeVMNames,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return cmd.Usage()

--- a/cmd/vm_reset.go
+++ b/cmd/vm_reset.go
@@ -9,8 +9,9 @@ import (
 
 // vmResetCmd represents the stop command
 var vmResetCmd = &cobra.Command{
-	Use:   "reset <vm name> [vm name] ...",
-	Short: "Reset virtual machine instance",
+	Use:               "reset <vm name | id>+",
+	Short:             "Reset virtual machine instance",
+	ValidArgsFunction: completeVMNames,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return cmd.Usage()

--- a/cmd/vm_resize.go
+++ b/cmd/vm_resize.go
@@ -10,7 +10,7 @@ import (
 // vmResetCmd represents the stop command
 var vmResizeCmd = &cobra.Command{
 	Use:               "resize <vm name | id>+",
-	Short:             "resize disk virtual machine instance",
+	Short:             "Resize disk virtual machine instance",
 	ValidArgsFunction: completeVMNames,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {

--- a/cmd/vm_resize.go
+++ b/cmd/vm_resize.go
@@ -9,8 +9,9 @@ import (
 
 // vmResetCmd represents the stop command
 var vmResizeCmd = &cobra.Command{
-	Use:   "resize <vm name> [vm name] ...",
-	Short: "resize disk virtual machine instance",
+	Use:               "resize <vm name | id>+",
+	Short:             "resize disk virtual machine instance",
+	ValidArgsFunction: completeVMNames,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			cmdExitOnUsageError(cmd, "invalid arguments")

--- a/cmd/vm_scale.go
+++ b/cmd/vm_scale.go
@@ -11,8 +11,9 @@ import (
 
 // scaleCmd represents the scale command
 var vmScaleCmd = &cobra.Command{
-	Use:   "scale <vm name> [vm name] ...",
-	Short: "Scale virtual machine",
+	Use:               "scale <vm name | id>+",
+	Short:             "Scale virtual machine",
+	ValidArgsFunction: completeVMNames,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			cmdExitOnUsageError(cmd, "invalid arguments")

--- a/cmd/vm_show.go
+++ b/cmd/vm_show.go
@@ -40,7 +40,8 @@ func init() {
 
 Supported output template annotations: %s`,
 			strings.Join(outputterTemplateAnnotations(&vmShowOutput{}), ", ")),
-		Aliases: gShowAlias,
+		Aliases:           gShowAlias,
+		ValidArgsFunction: completeVMNames,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return cmd.Usage()

--- a/cmd/vm_start.go
+++ b/cmd/vm_start.go
@@ -10,8 +10,9 @@ import (
 
 // startCmd represents the start command
 var vmStartCmd = &cobra.Command{
-	Use:   "start <vm name>+",
-	Short: "Start virtual machine",
+	Use:               "start <vm name | id>+",
+	Short:             "Start virtual machine",
+	ValidArgsFunction: completeVMNames,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return cmd.Usage()

--- a/cmd/vm_stop.go
+++ b/cmd/vm_stop.go
@@ -10,8 +10,9 @@ import (
 
 // stopCmd represents the stop command
 var vmStopCmd = &cobra.Command{
-	Use:   "stop <vm name>+",
-	Short: "Stop virtual machine instance",
+	Use:               "stop <vm name | id>+",
+	Short:             "Stop virtual machine instance",
+	ValidArgsFunction: completeVMNames,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return cmd.Usage()

--- a/cmd/vm_update.go
+++ b/cmd/vm_update.go
@@ -8,8 +8,9 @@ import (
 )
 
 var vmUpdateCmd = &cobra.Command{
-	Use:   "update <name|ID>",
-	Short: "Update virtual machine properties",
+	Use:               "update <vm name | id>",
+	Short:             "Update virtual machine properties",
+	ValidArgsFunction: completeVMNames,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var (
 			vmEdit egoscale.UpdateVirtualMachine


### PR DESCRIPTION
This change introduces dynamic CLI argument auto-completion for `exo vm *`
commands (and `exo ssh`) with the current user's Compute instance names:

[![asciicast](https://asciinema.org/a/7IcN1UacbwtHoZFLr8Fi4TnYK.svg)](https://asciinema.org/a/7IcN1UacbwtHoZFLr8Fi4TnYK)

