### PR TITLE
Allow access to $HOME/.cloudstack.ini

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,6 +22,7 @@ plugs:
     write:
       - $HOME/.exoscale
       - $HOME/.cloudstack.ini
+      - $HOME/.config/exoscale
 
 apps:
   # The app has an alias to "exo" that was granted via forum post.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,6 +21,7 @@ plugs:
     interface: personal-files
     write:
       - $HOME/.exoscale
+      - $HOME/.cloudstack.ini
 
 apps:
   # The app has an alias to "exo" that was granted via forum post.


### PR DESCRIPTION
The Exoscale Terraform provider looks for credentials in `$HOME/.cloudstack.ini`. Would be cool if the Exoscale CLI followed this convention. Currently, Exoscale CLI fails as follows:

```
$ exo config
No Exoscale CLI configuration found
error: open /home/cklein/.cloudstack.ini: permission denied
$ exo version
exo 1.22.2 df6255d (egoscale 0.37.1)
```