### PR TITLE
vm: support custom output for "create" command

### DIFF
--- a/cmd/affinitygroup.go
+++ b/cmd/affinitygroup.go
@@ -39,6 +39,21 @@ func getAffinityGroupByNameOrID(v string) (*egoscale.AffinityGroup, error) {
 	}
 }
 
+func getAffinityGroupIDs(params []string) ([]egoscale.UUID, error) {
+	ids := make([]egoscale.UUID, len(params))
+
+	for i, aff := range params {
+		s, err := getAffinityGroupByNameOrID(aff)
+		if err != nil {
+			return nil, err
+		}
+
+		ids[i] = *s.ID
+	}
+
+	return ids, nil
+}
+
 func init() {
 	RootCmd.AddCommand(affinitygroupCmd)
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
@@ -66,4 +67,24 @@ func completeVMNames(cmd *cobra.Command, args []string, toComplete string) ([]st
 		return nil, cobra.ShellCompDirectiveError
 	}
 	return list.(*vmListOutput).names(), cobra.ShellCompDirectiveNoFileComp
+}
+
+func getCommaflag(p string) []string {
+	if p == "" {
+		return nil
+	}
+
+	p = strings.Trim(p, ",")
+	args := strings.Split(p, ",")
+
+	res := []string{}
+
+	for _, arg := range args {
+		if arg == "" {
+			continue
+		}
+		res = append(res, strings.TrimSpace(arg))
+	}
+
+	return res
 }

--- a/cmd/coi.go
+++ b/cmd/coi.go
@@ -86,7 +86,7 @@ Supported output template annotations: %s`,
 			return err
 		}
 
-		securityGroups, err := getSecurityGroups(sg)
+		securityGroups, err := getSecurityGroupIDs(sg)
 		if err != nil {
 			return err
 		}
@@ -96,7 +96,7 @@ Supported output template annotations: %s`,
 			return err
 		}
 
-		privnets, err := getPrivnetList(privnet, zone.ID)
+		privnets, err := getPrivnetIDs(privnet, zone.ID)
 		if err != nil {
 			return err
 		}

--- a/cmd/firewall.go
+++ b/cmd/firewall.go
@@ -9,8 +9,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var defaultCIDR = egoscale.MustParseCIDR("0.0.0.0/0")
-var defaultCIDR6 = egoscale.MustParseCIDR("::/0")
+var (
+	defaultCIDR  = egoscale.MustParseCIDR("0.0.0.0/0")
+	defaultCIDR6 = egoscale.MustParseCIDR("::/0")
+)
 
 var firewallCmd = &cobra.Command{
 	Use:   "firewall",
@@ -79,6 +81,21 @@ func getSecurityGroupByNameOrID(v string) (*egoscale.SecurityGroup, error) {
 	default:
 		return nil, err
 	}
+}
+
+func getSecurityGroupIDs(params []string) ([]egoscale.UUID, error) {
+	ids := make([]egoscale.UUID, len(params))
+
+	for i, sg := range params {
+		s, err := getSecurityGroupByNameOrID(sg)
+		if err != nil {
+			return nil, err
+		}
+
+		ids[i] = *s.ID
+	}
+
+	return ids, nil
 }
 
 func getMyCIDR(isIpv6 bool) (*egoscale.CIDR, error) {

--- a/cmd/instance_pool_create.go
+++ b/cmd/instance_pool_create.go
@@ -97,7 +97,7 @@ Supported output template annotations: %s`,
 			return err
 		}
 
-		securityGroups, err := getSecurityGroups(sg)
+		securityGroups, err := getSecurityGroupIDs(sg)
 		if err != nil {
 			return err
 		}
@@ -107,7 +107,7 @@ Supported output template annotations: %s`,
 			return err
 		}
 
-		privnets, err := getPrivnetList(privnet, zone.ID)
+		privnets, err := getPrivnetIDs(privnet, zone.ID)
 		if err != nil {
 			return err
 		}

--- a/cmd/privnet.go
+++ b/cmd/privnet.go
@@ -65,6 +65,21 @@ func getNetwork(net string, zoneID *egoscale.UUID) (*egoscale.Network, error) {
 	return nil, fmt.Errorf("network %q not found", net)
 }
 
+func getPrivnetIDs(params []string, zoneID *egoscale.UUID) ([]egoscale.UUID, error) {
+	ids := make([]egoscale.UUID, len(params))
+
+	for i, sg := range params {
+		n, err := getNetwork(sg, zoneID)
+		if err != nil {
+			return nil, err
+		}
+
+		ids[i] = *n.ID
+	}
+
+	return ids, nil
+}
+
 func init() {
 	RootCmd.AddCommand(privnetCmd)
 }

--- a/cmd/serviceoffering.go
+++ b/cmd/serviceoffering.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	serviceOfferingHelp = "<name | id> (micro|tiny|small|medium|large|extra-large|huge|mega|titan|jumbo)"
+	serviceOfferingHelp = "service offering <name | id> (micro|tiny|small|medium|large|extra-large|huge|mega|titan|jumbo)"
 )
 
 type serviceOfferingListItemOutput struct {
@@ -66,7 +66,6 @@ func listServiceOfferings() (outputter, error) {
 	}
 
 	return &out, nil
-
 }
 
 func getServiceOfferingByNameOrID(v string) (*egoscale.ServiceOffering, error) {

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	templateFilterHelp = "The template filter to use (mine,community,featured)"
+	templateFilterHelp = "template filter to use (featured|community|mine)"
 )
 
 // templateCmd represents the template command

--- a/cmd/zone.go
+++ b/cmd/zone.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	zoneHelp = "<zone name | id> (ch-dk-2|ch-gva-2|at-vie-1|de-fra-1|bg-sof-1|de-muc-1)"
+	zoneHelp = "zone <name | id> (ch-dk-2|ch-gva-2|at-vie-1|de-fra-1|bg-sof-1|de-muc-1)"
 )
 
 // zones represents the list of known Exoscale zones, in case we need it without performing API lookup.


### PR DESCRIPTION
This change refactors the `vm create` command implementation to support
global `--output` flag:

```command
$ go run main.go vm create blah --disk 10 -O json | jq .
Creating single-use SSH key
Deploying "blah" ⠴                                       done
{
  "id": "d5c46409-5c4e-4269-995a-2395bbca8128",
  "name": "blah",
  "creation_date": "2020-11-16T09:11:58+0100",
  "size": "Medium",
  "disk_size": "10 GiB",
  "template": "Linux Ubuntu 20.04 LTS 64-bit",
  "zone": "ch-gva-2",
  "state": "Running",
  "ip_address": "159.100.241.155",
  "username": "ubuntu",
  "ssh_key": "/Users/marc/Library/Application Support/exoscale/instances/d5c46409-5c4e-4269-995a-2395bbca8128/id_rsa",
  "security_groups": [
    "default"
  ]
}
```

Besides, the command now only supports creating a single instance to make it more consistent with the rest of the commands.

Fixes #294.