### PR TITLE
documentation fixes for exo config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,28 @@ Upon successful compilation, the resulting `exo` binary is stored in the `bin/` 
 
 Running the `exo config` command will guide you through the initial configuration.
 
-You can find your API credentials in the *Account* section of the [Exoscale Console](https://portal.exoscale.com/account/profile/api).
+You can create and find API credentials in the *IAM* section of the [Exoscale Console](https://portal.exoscale.com/iam/api-keys).
 
 The configuration file and all assets created during `exo` operations will be saved in the following location:
 
 | OS | Location |
 |:--|:--|
-| GNU/Linux, *BSD | `$HOME/.exoscale` |
-| macOS | `$HOME/Library/Application Support/exoscale` |
-| Windows | `%USERPROFILE%\.exoscale` |
+| GNU/Linux, *BSD | `$HOME/.config/exoscale/` |
+| macOS | `$HOME/.config/exoscale/` or `$HOME/Library/Application Support/exoscale/` |
+| Windows | `%USERPROFILE%\.config\exoscale\` |
 
+The configuration parameters are then saved in a `exoscale.toml` file with the following format:
+
+```
+defaultaccount = "account_name"
+
+[[accounts]]
+  account = "account_name"
+  endpoint = "https://api.exoscale.com/v1"
+  key = "API_KEY"
+  name = "account_name"
+  secret = "API_SECRET"
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ The configuration file and all assets created during `exo` operations will be sa
 | OS | Location |
 |:--|:--|
 | GNU/Linux, *BSD | `$HOME/.config/exoscale/` |
-| macOS | `$HOME/.config/exoscale/` or `$HOME/Library/Application Support/exoscale/` |
-| Windows | `%USERPROFILE%\.config\exoscale\` |
+| macOS | `$HOME/Library/Application Support/exoscale/` |
+| Windows | `%USERPROFILE%\.exoscale\` |
 
-The configuration parameters are then saved in a `exoscale.toml` file with the following format:
+The configuration parameters are then saved in a `exoscale.toml` file with the following minimum format:
 
 ```
 defaultaccount = "account_name"
@@ -52,6 +52,8 @@ defaultaccount = "account_name"
   name = "account_name"
   secret = "API_SECRET"
 ```
+
+The current configuration and configuration file path can be shown with `exo config show`.
 
 ## Usage
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -162,7 +162,7 @@ func configCmdRun(cmd *cobra.Command, args []string) error {
 Hi happy Exoscalian, some configuration is required to use exo.
 
 We now need some very important information, find them there.
-	<https://portal.exoscale.com/account/profile/api>
+	<https://portal.exoscale.com/iam/api-keys>
 
 `)
 	return addConfigAccount(true)


### PR DESCRIPTION
This is a proposal to align documentation to best practices regarding API credentials:

* redirect users to IAM instead of ACCOUNT section which is deprecated
* point to the correct configuration path