### PR TITLE
storage: various metadata bug fixes

### DIFF
--- a/cmd/storage_metadata_add.go
+++ b/cmd/storage_metadata_add.go
@@ -106,6 +106,10 @@ func (c *storageClient) addObjectMetadata(bucket, key string, metadata map[strin
 		return err
 	}
 
+	if len(object.Metadata) == 0 {
+		object.Metadata = make(map[string]string)
+	}
+
 	for k, v := range metadata {
 		object.Metadata[k] = v
 	}


### PR DESCRIPTION
##  storage: metadata: add: fix crash on empty metadata

This change fixes a crashing issue when a user attempted to set metadata
on an object that doesn't have any metadata set yet.

## storage: metadata: add: metadata keys validation

This change hardens the `metadata add` command by validating provided
metadata keys to prevent the use of invalid characters.

