### PR TITLE
sks: fix timeout extension

### DIFF
--- a/cmd/sks.go
+++ b/cmd/sks.go
@@ -15,7 +15,7 @@ var sksCmd = &cobra.Command{
 	PersistentPreRun: func(_ *cobra.Command, _ []string) {
 		// Some SKS operations can take a long time, raising
 		// the Exoscale API client timeout as a precaution.
-		cs.Timeout = 10 * time.Minute
+		cs.Client.SetTimeout(10 * time.Minute)
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/deepmap/oapi-codegen v1.5.1 // indirect
 	github.com/dustin/go-humanize v1.0.0
-	github.com/exoscale/egoscale v0.46.1
+	github.com/exoscale/egoscale v0.47.0
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/exoscale/egoscale v0.46.1 h1:/5Gm1USbbLUwvDia5nmRp0rs3IpQhcv62Liz5jHbqOY=
-github.com/exoscale/egoscale v0.46.1/go.mod h1:pA0kDBbN+dyncVazLuGXcVf38WfuzbKa6ce5T0iex0w=
+github.com/exoscale/egoscale v0.47.0 h1:DZIksW3qItXlMWsyAZHDtnyxFEh89bl0LyW3L1zlN9w=
+github.com/exoscale/egoscale v0.47.0/go.mod h1:pA0kDBbN+dyncVazLuGXcVf38WfuzbKa6ce5T0iex0w=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/.gitignore
+++ b/vendor/github.com/exoscale/egoscale/.gitignore
@@ -3,3 +3,4 @@ dist
 ops.asc
 vendor
 listApis.json
+public-api.json

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.47.0
+------
+
+- feature: v2: add client property setters (#485)
+
 0.46.1
 ------
 

--- a/vendor/github.com/exoscale/egoscale/v2/client.go
+++ b/vendor/github.com/exoscale/egoscale/v2/client.go
@@ -146,6 +146,21 @@ func NewClient(apiKey, apiSecret string, opts ...ClientOpt) (*Client, error) {
 	return &client, nil
 }
 
+// SetHTTPClient overrides the current HTTP client.
+func (c *Client) SetHTTPClient(client *http.Client) {
+	c.httpClient = client
+}
+
+// SetTimeout overrides the current client timeout value.
+func (c *Client) SetTimeout(v time.Duration) {
+	c.timeout = v
+}
+
+// SetTrace enables or disables HTTP request/reponse tracing.
+func (c *Client) SetTrace(enabled bool) {
+	c.trace = enabled
+}
+
 // setEndpointFromContext is an HTTP client request interceptor that overrides the "Host" header
 // with information from a request endpoint optionally set in the context instance. If none is
 // found, the request is left untouched.

--- a/vendor/github.com/exoscale/egoscale/version.go
+++ b/vendor/github.com/exoscale/egoscale/version.go
@@ -1,4 +1,4 @@
 package egoscale
 
 // Version of the library
-const Version = "0.46.1"
+const Version = "0.47.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -70,7 +70,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.0
 ## explicit
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.46.1
+# github.com/exoscale/egoscale v0.47.0
 ## explicit
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/admin


### PR DESCRIPTION
This change fixes the client timeout extension for the `exo sks`
commands.