### PR TITLE
sos: fix endpoint construction

### DIFF
--- a/cmd/sos.go
+++ b/cmd/sos.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	minio "github.com/minio/minio-go/v6"
@@ -136,7 +137,9 @@ func (s *sosClient) setZone(zone string) error {
 	// When a user wants to set the SOS zone to use for an operation, we actually have to re-create the
 	// underlying Minio S3 client to specify the zone-based endpoint.
 
-	endpoint := "sos-" + zone + ".exo.io"
+	endpoint := strings.TrimPrefix(
+		strings.Replace(gCurrentAccount.SosEndpoint, "{zone}", zone, 1),
+		"https://")
 	minioClient, err := minio.NewV4(endpoint, gCurrentAccount.Key, gCurrentAccount.APISecret(), true)
 	if err != nil {
 		return err


### PR DESCRIPTION
This change fixes a bug in zoned SOS commands, where the zone endpoint
was be incorrectly constructed in some contexts (e.g. non-production
environments).