### PR TITLE
Write async operation output to stderr

### DIFF
--- a/cmd/request.go
+++ b/cmd/request.go
@@ -40,6 +40,7 @@ func asyncTasks(tasks []task) []taskResponse {
 	maximum := 1 << 30
 	var taskWG sync.WaitGroup
 	progress := mpb.NewWithContext(gContext,
+		mpb.WithOutput(os.Stderr),
 		mpb.WithWaitGroup(&taskWG),
 		mpb.ContainerOptOnCond(mpb.WithOutput(nil), func() bool { return gQuiet }),
 	)


### PR DESCRIPTION
This change prints the output of asynchronous operations to `stderr`
instead of `stdout` by default, so that users can discard those using
`2>/null` and still use the `--output|-O` flag to retrieve information
after operation completion.