### PR TITLE
sks: fix "nodepool evict" arguments parsing issue

### DIFF
--- a/cmd/sks_nodepool_evict.go
+++ b/cmd/sks_nodepool_evict.go
@@ -19,7 +19,7 @@ Note: Kubernetes Nodes should be drained from their workload prior to being
 evicted from their Nodepool, e.g. using "kubectl drain".`,
 
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) <= 3 {
+		if len(args) < 3 {
 			cmdExitOnUsageError(cmd, "invalid arguments")
 		}
 


### PR DESCRIPTION
This changes fixes a bug in the `exo sks nodepool evict` command
arguments parsing, where an "invalid arguments" error would be returned
in the legitimate case of a single Node passed.