### PR TITLE
template list: don't de-dup custom templates

### DIFF
--- a/cmd/template.go
+++ b/cmd/template.go
@@ -120,7 +120,7 @@ func findTemplates(zoneID *egoscale.UUID, templateFilter string, filters ...stri
 		}
 
 		// In doubt, use it directly
-		allOS[template.Name] = template
+		allOS[template.ID.String()] = template
 		return true
 	})
 	if err != nil {


### PR DESCRIPTION
This change disables the name-based filtering performed on
"non-standard" templates in the `exo vm template list` command, allowing
the CLI to return the actual list of custom templates belonging to a
user/org.

Fixes #149.