### PR TITLE
fix: limits: display template used

### DIFF
--- a/cmd/limits.go
+++ b/cmd/limits.go
@@ -88,7 +88,7 @@ func fetchUsedResources(resourceType string) (int, error) {
 		resourceUsed = len(snapshots)
 
 	case "template":
-		templates, err := cs.ListWithContext(gContext, &egoscale.Template{})
+		templates, err := cs.ListWithContext(gContext, &egoscale.ListTemplates{TemplateFilter: "self"})
 		if err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
```
❯ exo vm template list --mine -z de-fra-1
┼──────────────────────────────────────┼──────┼──────────────────────────┼──────────┼───────────┼
│                  ID                  │ NAME │      CREATION DATE       │   ZONE   │ DISK SIZE │
┼──────────────────────────────────────┼──────┼──────────────────────────┼──────────┼───────────┼
│   4b71cc-8bee-4354-953e-18bb10bc0027 │ test │ 2020-11-27T11:19:32+0100 │ de-fra-1 │ 50 GiB    │
┼──────────────────────────────────────┼──────┼──────────────────────────┼──────────┼───────────┼
```
(only one template)


before:
```
❯ exo limits
┼──────────────────┼──────┼─────┼
│     RESOURCE     │ USED │ MAX │
┼──────────────────┼──────┼─────┼
│ Templates        │ 0    │ 30  │
│ Instances        │ 0    │ 4   │
│ Snapshots        │ 0    │ 30  │
│ Private Networks │ 0    │ 32  │
│ IP Addresses     │ 0    │ 5   │
┼──────────────────┼──────┼─────┼
```

after:

```
❯ exo limits
┼──────────────────┼──────┼─────┼
│     RESOURCE     │ USED │ MAX │
┼──────────────────┼──────┼─────┼
│ Templates        │ 1    │ 30  │
│ Instances        │ 0    │ 4   │
│ Snapshots        │ 0    │ 30  │
│ Private Networks │ 0    │ 32  │
│ IP Addresses     │ 0    │ 5   │
┼──────────────────┼──────┼─────┼
```
