### PR TITLE
storage: bug fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,10 +4,10 @@ linters-settings:
 
 linters:
   enable:
+    - exportloopref
     - gofmt
     - golint
     - megacheck
     - misspell
     - prealloc
     - unparam
-    - scopelint

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -175,6 +175,14 @@ func (c *storageClient) forEachObject(bucket, prefix string, recursive bool, fn 
 				continue
 			}
 
+			// If the prefix doesn't end with a trailing prefix separator ("/"),
+			// consider it as a single object key and match only one exact result
+			// (except in recursive mode, where the prefix is expected to be a
+			// "directory").
+			if !recursive && !strings.HasSuffix(prefix, "/") && aws.ToString(o.Key) != prefix {
+				continue
+			}
+
 			o := o
 			if err := fn(&o); err != nil {
 				return err

--- a/cmd/storage_download.go
+++ b/cmd/storage_download.go
@@ -165,7 +165,7 @@ func (c *storageClient) downloadFiles(config *storageDownloadConfig) error {
 			}
 
 			if strings.HasSuffix(config.destination, "/") {
-				return path.Join(config.destination, aws.ToString(object.Key))
+				return path.Join(config.destination, path.Base(aws.ToString(object.Key)))
 			}
 
 			return path.Join(config.destination)

--- a/cmd/storage_download.go
+++ b/cmd/storage_download.go
@@ -154,6 +154,13 @@ func (c *storageClient) downloadFiles(config *storageDownloadConfig) error {
 		return errors.New(`multiple files to download, destination must end with "/"`)
 	}
 
+	// Handle relative filesystem destination (e.g. ".", "../.." etc.)
+	if dstInfo, err := os.Stat(config.destination); err == nil {
+		if dstInfo.IsDir() && !strings.HasSuffix(config.destination, "/") {
+			config.destination += "/"
+		}
+	}
+
 	if config.dryRun {
 		fmt.Println("[DRY-RUN]")
 	}


### PR DESCRIPTION
## `storage`: fix prefix-based listing logic

This change fixes the listing logic used in the `exo storage` commands,
where previously all objects matching the specified prefix were
processed – which is not wanted when the prefix points to a discrete
file. The updated logic returns only the object matching the specified
prefix if the prefix doesn't end with a trailing separator ("/").

## `storage download`: fix destination file path

This change fixes the behavior of the `exo storage download` command,
where previously downloading a file located in a prefix would re-create
the prefix directory tree locally. The updated logic now stores the
specified file under its base name in the specified local directory.

## `storage download`: fix relative destination paths

This change fixes a bug causing a "file already exists" error message
returned when users pass a destination as relative path (e.g. ".", "..",
"../..") without trailing slash.
