### PR TITLE
sos upload: always send content md5

### DIFF
--- a/cmd/sos_upload.go
+++ b/cmd/sos_upload.go
@@ -195,7 +195,8 @@ var sosUploadCmd = &cobra.Command{
 					reader,
 					fileInfo.Size(),
 					minio.PutObjectOptions{
-						ContentType: fileToUP.contentType,
+						ContentType:    fileToUP.contentType,
+						SendContentMd5: true,
 					},
 				)
 				if upErr != nil {


### PR DESCRIPTION
For multipart uploads, this triggers this code path:

https://github.com/minio/minio-go/blob/v6.0.57/api-put-object-streaming.go#L278

For non-multipart, this code path:

https://github.com/minio/minio-go/blob/v6.0.57/api-put-object-streaming.go#L384

This results in put requests being done with a `Content-MD5` header,
allowing the client and the backend to agree on data integrity.