### PR TITLE
Minor refactoring + "exo instancepool" commands rewrite

### DIFF
--- a/cmd/config_add.go
+++ b/cmd/config_add.go
@@ -168,7 +168,7 @@ Let's start over.
 	if err != nil {
 		if egoerr, ok := err.(*egoscale.ErrorResponse); ok && egoerr.ErrorCode == egoscale.ErrorCode(403) {
 			for {
-				defaultZone, err := chooseZone(cs, zones)
+				defaultZone, err := chooseZone(cs, allZones)
 				if err != nil {
 					return nil, err
 				}

--- a/cmd/deploy_target.go
+++ b/cmd/deploy_target.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	exov2 "github.com/exoscale/egoscale/v2"
+	"github.com/spf13/cobra"
+)
+
+var deployTargetCmd = &cobra.Command{
+	Use:     "deploytarget",
+	Short:   "Deploy Targets management",
+	Aliases: []string{"dt"},
+}
+
+func init() {
+	vmCmd.AddCommand(deployTargetCmd)
+}
+
+// lookupDeployTarget attempts to look up a Deploy Target resource by name or ID.
+func lookupDeployTarget(ctx context.Context, zone, v string) (*exov2.DeployTarget, error) {
+	deployTargets, err := cs.ListDeployTargets(ctx, zone)
+	if err != nil {
+		return nil, fmt.Errorf("unable to list Deploy Targets in zone %s: %v", zone, err)
+	}
+
+	for _, dt := range deployTargets {
+		if dt.ID == v || dt.Name == v {
+			return dt, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Deploy Target %q not found", v) // nolint:golint
+}

--- a/cmd/deploy_target_list.go
+++ b/cmd/deploy_target_list.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type deployTargetListItemOutput struct {
+	Zone string `json:"zone"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type deployTargetListOutput []deployTargetListItemOutput
+
+func (o *deployTargetListOutput) toJSON()  { outputJSON(o) }
+func (o *deployTargetListOutput) toText()  { outputText(o) }
+func (o *deployTargetListOutput) toTable() { outputTable(o) }
+
+var deployTargetListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List Deploy Targets",
+	Long: fmt.Sprintf(`This command lists existing Deploy Targets.
+
+Supported output template annotations: %s`,
+		strings.Join(outputterTemplateAnnotations(&vmListOutput{}), ", ")),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		zone, err := cmd.Flags().GetString("zone")
+		if err != nil {
+			return err
+		}
+		zone = strings.ToLower(zone)
+
+		return output(listDeployTargets(zone), nil)
+	},
+}
+
+func listDeployTargets(zone string) outputter {
+	var listZones []string
+
+	if zone != "" {
+		listZones = []string{zone}
+	} else {
+		listZones = allZones
+	}
+
+	out := make(deployTargetListOutput, 0)
+	res := make(chan deployTargetListItemOutput)
+	defer close(res)
+
+	go func() {
+		for dt := range res {
+			out = append(out, dt)
+		}
+	}()
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+	err := forEachZone(listZones, func(zone string) error {
+		list, err := cs.ListDeployTargets(ctx, zone)
+		if err != nil {
+			return fmt.Errorf("unable to list Deploy Targets in zone %s: %v", zone, err)
+		}
+
+		for _, dt := range list {
+			res <- deployTargetListItemOutput{
+				Zone: zone,
+				ID:   dt.ID,
+				Name: dt.Name,
+				Type: dt.Type,
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr,
+			"warning: errors during listing, results might be incomplete.\n%s\n", err) // nolint:golint
+	}
+
+	return &out
+}
+
+func init() {
+	deployTargetListCmd.Flags().StringP("zone", "z", "", "zone to filter results to")
+	deployTargetCmd.AddCommand(deployTargetListCmd)
+}

--- a/cmd/deploy_target_show.go
+++ b/cmd/deploy_target_show.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+)
+
+type deployTargetShowOutput struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Type        string `json:"type"`
+	Zone        string `json:"zone"`
+}
+
+func (o *deployTargetShowOutput) toJSON()  { outputJSON(o) }
+func (o *deployTargetShowOutput) toText()  { outputText(o) }
+func (o *deployTargetShowOutput) toTable() { outputTable(o) }
+
+var deployTargetShowCmd = &cobra.Command{
+	Use:   "show NAME|ID",
+	Short: "Show a Deploy Target details",
+	Long: fmt.Sprintf(`This command shows a Deploy Target details.
+
+Supported output template annotations: %s`,
+		strings.Join(outputterTemplateAnnotations(&deployTargetShowOutput{}), ", ")),
+	Aliases: gShowAlias,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			cmdExitOnUsageError(cmd, "invalid arguments")
+		}
+
+		cmdSetZoneFlagFromDefault(cmd)
+
+		return cmdCheckRequiredFlags(cmd, []string{"zone"})
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		zone, err := cmd.Flags().GetString("zone")
+		if err != nil {
+			return err
+		}
+
+		return output(showDeployTarget(zone, args[0]))
+	},
+}
+
+func showDeployTarget(zone, c string) (outputter, error) {
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+	dt, err := lookupDeployTarget(ctx, zone, c)
+	if err != nil {
+		return nil, err
+	}
+
+	return &deployTargetShowOutput{
+		ID:          dt.ID,
+		Name:        dt.Name,
+		Description: dt.Description,
+		Type:        dt.Type,
+		Zone:        zone,
+	}, nil
+}
+
+func init() {
+	deployTargetShowCmd.Flags().StringP("zone", "z", "", "Deploy Target zone")
+	deployTargetCmd.AddCommand(deployTargetShowCmd)
+}

--- a/cmd/eip.go
+++ b/cmd/eip.go
@@ -13,11 +13,9 @@ var eipCmd = &cobra.Command{
 	Short: "Elastic IP management",
 }
 
-func getEIPIDByIP(ipAddr string) (*egoscale.UUID, error) {
-	ip := net.ParseIP(ipAddr)
-	if ip == nil {
-		return nil, fmt.Errorf("invalid IP address %q", ipAddr)
-	}
+func getElasticIPByAddressOrID(v string) (*egoscale.IPAddress, error) {
+	ip := net.ParseIP(v)
+	id, _ := egoscale.ParseUUID(v)
 
 	eips, err := cs.ListWithContext(gContext, &egoscale.IPAddress{IsElastic: true})
 	if err != nil {
@@ -26,12 +24,12 @@ func getEIPIDByIP(ipAddr string) (*egoscale.UUID, error) {
 
 	for _, e := range eips {
 		eip := e.(*egoscale.IPAddress)
-		if eip.IPAddress.Equal(ip) {
-			return eip.ID, nil
+		if (ip != nil && eip.IPAddress.Equal(ip)) || (id != nil && id.Equal(*eip.ID)) {
+			return eip, nil
 		}
 	}
 
-	return nil, fmt.Errorf("Elastic IP %q not found", ipAddr) // nolint
+	return nil, fmt.Errorf("Elastic IP %q not found", v) // nolint
 }
 
 func init() {

--- a/cmd/eip_list.go
+++ b/cmd/eip_list.go
@@ -9,12 +9,11 @@ import (
 )
 
 type eipListItemOutput struct {
-	ID          string   `json:"id"`
-	Zone        string   `json:"zone"`
-	IPAddress   string   `json:"ip_address"`
-	Description string   `json:"description"`
-	Managed     bool     `json:"managed"`
-	Instances   []string `json:"instances,omitempty"`
+	ID          string `json:"id"`
+	Zone        string `json:"zone"`
+	IPAddress   string `json:"ip_address"`
+	Description string `json:"description"`
+	Managed     bool   `json:"managed"`
 }
 
 type eipListOutput []eipListItemOutput
@@ -72,22 +71,13 @@ func listEIP(zone string) (outputter, error) {
 		for _, ip := range ips {
 			eip := ip.(*egoscale.IPAddress)
 
-			_, vms, err := eipDetails(eip.ID)
-			if err != nil {
-				return nil, err
-			}
-			instances := make([]string, len(vms))
-			for i := range vms {
-				instances[i] = vms[i].Name
-			}
-
 			o := eipListItemOutput{
 				Description: eip.Description,
 				ID:          eip.ID.String(),
 				IPAddress:   eip.IPAddress.String(),
 				Zone:        z.(*egoscale.Zone).Name,
-				Instances:   instances,
 			}
+
 			if eip.Healthcheck != nil {
 				o.Managed = true
 			}

--- a/cmd/eip_update.go
+++ b/cmd/eip_update.go
@@ -16,16 +16,15 @@ var eipUpdateCmd = &cobra.Command{
 		if len(args) != 1 {
 			return cmd.Usage()
 		}
-		description, err := cmd.Flags().GetString("description")
+
+		eip, err := getElasticIPByAddressOrID(args[0])
 		if err != nil {
 			return err
 		}
-		id, err := egoscale.ParseUUID(args[0])
+
+		description, err := cmd.Flags().GetString("description")
 		if err != nil {
-			id, err = getEIPIDByIP(args[0])
-			if err != nil {
-				return err
-			}
+			return err
 		}
 
 		interval, err := cmd.Flags().GetInt64("healthcheck-interval")
@@ -75,7 +74,7 @@ var eipUpdateCmd = &cobra.Command{
 			HealthcheckTimeout:       timeout,
 			HealthcheckTLSSNI:        tlsSNI,
 			HealthcheckTLSSkipVerify: tlsSkipVerify,
-			ID:                       id,
+			ID:                       eip.ID,
 		}
 
 		return updateIPAddress(req)

--- a/cmd/instance_pool_create.go
+++ b/cmd/instance_pool_create.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/exoscale/egoscale"
+	exov2 "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
 	"github.com/spf13/cobra"
 )
 
@@ -14,8 +15,9 @@ var instancePoolCreateCmd = &cobra.Command{
 	Long: fmt.Sprintf(`This command creates an Instance Pool.
 
 Supported output template annotations: %s`,
-		strings.Join(outputterTemplateAnnotations(&instancePoolItemOutput{}), ", ")),
+		strings.Join(outputterTemplateAnnotations(&instancePoolShowOutput{}), ", ")),
 	Aliases: gCreateAlias,
+
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
 			cmdExitOnUsageError(cmd, "invalid arguments")
@@ -23,150 +25,163 @@ Supported output template annotations: %s`,
 
 		cmdSetZoneFlagFromDefault(cmd)
 
-		return cmdCheckRequiredFlags(cmd, []string{
-			"service-offering",
-			"template",
-		})
+		return cmdCheckRequiredFlags(cmd, []string{"zone"})
 	},
+
 	RunE: func(cmd *cobra.Command, args []string) error {
-		description, err := cmd.Flags().GetString("description")
+		instancePool := new(exov2.InstancePool)
+		instancePool.Name = args[0]
+
+		zone, err := cmd.Flags().GetString("zone")
 		if err != nil {
 			return err
 		}
 
-		zoneName, err := cmd.Flags().GetString("zone")
+		ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+
+		zoneV1, err := getZoneByNameOrID(zone)
 		if err != nil {
 			return err
 		}
 
-		zone, err := getZoneByNameOrID(zoneName)
+		antiAffinityGroups, err := cmd.Flags().GetStringSlice("anti-affinity-group")
+		if err != nil {
+			return err
+		}
+		for _, v := range antiAffinityGroups {
+			antiAffinityGroup, err := getAntiAffinityGroupByNameOrID(v)
+			if err != nil {
+				return err
+			}
+			instancePool.AntiAffinityGroupIDs = append(instancePool.AntiAffinityGroupIDs, antiAffinityGroup.ID.String())
+		}
+
+		deployTargetFlagVal, err := cmd.Flags().GetString("deploy-target")
+		if err != nil {
+			return err
+		}
+		if deployTargetFlagVal != "" {
+			deployTarget, err := lookupDeployTarget(ctx, zone, deployTargetFlagVal)
+			if err != nil {
+				return err
+			}
+			instancePool.DeployTargetID = deployTarget.ID
+		}
+
+		if instancePool.Description, err = cmd.Flags().GetString("description"); err != nil {
+			return err
+		}
+
+		if instancePool.DiskSize, err = cmd.Flags().GetInt64("disk"); err != nil {
+			return err
+		}
+
+		elasticIPs, err := cmd.Flags().GetStringSlice("elastic-ip")
+		if err != nil {
+			return err
+		}
+		for _, v := range elasticIPs {
+			elasticIP, err := getElasticIPByAddressOrID(v)
+			if err != nil {
+				return err
+			}
+			instancePool.ElasticIPIDs = append(instancePool.ElasticIPIDs, elasticIP.ID.String())
+		}
+
+		if instancePool.InstancePrefix, err = cmd.Flags().GetString("instance-prefix"); err != nil {
+			return err
+		}
+
+		if instancePool.IPv6Enabled, err = cmd.Flags().GetBool("ipv6"); err != nil {
+			return err
+		}
+
+		privateNetworks, err := cmd.Flags().GetStringSlice("privnet")
+		if err != nil {
+			return err
+		}
+		for _, v := range privateNetworks {
+			privateNetwork, err := getNetwork(v, zoneV1.ID)
+			if err != nil {
+				return err
+			}
+			instancePool.PrivateNetworkIDs = append(instancePool.PrivateNetworkIDs, privateNetwork.ID.String())
+		}
+
+		securityGroups, err := cmd.Flags().GetStringSlice("security-group")
+		if err != nil {
+			return err
+		}
+		for _, v := range securityGroups {
+			securityGroup, err := getSecurityGroupByNameOrID(v)
+			if err != nil {
+				return err
+			}
+			instancePool.SecurityGroupIDs = append(instancePool.SecurityGroupIDs, securityGroup.ID.String())
+		}
+
+		serviceOfferingFlagVal, err := cmd.Flags().GetString("service-offering")
+		if err != nil {
+			return err
+		}
+		serviceOffering, err := getServiceOfferingByNameOrID(serviceOfferingFlagVal)
+		if err != nil {
+			return err
+		}
+		instancePool.InstanceTypeID = serviceOffering.ID.String()
+
+		if instancePool.Size, err = cmd.Flags().GetInt64("size"); err != nil {
+			return err
+		}
+
+		if instancePool.SSHKey, err = cmd.Flags().GetString("keypair"); err != nil {
+			return err
+		}
+		if instancePool.SSHKey == "" {
+			instancePool.SSHKey = gCurrentAccount.DefaultSSHKey
+		}
+
+		templateFilterFlagVal, err := cmd.Flags().GetString("template-filter")
+		if err != nil {
+			return err
+		}
+		templateFilter, err := validateTemplateFilter(templateFilterFlagVal)
 		if err != nil {
 			return err
 		}
 
-		so, err := cmd.Flags().GetString("service-offering")
+		templateFlagVal, err := cmd.Flags().GetString("template")
 		if err != nil {
 			return err
 		}
+		template, err := getTemplateByNameOrID(zoneV1.ID, templateFlagVal, templateFilter)
+		if err != nil {
+			return err
+		}
+		instancePool.TemplateID = template.ID.String()
 
-		servOffering, err := getServiceOfferingByNameOrID(so)
-		if err != nil {
-			return err
-		}
-
-		templateFilterCmd, err := cmd.Flags().GetString("template-filter")
-		if err != nil {
-			return err
-		}
-		templateFilter, err := validateTemplateFilter(templateFilterCmd)
-		if err != nil {
-			return err
-		}
-
-		templateName, err := cmd.Flags().GetString("template")
-		if err != nil {
-			return err
-		}
-
-		template, err := getTemplateByNameOrID(zone.ID, templateName, templateFilter)
-		if err != nil {
-			return err
-		}
-
-		keypair, err := cmd.Flags().GetString("keypair")
-		if err != nil {
-			return err
-		}
-
-		if keypair == "" {
-			keypair = gCurrentAccount.DefaultSSHKey
-		}
-
-		size, err := cmd.Flags().GetInt("size")
-		if err != nil {
-			return err
-		}
-
-		diskSize, err := cmd.Flags().GetInt("disk")
-		if err != nil {
-			return err
-		}
-
-		aag, err := cmd.Flags().GetStringSlice("anti-affinity-group")
-		if err != nil {
-			return err
-		}
-		antiAffinityGroups, err := getAffinityGroupIDs(aag)
-		if err != nil {
-			return err
-		}
-
-		sg, err := cmd.Flags().GetStringSlice("security-group")
-		if err != nil {
-			return err
-		}
-		securityGroups, err := getSecurityGroupIDs(sg)
-		if err != nil {
-			return err
-		}
-
-		privnet, err := cmd.Flags().GetStringSlice("privnet")
-		if err != nil {
-			return err
-		}
-
-		privnets, err := getPrivnetIDs(privnet, zone.ID)
-		if err != nil {
-			return err
-		}
-
-		ipv6, err := cmd.Flags().GetBool("ipv6")
-		if err != nil {
-			return err
-		}
-
+		userData := ""
 		userDataPath, err := cmd.Flags().GetString("cloud-init")
 		if err != nil {
 			return err
 		}
-
-		userData := ""
-
 		if userDataPath != "" {
 			userData, err = getUserDataFromFile(userDataPath)
 			if err != nil {
 				return err
 			}
+			instancePool.UserData = userData
 		}
 
-		r := asyncTasks([]task{
-			{
-				egoscale.CreateInstancePool{
-					Name:                 args[0],
-					Description:          description,
-					ZoneID:               zone.ID,
-					ServiceOfferingID:    servOffering.ID,
-					TemplateID:           template.ID,
-					KeyPair:              keypair,
-					Size:                 size,
-					RootDiskSize:         diskSize,
-					AntiAffinityGroupIDs: antiAffinityGroups,
-					SecurityGroupIDs:     securityGroups,
-					NetworkIDs:           privnets,
-					IPv6:                 ipv6,
-					UserData:             userData,
-				},
-				fmt.Sprintf("Creating Instance Pool %q", args[0]),
-			},
+		decorateAsyncOperation(fmt.Sprintf("Creating Instance Pool %q...", instancePool.Name), func() {
+			instancePool, err = cs.CreateInstancePool(ctx, zone, instancePool)
 		})
-		errs := filterErrors(r)
-		if len(errs) > 0 {
-			return errs[0]
+		if err != nil {
+			return fmt.Errorf("unable to create Instance Pool: %s", err)
 		}
-		pool := r[0].resp.(*egoscale.CreateInstancePoolResponse)
 
 		if !gQuiet {
-			return showInstancePool(pool.ID.String(), pool.ZoneID.String())
+			return output(showInstancePool(zone, instancePool.ID))
 		}
 
 		return nil
@@ -174,20 +189,21 @@ Supported output template annotations: %s`,
 }
 
 func init() {
-	// Required Flags
-	instancePoolCreateCmd.Flags().StringP("service-offering", "o", "", serviceOfferingHelp)
-	instancePoolCreateCmd.Flags().StringP("template", "t", "", "Instance pool template")
-
-	instancePoolCreateCmd.Flags().StringP("zone", "z", "", "Instance pool zone")
-	instancePoolCreateCmd.Flags().IntP("size", "", 3, "Number of instance in the pool")
-	instancePoolCreateCmd.Flags().IntP("disk", "d", 50, "Disk size")
-	instancePoolCreateCmd.Flags().StringP("description", "", "", "Instance pool description")
-	instancePoolCreateCmd.Flags().StringP("cloud-init", "c", "", "Cloud-init file path")
+	instancePoolCreateCmd.Flags().StringSliceP("anti-affinity-group", "a", nil, "Anti-Affinity Group NAME|ID. Can be specified multiple times.")
+	instancePoolCreateCmd.Flags().StringP("cloud-init", "c", "", "Cloud-init user data configuration file path")
+	instancePoolCreateCmd.Flags().StringP("description", "", "", "Instance Pool description")
+	instancePoolCreateCmd.Flags().String("deploy-target", "", "Deploy Target NAME|ID")
+	instancePoolCreateCmd.Flags().Int64P("disk", "d", 50, "Instance Pool members disk size")
+	instancePoolCreateCmd.Flags().StringSliceP("elastic-ip", "e", nil, "Elastic IP ADDRESS. Can be specified multiple times.")
+	instancePoolCreateCmd.Flags().String("instance-prefix", "", "string to prefix Instance Pool member names with")
+	instancePoolCreateCmd.Flags().BoolP("ipv6", "6", false, "enable IPv6")
+	instancePoolCreateCmd.Flags().StringP("keypair", "k", "", "Instance Pool members SSH key")
+	instancePoolCreateCmd.Flags().StringSliceP("privnet", "p", nil, "Private Network NAME|ID. Can be specified multiple times.")
+	instancePoolCreateCmd.Flags().StringSliceP("security-group", "s", nil, "Security Group NAME|ID. Can be specified multiple times.")
+	instancePoolCreateCmd.Flags().StringP("service-offering", "o", defaultServiceOffering, serviceOfferingHelp)
+	instancePoolCreateCmd.Flags().Int64P("size", "", 1, "number of Compute instances in the Instance Pool")
+	instancePoolCreateCmd.Flags().StringP("template", "t", defaultTemplate, "Instance Pool members template NAME|ID")
 	instancePoolCreateCmd.Flags().StringP("template-filter", "", "featured", templateFilterHelp)
-	instancePoolCreateCmd.Flags().StringP("keypair", "k", "", "Instance pool keypair")
-	instancePoolCreateCmd.Flags().StringSliceP("anti-affinity-group", "a", nil, "Anti-Affinity group NAME|ID|NAME|ID. Can be specified multiple times.")
-	instancePoolCreateCmd.Flags().StringSliceP("security-group", "s", nil, "Security Group NAME|ID|NAME|ID. Can be specified multiple times.")
-	instancePoolCreateCmd.Flags().StringSliceP("privnet", "p", nil, "Private Network NAME|ID|NAME|ID. Can be specified multiple times.")
-	instancePoolCreateCmd.Flags().BoolP("ipv6", "6", false, "Enable IPv6")
+	instancePoolCreateCmd.Flags().StringP("zone", "z", "", "Zone to deploy the Instance Pool to")
 	instancePoolCmd.AddCommand(instancePoolCreateCmd)
 }

--- a/cmd/instance_pool_evict.go
+++ b/cmd/instance_pool_evict.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"fmt"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+var instancePoolEvictCmd = &cobra.Command{
+	Use:   "evict INSTANCE-POOL-NAME|ID INSTANCE-NAME|ID...",
+	Short: "Evict Instance Pool members",
+	Long: `This command evicts specific members from an Instance Pool, effectively
+scaling down the Instance Pool similar to the "exo instancepool scale" command.`,
+
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 2 {
+			cmdExitOnUsageError(cmd, "invalid arguments")
+		}
+
+		cmdSetZoneFlagFromDefault(cmd)
+
+		return cmdCheckRequiredFlags(cmd, []string{"zone"})
+	},
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var (
+			i         = args[0]
+			instances = args[1:]
+		)
+
+		zone, err := cmd.Flags().GetString("zone")
+		if err != nil {
+			return err
+		}
+
+		force, err := cmd.Flags().GetBool("force")
+		if err != nil {
+			return err
+		}
+		if !force {
+			if !askQuestion(fmt.Sprintf("Are you sure you want to evict %v from Instance Pool %q?", instances, i)) {
+				return nil
+			}
+		}
+
+		ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+
+		instancePool, err := lookupInstancePool(ctx, zone, i)
+		if err != nil {
+			return err
+		}
+
+		members := make([]string, len(args[1:]))
+		for i, n := range args[2:] {
+			instance, err := getVirtualMachineByNameOrID(n)
+			if err != nil {
+				return fmt.Errorf("invalid Instance %q: %s", n, err)
+			}
+			members[i] = instance.ID.String()
+		}
+
+		decorateAsyncOperation(fmt.Sprintf("Evicting Instances from Instance Pool %q...", instancePool.Name), func() {
+			err = instancePool.EvictMembers(ctx, members)
+		})
+		if err != nil {
+			return err
+		}
+
+		if !gQuiet {
+			return output(showInstancePool(zone, instancePool.ID))
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	instancePoolEvictCmd.Flags().BoolP("force", "f", false, cmdFlagForceHelp)
+	instancePoolEvictCmd.Flags().StringP("zone", "z", "", "Instance Pool zone")
+	instancePoolCmd.AddCommand(instancePoolEvictCmd)
+}

--- a/cmd/instance_pool_scale.go
+++ b/cmd/instance_pool_scale.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+var instancePoolScaleCmd = &cobra.Command{
+	Use:   "scale NAME|ID SIZE",
+	Short: "Scale an Instance Pool size",
+	Long: `This command scales an Instance Pool size up (growing) or down
+(shrinking).
+
+In case of a scale-down, operators should use the "exo instancepool evict"
+variant, allowing them to specify which specific instance should be evicted
+from the Instance Pool rather than leaving the decision to the orchestrator.`,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 2 {
+			cmdExitOnUsageError(cmd, "invalid arguments")
+		}
+
+		cmdSetZoneFlagFromDefault(cmd)
+
+		return cmdCheckRequiredFlags(cmd, []string{"zone"})
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		size, err := strconv.Atoi(args[1])
+		if err != nil {
+			return fmt.Errorf("invalid size %q", args[1])
+		}
+		if size <= 0 {
+			return errors.New("minimum Instance Pool size is 1")
+		}
+
+		zone, err := cmd.Flags().GetString("zone")
+		if err != nil {
+			return err
+		}
+
+		force, err := cmd.Flags().GetBool("force")
+		if err != nil {
+			return err
+		}
+
+		ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+		instancePool, err := lookupInstancePool(ctx, zone, args[0])
+		if err != nil {
+			return err
+		}
+
+		if !force {
+			if !askQuestion(fmt.Sprintf(
+				"Are you sure you want to scale Instance Pool %q to %d?",
+				instancePool.Name,
+				size),
+			) {
+				return nil
+			}
+		}
+
+		decorateAsyncOperation(fmt.Sprintf("Scaling Instance Pool %q...", instancePool.Name), func() {
+			err = instancePool.Scale(ctx, int64(size))
+		})
+		if err != nil {
+			return err
+		}
+
+		if !gQuiet {
+			return output(showInstancePool(zone, instancePool.ID))
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	instancePoolScaleCmd.Flags().BoolP("force", "f", false, cmdFlagForceHelp)
+	instancePoolScaleCmd.Flags().StringP("zone", "z", "", "SKS cluster zone")
+	instancePoolCmd.AddCommand(instancePoolScaleCmd)
+}

--- a/cmd/instance_pool_update.go
+++ b/cmd/instance_pool_update.go
@@ -2,11 +2,24 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
-	"github.com/exoscale/egoscale"
+	exoapi "github.com/exoscale/egoscale/v2/api"
 	"github.com/spf13/cobra"
 )
+
+var instancePoolResetFields = []string{
+	"anti-affinity-groups",
+	"deploy-target",
+	"description",
+	"elastic-ips",
+	"ipv6",
+	"private-networks",
+	"ssh-key",
+	"security-groups",
+	"user-data",
+}
 
 var instancePoolUpdateCmd = &cobra.Command{
 	Use:   "update NAME|ID",
@@ -14,120 +27,290 @@ var instancePoolUpdateCmd = &cobra.Command{
 	Long: fmt.Sprintf(`This command updates an Instance Pool.
 
 Supported output template annotations: %s`,
-		strings.Join(outputterTemplateAnnotations(&instancePoolItemOutput{}), ", ")),
+		strings.Join(outputterTemplateAnnotations(&instancePoolShowOutput{}), ", ")),
 	Aliases: gCreateAlias,
+
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
 			cmdExitOnUsageError(cmd, "invalid arguments")
+		}
+
+		resetFields, err := cmd.Flags().GetStringSlice("reset")
+		if err != nil {
+			return err
+		}
+		for _, f := range resetFields {
+			if !isInList(instancePoolResetFields, f) {
+				cmdExitOnUsageError(cmd, fmt.Sprintf("--reset: unsupported property %q", f))
+			}
 		}
 
 		cmdSetZoneFlagFromDefault(cmd)
 
 		return cmdCheckRequiredFlags(cmd, []string{"zone"})
 	},
+
 	RunE: func(cmd *cobra.Command, args []string) error {
-		name, err := cmd.Flags().GetString("name")
+		var updated bool
+
+		zone, err := cmd.Flags().GetString("zone")
 		if err != nil {
 			return err
 		}
 
-		description, err := cmd.Flags().GetString("description")
+		ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+
+		zoneV1, err := getZoneByNameOrID(zone)
 		if err != nil {
 			return err
 		}
 
-		zoneName, err := cmd.Flags().GetString("zone")
+		instancePool, err := lookupInstancePool(ctx, zone, args[0])
 		if err != nil {
 			return err
 		}
 
-		zone, err := getZoneByNameOrID(zoneName)
+		resetFields, err := cmd.Flags().GetStringSlice("reset")
 		if err != nil {
 			return err
 		}
 
-		templateFilterCmd, err := cmd.Flags().GetString("template-filter")
-		if err != nil {
-			return err
-		}
-		templateFilter, err := validateTemplateFilter(templateFilterCmd)
-		if err != nil {
-			return err
-		}
-
-		template := new(egoscale.Template)
-		templateName, err := cmd.Flags().GetString("template")
-		if err != nil {
-			return err
-		}
-
-		if templateName != "" {
-			template, err = getTemplateByNameOrID(zone.ID, templateName, templateFilter)
+		if cmd.Flags().Changed("anti-affinity-group") {
+			antiAffinityGroups, err := cmd.Flags().GetStringSlice("anti-affinity-group")
 			if err != nil {
 				return err
 			}
+
+			instancePool.AntiAffinityGroupIDs = make([]string, 0)
+			for _, v := range antiAffinityGroups {
+				antiAffinityGroup, err := getAntiAffinityGroupByNameOrID(v)
+				if err != nil {
+					return err
+				}
+				instancePool.AntiAffinityGroupIDs = append(
+					instancePool.AntiAffinityGroupIDs,
+					antiAffinityGroup.ID.String(),
+				)
+			}
+			updated = true
 		}
 
-		diskSize, err := cmd.Flags().GetInt("disk")
-		if err != nil {
-			return err
-		}
-
-		ipv6, err := cmd.Flags().GetBool("ipv6")
-		if err != nil {
-			return err
-		}
-
-		userDataPath, err := cmd.Flags().GetString("cloud-init")
-		if err != nil {
-			return err
-		}
-
-		userData := ""
-		if userDataPath != "" {
-			userData, err = getUserDataFromFile(userDataPath)
+		if cmd.Flags().Changed("deploy-target") {
+			deployTargetFlagVal, err := cmd.Flags().GetString("deploy-target")
 			if err != nil {
 				return err
 			}
+
+			deployTarget, err := lookupDeployTarget(ctx, zone, deployTargetFlagVal)
+			if err != nil {
+				return err
+			}
+			instancePool.DeployTargetID = deployTarget.ID
+			updated = true
 		}
 
-		instancePool, err := getInstancePoolByNameOrID(args[0], zone.ID)
-		if err != nil {
-			return err
+		if cmd.Flags().Changed("description") {
+			if instancePool.Description, err = cmd.Flags().GetString("description"); err != nil {
+				return err
+			}
+			updated = true
 		}
 
-		size, err := cmd.Flags().GetInt("size")
-		if err != nil {
-			return err
+		if cmd.Flags().Changed("disk") {
+			if instancePool.DiskSize, err = cmd.Flags().GetInt64("disk"); err != nil {
+				return err
+			}
+			updated = true
 		}
 
-		_, err = cs.RequestWithContext(gContext, &egoscale.UpdateInstancePool{
-			ID:           instancePool.ID,
-			ZoneID:       zone.ID,
-			Name:         name,
-			Description:  description,
-			TemplateID:   template.ID,
-			RootDiskSize: diskSize,
-			IPv6:         ipv6,
-			UserData:     userData,
+		if cmd.Flags().Changed("elastic-ip") {
+			elasticIPs, err := cmd.Flags().GetStringSlice("elastic-ip")
+			if err != nil {
+				return err
+			}
+
+			instancePool.ElasticIPIDs = make([]string, 0)
+			for _, v := range elasticIPs {
+				elasticIP, err := getElasticIPByAddressOrID(v)
+				if err != nil {
+					return err
+				}
+				instancePool.ElasticIPIDs = append(instancePool.ElasticIPIDs, elasticIP.ID.String())
+			}
+			updated = true
+		}
+
+		if cmd.Flags().Changed("instance-prefix") {
+			if instancePool.InstancePrefix, err = cmd.Flags().GetString("instance-prefix"); err != nil {
+				return err
+			}
+			updated = true
+		}
+
+		if cmd.Flags().Changed("ipv6") {
+			if instancePool.IPv6Enabled, err = cmd.Flags().GetBool("ipv6"); err != nil {
+				return err
+			}
+			updated = true
+		}
+
+		if cmd.Flags().Changed("name") {
+			if instancePool.Name, err = cmd.Flags().GetString("name"); err != nil {
+				return err
+			}
+			updated = true
+		}
+
+		if cmd.Flags().Changed("privnet") {
+			privateNetworks, err := cmd.Flags().GetStringSlice("privnet")
+			if err != nil {
+				return err
+			}
+
+			instancePool.PrivateNetworkIDs = make([]string, 0)
+			for _, v := range privateNetworks {
+				privateNetwork, err := getNetwork(v, zoneV1.ID)
+				if err != nil {
+					return err
+				}
+				instancePool.PrivateNetworkIDs = append(instancePool.PrivateNetworkIDs, privateNetwork.ID.String())
+			}
+			updated = true
+		}
+
+		if cmd.Flags().Changed("security-group") {
+			securityGroups, err := cmd.Flags().GetStringSlice("security-group")
+			if err != nil {
+				return err
+			}
+
+			instancePool.SecurityGroupIDs = make([]string, 0)
+			for _, v := range securityGroups {
+				securityGroup, err := getSecurityGroupByNameOrID(v)
+				if err != nil {
+					return err
+				}
+				instancePool.SecurityGroupIDs = append(instancePool.SecurityGroupIDs, securityGroup.ID.String())
+			}
+			updated = true
+		}
+
+		if cmd.Flags().Changed("service-offering") {
+			serviceOfferingFlagVal, err := cmd.Flags().GetString("service-offering")
+			if err != nil {
+				return err
+			}
+			serviceOffering, err := getServiceOfferingByNameOrID(serviceOfferingFlagVal)
+			if err != nil {
+				return err
+			}
+			instancePool.InstanceTypeID = serviceOffering.ID.String()
+			updated = true
+		}
+
+		if cmd.Flags().Changed("keypair") {
+			if instancePool.SSHKey, err = cmd.Flags().GetString("keypair"); err != nil {
+				return err
+			}
+			updated = true
+		}
+
+		if cmd.Flags().Changed("template") {
+			templateFilterFlagVal, err := cmd.Flags().GetString("template-filter")
+			if err != nil {
+				return err
+			}
+			templateFilter, err := validateTemplateFilter(templateFilterFlagVal)
+			if err != nil {
+				return err
+			}
+
+			templateFlagVal, err := cmd.Flags().GetString("template")
+			if err != nil {
+				return err
+			}
+			template, err := getTemplateByNameOrID(zoneV1.ID, templateFlagVal, templateFilter)
+			if err != nil {
+				return err
+			}
+			instancePool.TemplateID = template.ID.String()
+			updated = true
+		}
+
+		if cmd.Flags().Changed("cloud-init") {
+			userData := ""
+			userDataPath, err := cmd.Flags().GetString("cloud-init")
+			if err != nil {
+				return err
+			}
+			if userDataPath != "" {
+				userData, err = getUserDataFromFile(userDataPath)
+				if err != nil {
+					return err
+				}
+				instancePool.UserData = userData
+			}
+			updated = true
+		}
+
+		decorateAsyncOperation(fmt.Sprintf("Updating Instance Pool %q...", instancePool.Name), func() {
+			if updated {
+				if err = cs.UpdateInstancePool(ctx, zone, instancePool); err != nil {
+					return
+				}
+			}
+
+			for _, f := range resetFields {
+				switch f {
+				case "anti-affinity-groups":
+					err = instancePool.ResetField(ctx, &instancePool.AntiAffinityGroupIDs)
+				case "elastic-ips":
+					err = instancePool.ResetField(ctx, &instancePool.ElasticIPIDs)
+				case "deploy-target":
+					err = instancePool.ResetField(ctx, &instancePool.DeployTargetID)
+				case "description":
+					err = instancePool.ResetField(ctx, &instancePool.Description)
+				case "ipv6":
+					err = instancePool.ResetField(ctx, &instancePool.IPv6Enabled)
+				case "private-networks":
+					err = instancePool.ResetField(ctx, &instancePool.PrivateNetworkIDs)
+				case "security-groups":
+					err = instancePool.ResetField(ctx, &instancePool.SecurityGroupIDs)
+				case "ssh-key":
+					err = instancePool.ResetField(ctx, &instancePool.SSHKey)
+				case "user-data":
+					err = instancePool.ResetField(ctx, &instancePool.UserData)
+				}
+				if err != nil {
+					return
+				}
+			}
 		})
 		if err != nil {
 			return err
 		}
 
-		if size > 0 {
-			_, err = cs.RequestWithContext(gContext, &egoscale.ScaleInstancePool{
-				ID:     instancePool.ID,
-				ZoneID: instancePool.ZoneID,
-				Size:   size,
-			})
+		if cmd.Flags().Changed("size") {
+			size, err := cmd.Flags().GetInt64("size")
 			if err != nil {
 				return err
+			}
+
+			if size > 0 {
+				fmt.Fprintln(
+					os.Stderr,
+					`WARNING: the "--size" flag is deprecated and replaced by the `+
+						`"exo instancepool scale" command, it will be removed in a future version.`,
+				)
+
+				decorateAsyncOperation(fmt.Sprintf("Scaling Instance Pool %q...", instancePool.Name), func() {
+					err = instancePool.Scale(ctx, int64(size))
+				})
 			}
 		}
 
 		if !gQuiet {
-			return showInstancePool(instancePool.ID.String(), instancePool.ZoneID.String())
+			return output(showInstancePool(zone, instancePool.ID))
 		}
 
 		return nil
@@ -135,14 +318,23 @@ Supported output template annotations: %s`,
 }
 
 func init() {
-	instancePoolUpdateCmd.Flags().StringP("zone", "z", "", "Instance pool zone")
-	instancePoolUpdateCmd.Flags().StringP("name", "n", "", "Instance pool name")
-	instancePoolUpdateCmd.Flags().StringP("description", "d", "", "Instance pool description")
-	instancePoolUpdateCmd.Flags().StringP("template", "t", "", "Instance pool template")
+	instancePoolUpdateCmd.Flags().StringSliceP("anti-affinity-group", "a", nil, "Anti-Affinity Group NAME|ID. Can be specified multiple times.")
+	instancePoolUpdateCmd.Flags().StringP("cloud-init", "c", "", "Cloud-init user data configuration file path")
+	instancePoolUpdateCmd.Flags().StringP("description", "", "", "Instance Pool description")
+	instancePoolUpdateCmd.Flags().String("deploy-target", "", "Deploy Target NAME|ID")
+	instancePoolUpdateCmd.Flags().Int64P("disk", "d", 50, "Instance Pool members disk size")
+	instancePoolUpdateCmd.Flags().StringSliceP("elastic-ip", "e", nil, "Elastic IP ADDRESS. Can be specified multiple times.")
+	instancePoolUpdateCmd.Flags().String("instance-prefix", "", "string to prefix Instance Pool member names with")
+	instancePoolUpdateCmd.Flags().BoolP("ipv6", "6", false, "enable IPv6")
+	instancePoolUpdateCmd.Flags().StringP("keypair", "k", "", "Instance Pool members SSH key")
+	instancePoolUpdateCmd.Flags().StringP("name", "n", "", "Instance Pool name")
+	instancePoolUpdateCmd.Flags().StringSliceP("privnet", "p", nil, "Private Network NAME|ID. Can be specified multiple times.")
+	instancePoolUpdateCmd.Flags().StringSliceP("reset", "r", nil, fmt.Sprintf("properties to reset to default value. Supported values: %s", strings.Join(instancePoolResetFields, ", ")))
+	instancePoolUpdateCmd.Flags().StringSliceP("security-group", "s", nil, "Security Group NAME|ID. Can be specified multiple times.")
+	instancePoolUpdateCmd.Flags().StringP("service-offering", "o", "", serviceOfferingHelp)
+	instancePoolUpdateCmd.Flags().Int64P("size", "", 1, "number of Compute instances in the Instance Pool")
+	instancePoolUpdateCmd.Flags().StringP("template", "t", "", "Instance Pool members template NAME|ID")
 	instancePoolUpdateCmd.Flags().StringP("template-filter", "", "featured", templateFilterHelp)
-	instancePoolUpdateCmd.Flags().StringP("cloud-init", "c", "", "Cloud-init file path")
-	instancePoolUpdateCmd.Flags().IntP("size", "s", 0, "Update Instance Pool size")
-	instancePoolUpdateCmd.Flags().Int("disk", 0, "Disk size")
-	instancePoolUpdateCmd.Flags().BoolP("ipv6", "6", false, "Enable IPv6")
+	instancePoolUpdateCmd.Flags().StringP("zone", "z", "", "Zone to deploy the Instance Pool to")
 	instancePoolCmd.AddCommand(instancePoolUpdateCmd)
 }

--- a/cmd/nlb_list.go
+++ b/cmd/nlb_list.go
@@ -47,7 +47,7 @@ func listNLBs(zone string) outputter {
 	if zone != "" {
 		nlbZones = []string{zone}
 	} else {
-		nlbZones = zones
+		nlbZones = allZones
 	}
 
 	out := make(nlbListOutput, 0)

--- a/cmd/nlb_update.go
+++ b/cmd/nlb_update.go
@@ -47,7 +47,7 @@ var nlbUpdateCmd = &cobra.Command{
 			nlb.Description = description
 		}
 
-		if _, err := cs.UpdateNetworkLoadBalancer(ctx, zone, nlb); err != nil {
+		if err := cs.UpdateNetworkLoadBalancer(ctx, zone, nlb); err != nil {
 			return fmt.Errorf("unable to update Network Load Balancer: %s", err)
 		}
 

--- a/cmd/sks.go
+++ b/cmd/sks.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	v2 "github.com/exoscale/egoscale/v2"
+	exov2 "github.com/exoscale/egoscale/v2"
 	"github.com/spf13/cobra"
 )
 
@@ -24,7 +24,7 @@ func init() {
 }
 
 // lookupSKSCluster attempts to look up a SKS cluster resource by name or ID.
-func lookupSKSCluster(ctx context.Context, zone, v string) (*v2.SKSCluster, error) {
+func lookupSKSCluster(ctx context.Context, zone, v string) (*exov2.SKSCluster, error) {
 	clusters, err := cs.ListSKSClusters(ctx, zone)
 	if err != nil {
 		return nil, fmt.Errorf("unable to list SKS clusters in zone %s: %v", zone, err)

--- a/cmd/sks_list.go
+++ b/cmd/sks_list.go
@@ -46,7 +46,7 @@ func listSKSClusters(zone string) outputter {
 	if zone != "" {
 		sksClusterZones = []string{zone}
 	} else {
-		sksClusterZones = zones
+		sksClusterZones = allZones
 	}
 
 	out := make(sksClusterListOutput, 0)

--- a/cmd/sks_nodepool_add.go
+++ b/cmd/sks_nodepool_add.go
@@ -36,13 +36,9 @@ Supported output template annotations: %s`,
 			nodepool *exov2.SKSNodepool
 		)
 
-		z, err := cmd.Flags().GetString("zone")
+		zone, err := cmd.Flags().GetString("zone")
 		if err != nil {
 			return err
-		}
-		zone, err := getZoneByNameOrID(z)
-		if err != nil {
-			return fmt.Errorf("error retrieving zone: %s", err)
 		}
 
 		description, err := cmd.Flags().GetString("description")
@@ -95,8 +91,8 @@ Supported output template annotations: %s`,
 			}
 		}
 
-		ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone.Name))
-		cluster, err := lookupSKSCluster(ctx, zone.Name, c)
+		ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+		cluster, err := lookupSKSCluster(ctx, zone, c)
 		if err != nil {
 			return err
 		}

--- a/cmd/sks_nodepool_evict.go
+++ b/cmd/sks_nodepool_evict.go
@@ -13,7 +13,7 @@ var sksNodepoolEvictCmd = &cobra.Command{
 	Use:   "evict CLUSTER-NAME|ID NODEPOOL-NAME|ID NODE-NAME|ID...",
 	Short: "Evict SKS cluster Nodepool members",
 	Long: `This command evicts specific members from a SKS cluster Nodepool, effectively
-shrinking down the Nodepool similar to the "exo sks nodepool scale" command.
+scaling down the Nodepool similar to the "exo sks nodepool scale" command.
 
 Note: Kubernetes Nodes should be drained from their workload prior to being
 evicted from their Nodepool, e.g. using "kubectl drain".`,
@@ -36,13 +36,9 @@ evicted from their Nodepool, e.g. using "kubectl drain".`,
 			nodepool *exov2.SKSNodepool
 		)
 
-		z, err := cmd.Flags().GetString("zone")
+		zone, err := cmd.Flags().GetString("zone")
 		if err != nil {
 			return err
-		}
-		zone, err := getZoneByNameOrID(z)
-		if err != nil {
-			return fmt.Errorf("error retrieving zone: %s", err)
 		}
 
 		force, err := cmd.Flags().GetBool("force")
@@ -56,8 +52,8 @@ evicted from their Nodepool, e.g. using "kubectl drain".`,
 			}
 		}
 
-		ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone.Name))
-		cluster, err := lookupSKSCluster(ctx, zone.Name, c)
+		ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+		cluster, err := lookupSKSCluster(ctx, zone, c)
 		if err != nil {
 			return err
 		}

--- a/cmd/sks_nodepool_list.go
+++ b/cmd/sks_nodepool_list.go
@@ -49,7 +49,7 @@ func listSKSNodepools(zone string) outputter {
 	if zone != "" {
 		sksClusterZones = []string{zone}
 	} else {
-		sksClusterZones = zones
+		sksClusterZones = allZones
 	}
 
 	out := make(sksNodepoolListOutput, 0)

--- a/cmd/sks_nodepool_scale.go
+++ b/cmd/sks_nodepool_scale.go
@@ -44,17 +44,13 @@ the pool rather than leaving the decision to the SKS manager.`,
 			return errors.New("minimum Nodepool size is 1")
 		}
 
-		z, err := cmd.Flags().GetString("zone")
+		zone, err := cmd.Flags().GetString("zone")
 		if err != nil {
 			return err
 		}
-		zone, err := getZoneByNameOrID(z)
-		if err != nil {
-			return fmt.Errorf("error retrieving zone: %s", err)
-		}
 
-		ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone.Name))
-		cluster, err := lookupSKSCluster(ctx, zone.Name, c)
+		ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+		cluster, err := lookupSKSCluster(ctx, zone, c)
 		if err != nil {
 			return err
 		}

--- a/cmd/sks_nodepool_scale.go
+++ b/cmd/sks_nodepool_scale.go
@@ -49,6 +49,11 @@ the pool rather than leaving the decision to the SKS manager.`,
 			return err
 		}
 
+		force, err := cmd.Flags().GetBool("force")
+		if err != nil {
+			return err
+		}
+
 		ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
 		cluster, err := lookupSKSCluster(ctx, zone, c)
 		if err != nil {
@@ -63,6 +68,12 @@ the pool rather than leaving the decision to the SKS manager.`,
 		}
 		if nodepool == nil {
 			return errors.New("Nodepool not found") // nolint:golint
+		}
+
+		if !force {
+			if !askQuestion(fmt.Sprintf("Are you sure you want to scale Nodepool %q to %d?", nodepool.Name, size)) {
+				return nil
+			}
 		}
 
 		decorateAsyncOperation(fmt.Sprintf("Scaling Nodepool %q...", np), func() {
@@ -81,6 +92,7 @@ the pool rather than leaving the decision to the SKS manager.`,
 }
 
 func init() {
+	sksNodepoolScaleCmd.Flags().BoolP("force", "f", false, cmdFlagForceHelp)
 	sksNodepoolScaleCmd.Flags().StringP("zone", "z", "", "SKS cluster zone")
 	sksNodepoolCmd.AddCommand(sksNodepoolScaleCmd)
 }

--- a/cmd/sks_nodepool_update.go
+++ b/cmd/sks_nodepool_update.go
@@ -29,17 +29,13 @@ var sksNodepoolUpdateCmd = &cobra.Command{
 			nodepool *exov2.SKSNodepool
 		)
 
-		z, err := cmd.Flags().GetString("zone")
+		zone, err := cmd.Flags().GetString("zone")
 		if err != nil {
 			return err
 		}
-		zone, err := getZoneByNameOrID(z)
-		if err != nil {
-			return fmt.Errorf("error retrieving zone: %s", err)
-		}
 
-		ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone.Name))
-		cluster, err := lookupSKSCluster(ctx, zone.Name, c)
+		ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+		cluster, err := lookupSKSCluster(ctx, zone, c)
 		if err != nil {
 			return err
 		}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -2,8 +2,8 @@ package cmd
 
 // isInList returns true if v exists in the specified list, false otherwise.
 func isInList(list []string, v string) bool {
-	for _, acl := range list {
-		if acl == v {
+	for _, lv := range list {
+		if lv == v {
 			return true
 		}
 	}

--- a/cmd/vm.go
+++ b/cmd/vm.go
@@ -106,7 +106,7 @@ func getUserDataFromFile(path string) (string, error) {
 		return "", err
 	}
 
-	userData, err := prepareUserData(data)
+	userData, err := encodeUserData(data)
 	if err != nil {
 		return "", err
 	}
@@ -118,7 +118,7 @@ func getUserDataFromFile(path string) (string, error) {
 	return userData, nil
 }
 
-func prepareUserData(data []byte) (string, error) {
+func encodeUserData(data []byte) (string, error) {
 	b := new(bytes.Buffer)
 	gz := gzip.NewWriter(b)
 

--- a/cmd/vm.go
+++ b/cmd/vm.go
@@ -135,6 +135,31 @@ func encodeUserData(data []byte) (string, error) {
 	return base64.StdEncoding.EncodeToString(b.Bytes()), nil
 }
 
+func decodeUserData(data string) (string, error) {
+	base64Decoded, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return "", err
+	}
+
+	gz, err := gzip.NewReader(bytes.NewReader(base64Decoded))
+	if err != nil {
+		// User data are not compressed, returning as-is.
+		if errors.Is(err, gzip.ErrHeader) {
+			return string(base64Decoded), nil
+		}
+
+		return "", err
+	}
+	defer gz.Close()
+
+	userData, err := ioutil.ReadAll(gz)
+	if err != nil {
+		return "", err
+	}
+
+	return string(userData), nil
+}
+
 func init() {
 	RootCmd.AddCommand(vmCmd)
 }

--- a/cmd/zone.go
+++ b/cmd/zone.go
@@ -13,8 +13,8 @@ const (
 	zoneHelp = "zone NAME|ID (ch-dk-2|ch-gva-2|at-vie-1|de-fra-1|bg-sof-1|de-muc-1)"
 )
 
-// zones represents the list of known Exoscale zones, in case we need it without performing API lookup.
-var zones = []string{
+// allZones represents the list of known Exoscale zones, in case we need it without performing API lookup.
+var allZones = []string{
 	"at-vie-1",
 	"bg-sof-1",
 	"ch-dk-2",

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/deepmap/oapi-codegen v1.5.1 // indirect
 	github.com/dustin/go-humanize v1.0.0
-	github.com/exoscale/egoscale v0.47.0
+	github.com/exoscale/egoscale v0.48.1
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/exoscale/egoscale v0.47.0 h1:DZIksW3qItXlMWsyAZHDtnyxFEh89bl0LyW3L1zlN9w=
-github.com/exoscale/egoscale v0.47.0/go.mod h1:pA0kDBbN+dyncVazLuGXcVf38WfuzbKa6ce5T0iex0w=
+github.com/exoscale/egoscale v0.48.1 h1:UEhZxsTO/l8hw0KP839u9SV1q6pSiNYiABAbvKA9x/8=
+github.com/exoscale/egoscale v0.48.1/go.mod h1:pA0kDBbN+dyncVazLuGXcVf38WfuzbKa6ce5T0iex0w=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/.golangci.yml
+++ b/vendor/github.com/exoscale/egoscale/.golangci.yml
@@ -13,6 +13,7 @@ linters:
   enable:
     - deadcode
     - errcheck
+    - exportloopref
     - gocritic
     - gocyclo
     - goimports
@@ -22,7 +23,6 @@ linters:
     - ineffassign
     - megacheck
     - nakedret
-    - scopelint
     - staticcheck
     - structcheck
     - unused

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,21 @@
 Changelog
 =========
 
+0.48.1
+------
+
+- fix: v2: add support for `InstancePool.IPv6Enabled` field resetting
+
+0.48.0
+------
+
+- feature: v2: add support for Instance prefix to Instance Pools
+- feature: v2: add support for Deploy Targets
+- feature: v2: add support for Compute instances management
+- feature: v2: add support for Snapshots management
+- feature: v2: add support for Templates management
+- feature: v2: add getter methods on API resources
+
 0.47.0
 ------
 

--- a/vendor/github.com/exoscale/egoscale/v2/anti_affinity_group.go
+++ b/vendor/github.com/exoscale/egoscale/v2/anti_affinity_group.go
@@ -22,9 +22,16 @@ func antiAffinityGroupFromAPI(a *papi.AntiAffinityGroup) *AntiAffinityGroup {
 	}
 }
 
+func (a AntiAffinityGroup) get(ctx context.Context, client *Client, zone, id string) (interface{}, error) {
+	return client.GetAntiAffinityGroup(ctx, zone, id)
+}
+
 // CreateAntiAffinityGroup creates an Anti-Affinity Group in the specified zone.
-func (c *Client) CreateAntiAffinityGroup(ctx context.Context, zone string,
-	antiAffinityGroup *AntiAffinityGroup) (*AntiAffinityGroup, error) {
+func (c *Client) CreateAntiAffinityGroup(
+	ctx context.Context,
+	zone string,
+	antiAffinityGroup *AntiAffinityGroup,
+) (*AntiAffinityGroup, error) {
 	resp, err := c.CreateAntiAffinityGroupWithResponse(
 		apiv2.WithZone(ctx, zone),
 		papi.CreateAntiAffinityGroupJSONRequestBody{

--- a/vendor/github.com/exoscale/egoscale/v2/deploy_target.go
+++ b/vendor/github.com/exoscale/egoscale/v2/deploy_target.go
@@ -1,0 +1,53 @@
+package v2
+
+import (
+	"context"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	papi "github.com/exoscale/egoscale/v2/internal/public-api"
+)
+
+// DeployTarget represents a Deploy Target.
+type DeployTarget struct {
+	Description string
+	ID          string
+	Name        string
+	Type        string
+}
+
+func deployTargetFromAPI(d *papi.DeployTarget) *DeployTarget {
+	return &DeployTarget{
+		Description: papi.OptionalString(d.Description),
+		ID:          *d.Id,
+		Name:        papi.OptionalString(d.Name),
+		Type:        *d.Type,
+	}
+}
+
+// ListDeployTargets returns the list of existing Deploy Targets in the specified zone.
+func (c *Client) ListDeployTargets(ctx context.Context, zone string) ([]*DeployTarget, error) {
+	list := make([]*DeployTarget, 0)
+
+	resp, err := c.ListDeployTargetsWithResponse(apiv2.WithZone(ctx, zone))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.DeployTargets != nil {
+		for i := range *resp.JSON200.DeployTargets {
+			list = append(list, deployTargetFromAPI(&(*resp.JSON200.DeployTargets)[i]))
+		}
+	}
+
+	return list, nil
+}
+
+// GetDeployTarget returns the Deploy Target corresponding to the specified ID in the specified zone.
+func (c *Client) GetDeployTarget(ctx context.Context, zone, id string) (*DeployTarget, error) {
+	resp, err := c.GetDeployTargetWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	return deployTargetFromAPI(resp.JSON200), nil
+}

--- a/vendor/github.com/exoscale/egoscale/v2/instance.go
+++ b/vendor/github.com/exoscale/egoscale/v2/instance.go
@@ -1,0 +1,336 @@
+package v2
+
+import (
+	"context"
+	"net"
+	"time"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	papi "github.com/exoscale/egoscale/v2/internal/public-api"
+)
+
+// Instance represents a Compute instance.
+type Instance struct {
+	AntiAffinityGroupIDs []string
+	CreatedAt            time.Time
+	DiskSize             int64
+	ElasticIPIDs         []string
+	ID                   string
+	IPv6Address          net.IP
+	IPv6Enabled          bool
+	InstanceTypeID       string
+	ManagerID            string
+	Name                 string
+	PrivateNetworkIDs    []string
+	PublicIPAddress      net.IP
+	SSHKey               string
+	SecurityGroupIDs     []string
+	SnapshotIDs          []string
+	State                string
+	TemplateID           string
+	UserData             string
+
+	c    *Client
+	zone string
+}
+
+func instanceFromAPI(client *Client, zone string, i *papi.Instance) *Instance {
+	return &Instance{
+		AntiAffinityGroupIDs: func() []string {
+			ids := make([]string, 0)
+
+			if i.AntiAffinityGroups != nil {
+				for _, item := range *i.AntiAffinityGroups {
+					item := item
+					ids = append(ids, *item.Id)
+				}
+			}
+
+			return ids
+		}(),
+		CreatedAt: *i.CreatedAt,
+		DiskSize:  *i.DiskSize,
+		ElasticIPIDs: func() []string {
+			ids := make([]string, 0)
+
+			if i.ElasticIps != nil {
+				for _, item := range *i.ElasticIps {
+					item := item
+					ids = append(ids, *item.Id)
+				}
+			}
+
+			return ids
+		}(),
+		ID: *i.Id,
+		IPv6Address: func() net.IP {
+			if i.Ipv6Address != nil {
+				return net.ParseIP(*i.Ipv6Address)
+			}
+			return nil
+		}(),
+		IPv6Enabled: func() bool {
+			return i.Ipv6Address != nil
+		}(),
+		InstanceTypeID: *i.InstanceType.Id,
+		ManagerID: func() string {
+			if i.Manager != nil {
+				return papi.OptionalString(i.Manager.Id)
+			}
+			return ""
+		}(),
+		Name: *i.Name,
+		PrivateNetworkIDs: func() []string {
+			ids := make([]string, 0)
+
+			if i.PrivateNetworks != nil {
+				for _, item := range *i.PrivateNetworks {
+					item := item
+					ids = append(ids, *item.Id)
+				}
+			}
+
+			return ids
+		}(),
+		PublicIPAddress: net.ParseIP(papi.OptionalString(i.PublicIp)),
+		SSHKey: func() string {
+			key := ""
+			if i.SshKey != nil {
+				key = papi.OptionalString(i.SshKey.Name)
+			}
+			return key
+		}(),
+		SecurityGroupIDs: func() []string {
+			ids := make([]string, 0)
+
+			if i.SecurityGroups != nil {
+				for _, item := range *i.SecurityGroups {
+					item := item
+					ids = append(ids, *item.Id)
+				}
+			}
+
+			return ids
+		}(),
+		SnapshotIDs: func() []string {
+			ids := make([]string, 0)
+
+			if i.Snapshots != nil {
+				for _, item := range *i.Snapshots {
+					item := item
+					ids = append(ids, *item.Id)
+				}
+			}
+
+			return ids
+		}(),
+		State:      *i.State,
+		TemplateID: *i.Template.Id,
+		UserData:   papi.OptionalString(i.UserData),
+
+		c:    client,
+		zone: zone,
+	}
+}
+
+func (i Instance) get(ctx context.Context, client *Client, zone, id string) (interface{}, error) {
+	return client.GetInstance(ctx, zone, id)
+}
+
+// AntiAffinityGroups returns the list of Anti-Affinity Groups applied to the Compute instance.
+func (i *Instance) AntiAffinityGroups(ctx context.Context) ([]*AntiAffinityGroup, error) {
+	res, err := i.c.fetchFromIDs(ctx, i.zone, i.AntiAffinityGroupIDs, new(AntiAffinityGroup))
+	return res.([]*AntiAffinityGroup), err
+}
+
+// ElasticIPs returns the list of Elastic IPs attached to the Compute instance.
+func (i *Instance) ElasticIPs(ctx context.Context) ([]*ElasticIP, error) {
+	res, err := i.c.fetchFromIDs(ctx, i.zone, i.ElasticIPIDs, new(ElasticIP))
+	return res.([]*ElasticIP), err
+}
+
+// PrivateNetworks returns the list of Private Networks attached to the Compute instance.
+func (i *Instance) PrivateNetworks(ctx context.Context) ([]*PrivateNetwork, error) {
+	res, err := i.c.fetchFromIDs(ctx, i.zone, i.PrivateNetworkIDs, new(PrivateNetwork))
+	return res.([]*PrivateNetwork), err
+}
+
+// SecurityGroups returns the list of Security Groups attached to the Compute instance.
+func (i *Instance) SecurityGroups(ctx context.Context) ([]*SecurityGroup, error) {
+	res, err := i.c.fetchFromIDs(ctx, i.zone, i.SecurityGroupIDs, new(SecurityGroup))
+	return res.([]*SecurityGroup), err
+}
+
+// CreateSnapshot creates a Snapshot of the Compute instance storage volume.
+func (i *Instance) CreateSnapshot(ctx context.Context) (*Snapshot, error) {
+	resp, err := i.c.CreateSnapshotWithResponse(apiv2.WithZone(ctx, i.zone), i.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := papi.NewPoller().
+		WithTimeout(i.c.timeout).
+		Poll(ctx, i.c.OperationPoller(i.zone, *resp.JSON200.Id))
+	if err != nil {
+		return nil, err
+	}
+
+	return i.c.GetSnapshot(ctx, i.zone, *res.(*papi.Reference).Id)
+}
+
+// RevertToSnapshot reverts the Compute instance storage volume to the specified Snapshot.
+func (i *Instance) RevertToSnapshot(ctx context.Context, snapshot *Snapshot) error {
+	resp, err := i.c.RevertInstanceToSnapshotWithResponse(
+		apiv2.WithZone(ctx, i.zone),
+		i.ID,
+		papi.RevertInstanceToSnapshotJSONRequestBody{Id: snapshot.ID})
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(i.c.timeout).
+		Poll(ctx, i.c.OperationPoller(i.zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateInstance creates a Compute instance in the specified zone.
+func (c *Client) CreateInstance(ctx context.Context, zone string, instance *Instance) (*Instance, error) {
+	resp, err := c.CreateInstanceWithResponse(
+		apiv2.WithZone(ctx, zone),
+		papi.CreateInstanceJSONRequestBody{
+			AntiAffinityGroups: func() *[]papi.AntiAffinityGroup {
+				if l := len(instance.AntiAffinityGroupIDs); l > 0 {
+					list := make([]papi.AntiAffinityGroup, l)
+					for i, v := range instance.AntiAffinityGroupIDs {
+						v := v
+						list[i] = papi.AntiAffinityGroup{Id: &v}
+					}
+					return &list
+				}
+				return nil
+			}(),
+			DiskSize:     instance.DiskSize,
+			InstanceType: papi.InstanceType{Id: &instance.InstanceTypeID},
+			Ipv6Enabled:  &instance.IPv6Enabled,
+			Name:         &instance.Name,
+			SecurityGroups: func() *[]papi.SecurityGroup {
+				if l := len(instance.SecurityGroupIDs); l > 0 {
+					list := make([]papi.SecurityGroup, l)
+					for i, v := range instance.SecurityGroupIDs {
+						v := v
+						list[i] = papi.SecurityGroup{Id: &v}
+					}
+					return &list
+				}
+				return nil
+			}(),
+			SshKey: func() *papi.SshKey {
+				if instance.SSHKey != "" {
+					return &papi.SshKey{Name: &instance.SSHKey}
+				}
+				return nil
+			}(),
+			Template: papi.Template{Id: &instance.TemplateID},
+			UserData: func() *string {
+				if instance.UserData != "" {
+					return &instance.UserData
+				}
+				return nil
+			}(),
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := papi.NewPoller().
+		WithTimeout(c.timeout).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return nil, err
+	}
+
+	return c.GetInstance(ctx, zone, *res.(*papi.Reference).Id)
+}
+
+// ListInstances returns the list of existing Compute instances in the specified zone.
+func (c *Client) ListInstances(ctx context.Context, zone string) ([]*Instance, error) {
+	list := make([]*Instance, 0)
+
+	resp, err := c.ListInstancesWithResponse(apiv2.WithZone(ctx, zone))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.Instances != nil {
+		for i := range *resp.JSON200.Instances {
+			list = append(list, instanceFromAPI(c, zone, &(*resp.JSON200.Instances)[i]))
+		}
+	}
+
+	return list, nil
+}
+
+// GetInstance returns the Instance  corresponding to the specified ID in the specified zone.
+func (c *Client) GetInstance(ctx context.Context, zone, id string) (*Instance, error) {
+	resp, err := c.GetInstanceWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	return instanceFromAPI(c, zone, resp.JSON200), nil
+}
+
+// UpdateInstance updates the specified Compute instance in the specified zone.
+func (c *Client) UpdateInstance(ctx context.Context, zone string, instance *Instance) error {
+	resp, err := c.UpdateInstanceWithResponse(
+		apiv2.WithZone(ctx, zone),
+		instance.ID,
+		papi.UpdateInstanceJSONRequestBody{
+			Name: func() *string {
+				if instance.Name != "" {
+					return &instance.Name
+				}
+				return nil
+			}(),
+			UserData: func() *string {
+				if instance.UserData != "" {
+					return &instance.UserData
+				}
+				return nil
+			}(),
+		})
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteInstance deletes the specified Compute instance in the specified zone.
+func (c *Client) DeleteInstance(ctx context.Context, zone, id string) error {
+	resp, err := c.DeleteInstanceWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/exoscale/egoscale/v2/internal/public-api/instance.go
+++ b/vendor/github.com/exoscale/egoscale/v2/internal/public-api/instance.go
@@ -1,0 +1,110 @@
+package publicapi
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// UnmarshalJSON unmarshals an Instance structure into a temporary structure whose "CreatedAt" field of type
+// string to be able to parse the original timestamp (ISO 8601) into a time.Time object, since json.Unmarshal()
+// only supports RFC 3339 format.
+func (i *Instance) UnmarshalJSON(data []byte) error {
+	raw := struct {
+		AntiAffinityGroups *[]AntiAffinityGroup `json:"anti-affinity-groups,omitempty"`
+		CreatedAt          *string              `json:"created-at,omitempty"`
+		DiskSize           *int64               `json:"disk-size,omitempty"`
+		ElasticIps         *[]ElasticIp         `json:"elastic-ips,omitempty"`
+		Id                 *string              `json:"id,omitempty"` // nolint:golint
+		InstanceType       *InstanceType        `json:"instance-type,omitempty"`
+		Ipv6Address        *string              `json:"ipv6-address,omitempty"`
+		Manager            *Manager             `json:"manager,omitempty"`
+		Name               *string              `json:"name,omitempty"`
+		PrivateNetworks    *[]PrivateNetwork    `json:"private-networks,omitempty"`
+		PublicIp           *string              `json:"public-ip,omitempty"` // nolint:golint
+		SecurityGroups     *[]SecurityGroup     `json:"security-groups,omitempty"`
+		Snapshots          *[]Snapshot          `json:"snapshots,omitempty"`
+		SshKey             *SshKey              `json:"ssh-key,omitempty"` // nolint:golint
+		State              *string              `json:"state,omitempty"`
+		Template           *Template            `json:"template,omitempty"`
+		UserData           *string              `json:"user-data,omitempty"`
+	}{}
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	if raw.CreatedAt != nil {
+		createdAt, err := time.Parse(iso8601Format, *raw.CreatedAt)
+		if err != nil {
+			return err
+		}
+		i.CreatedAt = &createdAt
+	}
+
+	i.AntiAffinityGroups = raw.AntiAffinityGroups
+	i.DiskSize = raw.DiskSize
+	i.ElasticIps = raw.ElasticIps
+	i.Id = raw.Id
+	i.InstanceType = raw.InstanceType
+	i.Ipv6Address = raw.Ipv6Address
+	i.Manager = raw.Manager
+	i.Name = raw.Name
+	i.PrivateNetworks = raw.PrivateNetworks
+	i.PublicIp = raw.PublicIp
+	i.SecurityGroups = raw.SecurityGroups
+	i.Snapshots = raw.Snapshots
+	i.SshKey = raw.SshKey
+	i.State = raw.State
+	i.Template = raw.Template
+	i.UserData = raw.UserData
+
+	return nil
+}
+
+// MarshalJSON returns the JSON encoding of an Instance structure after having formatted the CreatedAt field
+// in the original timestamp (ISO 8601), since time.MarshalJSON() only supports RFC 3339 format.
+func (i *Instance) MarshalJSON() ([]byte, error) {
+	raw := struct {
+		AntiAffinityGroups *[]AntiAffinityGroup `json:"anti-affinity-groups,omitempty"`
+		CreatedAt          *string              `json:"created-at,omitempty"`
+		DiskSize           *int64               `json:"disk-size,omitempty"`
+		ElasticIps         *[]ElasticIp         `json:"elastic-ips,omitempty"`
+		Id                 *string              `json:"id,omitempty"` // nolint:golint
+		InstanceType       *InstanceType        `json:"instance-type,omitempty"`
+		Ipv6Address        *string              `json:"ipv6-address,omitempty"`
+		Manager            *Manager             `json:"manager,omitempty"`
+		Name               *string              `json:"name,omitempty"`
+		PrivateNetworks    *[]PrivateNetwork    `json:"private-networks,omitempty"`
+		PublicIp           *string              `json:"public-ip,omitempty"` // nolint:golint
+		SecurityGroups     *[]SecurityGroup     `json:"security-groups,omitempty"`
+		Snapshots          *[]Snapshot          `json:"snapshots,omitempty"`
+		SshKey             *SshKey              `json:"ssh-key,omitempty"` // nolint:golint
+		State              *string              `json:"state,omitempty"`
+		Template           *Template            `json:"template,omitempty"`
+		UserData           *string              `json:"user-data,omitempty"`
+	}{}
+
+	if i.CreatedAt != nil {
+		createdAt := i.CreatedAt.Format(iso8601Format)
+		raw.CreatedAt = &createdAt
+	}
+
+	raw.AntiAffinityGroups = i.AntiAffinityGroups
+	raw.DiskSize = i.DiskSize
+	raw.ElasticIps = i.ElasticIps
+	raw.Id = i.Id
+	raw.InstanceType = i.InstanceType
+	raw.Ipv6Address = i.Ipv6Address
+	raw.Manager = i.Manager
+	raw.Name = i.Name
+	raw.PrivateNetworks = i.PrivateNetworks
+	raw.PublicIp = i.PublicIp
+	raw.SecurityGroups = i.SecurityGroups
+	raw.Snapshots = i.Snapshots
+	raw.SshKey = i.SshKey
+	raw.State = i.State
+	raw.Template = i.Template
+	raw.UserData = i.UserData
+
+	return json.Marshal(raw)
+}

--- a/vendor/github.com/exoscale/egoscale/v2/internal/public-api/public-api.gen.go
+++ b/vendor/github.com/exoscale/egoscale/v2/internal/public-api/public-api.gen.go
@@ -27,6 +27,14 @@ type AntiAffinityGroup struct {
 	Name        *string     `json:"name,omitempty"`
 }
 
+// DeployTarget defines model for deploy-target.
+type DeployTarget struct {
+	Description *string `json:"description,omitempty"`
+	Id          *string `json:"id,omitempty"`
+	Name        *string `json:"name,omitempty"`
+	Type        *string `json:"type,omitempty"`
+}
+
 // ElasticIp defines model for elastic-ip.
 type ElasticIp struct {
 	Description *string               `json:"description,omitempty"`
@@ -37,12 +45,12 @@ type ElasticIp struct {
 
 // ElasticIpHealthcheck defines model for elastic-ip-healthcheck.
 type ElasticIpHealthcheck struct {
-	Interval      int64   `json:"interval"`
+	Interval      *int64  `json:"interval,omitempty"`
 	Mode          string  `json:"mode"`
 	Port          int64   `json:"port"`
-	StrikesFail   int64   `json:"strikes-fail"`
-	StrikesOk     int64   `json:"strikes-ok"`
-	Timeout       int64   `json:"timeout"`
+	StrikesFail   *int64  `json:"strikes-fail,omitempty"`
+	StrikesOk     *int64  `json:"strikes-ok,omitempty"`
+	Timeout       *int64  `json:"timeout,omitempty"`
 	TlsSkipVerify *bool   `json:"tls-skip-verify,omitempty"`
 	TlsSni        *string `json:"tls-sni,omitempty"`
 	Uri           *string `json:"uri,omitempty"`
@@ -61,17 +69,34 @@ type Event_Payload struct {
 
 // Instance defines model for instance.
 type Instance struct {
-	Id   *string `json:"id,omitempty"`
-	Name *string `json:"name,omitempty"`
+	AntiAffinityGroups *[]AntiAffinityGroup `json:"anti-affinity-groups,omitempty"`
+	CreatedAt          *time.Time           `json:"created-at,omitempty"`
+	DiskSize           *int64               `json:"disk-size,omitempty"`
+	ElasticIps         *[]ElasticIp         `json:"elastic-ips,omitempty"`
+	Id                 *string              `json:"id,omitempty"`
+	InstanceType       *InstanceType        `json:"instance-type,omitempty"`
+	Ipv6Address        *string              `json:"ipv6-address,omitempty"`
+	Manager            *Manager             `json:"manager,omitempty"`
+	Name               *string              `json:"name,omitempty"`
+	PrivateNetworks    *[]PrivateNetwork    `json:"private-networks,omitempty"`
+	PublicIp           *string              `json:"public-ip,omitempty"`
+	SecurityGroups     *[]SecurityGroup     `json:"security-groups,omitempty"`
+	Snapshots          *[]Snapshot          `json:"snapshots,omitempty"`
+	SshKey             *SshKey              `json:"ssh-key,omitempty"`
+	State              *string              `json:"state,omitempty"`
+	Template           *Template            `json:"template,omitempty"`
+	UserData           *string              `json:"user-data,omitempty"`
 }
 
 // InstancePool defines model for instance-pool.
 type InstancePool struct {
 	AntiAffinityGroups *[]AntiAffinityGroup `json:"anti-affinity-groups,omitempty"`
+	DeployTarget       *DeployTarget        `json:"deploy-target,omitempty"`
 	Description        *string              `json:"description,omitempty"`
 	DiskSize           *int64               `json:"disk-size,omitempty"`
 	ElasticIps         *[]ElasticIp         `json:"elastic-ips,omitempty"`
 	Id                 *string              `json:"id,omitempty"`
+	InstancePrefix     *string              `json:"instance-prefix,omitempty"`
 	InstanceType       *InstanceType        `json:"instance-type,omitempty"`
 	Instances          *[]Instance          `json:"instances,omitempty"`
 	Ipv6Enabled        *bool                `json:"ipv6-enabled,omitempty"`
@@ -131,11 +156,11 @@ type LoadBalancerService struct {
 
 // LoadBalancerServiceHealthcheck defines model for load-balancer-service-healthcheck.
 type LoadBalancerServiceHealthcheck struct {
-	Interval int64   `json:"interval"`
+	Interval *int64  `json:"interval,omitempty"`
 	Mode     string  `json:"mode"`
 	Port     int64   `json:"port"`
-	Retries  int64   `json:"retries"`
-	Timeout  int64   `json:"timeout"`
+	Retries  *int64  `json:"retries,omitempty"`
+	Timeout  *int64  `json:"timeout,omitempty"`
 	TlsSni   *string `json:"tls-sni,omitempty"`
 	Uri      *string `json:"uri,omitempty"`
 }
@@ -303,6 +328,13 @@ type UpdateElasticIpJSONBody struct {
 	Healthcheck *ElasticIpHealthcheck `json:"healthcheck,omitempty"`
 }
 
+// AttachInstanceToElasticIpJSONBody defines parameters for AttachInstanceToElasticIp.
+type AttachInstanceToElasticIpJSONBody struct {
+	Instance *struct {
+		Id string `json:"id"`
+	} `json:"instance,omitempty"`
+}
+
 // ListEventsParams defines parameters for ListEvents.
 type ListEventsParams struct {
 	From *time.Time `json:"from,omitempty"`
@@ -310,19 +342,27 @@ type ListEventsParams struct {
 }
 
 // CreateInstanceJSONBody defines parameters for CreateInstance.
-type CreateInstanceJSONBody Instance
-
-// CreateInstanceParams defines parameters for CreateInstance.
-type CreateInstanceParams struct {
-	Start *bool `json:"start,omitempty"`
+type CreateInstanceJSONBody struct {
+	AntiAffinityGroups *[]AntiAffinityGroup `json:"anti-affinity-groups,omitempty"`
+	DeployTarget       *DeployTarget        `json:"deploy-target,omitempty"`
+	DiskSize           int64                `json:"disk-size"`
+	InstanceType       InstanceType         `json:"instance-type"`
+	Ipv6Enabled        *bool                `json:"ipv6-enabled,omitempty"`
+	Name               *string              `json:"name,omitempty"`
+	SecurityGroups     *[]SecurityGroup     `json:"security-groups,omitempty"`
+	SshKey             *SshKey              `json:"ssh-key,omitempty"`
+	Template           Template             `json:"template"`
+	UserData           *string              `json:"user-data,omitempty"`
 }
 
 // CreateInstancePoolJSONBody defines parameters for CreateInstancePool.
 type CreateInstancePoolJSONBody struct {
 	AntiAffinityGroups *[]AntiAffinityGroup `json:"anti-affinity-groups,omitempty"`
+	DeployTarget       *DeployTarget        `json:"deploy-target,omitempty"`
 	Description        *string              `json:"description,omitempty"`
 	DiskSize           int64                `json:"disk-size"`
 	ElasticIps         *[]ElasticIp         `json:"elastic-ips,omitempty"`
+	InstancePrefix     *string              `json:"instance-prefix,omitempty"`
 	InstanceType       InstanceType         `json:"instance-type"`
 	Ipv6Enabled        *bool                `json:"ipv6-enabled,omitempty"`
 	Name               string               `json:"name"`
@@ -337,9 +377,11 @@ type CreateInstancePoolJSONBody struct {
 // UpdateInstancePoolJSONBody defines parameters for UpdateInstancePool.
 type UpdateInstancePoolJSONBody struct {
 	AntiAffinityGroups *[]AntiAffinityGroup `json:"anti-affinity-groups,omitempty"`
+	DeployTarget       *DeployTarget        `json:"deploy-target,omitempty"`
 	Description        *string              `json:"description,omitempty"`
 	DiskSize           *int64               `json:"disk-size,omitempty"`
 	ElasticIps         *[]ElasticIp         `json:"elastic-ips,omitempty"`
+	InstancePrefix     *string              `json:"instance-prefix,omitempty"`
 	InstanceType       *InstanceType        `json:"instance-type,omitempty"`
 	Ipv6Enabled        *bool                `json:"ipv6-enabled,omitempty"`
 	Name               *string              `json:"name,omitempty"`
@@ -358,6 +400,12 @@ type EvictInstancePoolMembersJSONBody struct {
 // ScaleInstancePoolJSONBody defines parameters for ScaleInstancePool.
 type ScaleInstancePoolJSONBody struct {
 	Size int64 `json:"size"`
+}
+
+// UpdateInstanceJSONBody defines parameters for UpdateInstance.
+type UpdateInstanceJSONBody struct {
+	Name     *string `json:"name,omitempty"`
+	UserData *string `json:"user-data,omitempty"`
 }
 
 // RevertInstanceToSnapshotJSONBody defines parameters for RevertInstanceToSnapshot.
@@ -434,7 +482,7 @@ type AddRuleToSecurityGroupJSONBody struct {
 		Type *int64 `json:"type,omitempty"`
 	} `json:"icmp,omitempty"`
 	Network       *string                `json:"network,omitempty"`
-	Protocol      *string                `json:"protocol,omitempty"`
+	Protocol      string                 `json:"protocol"`
 	SecurityGroup *SecurityGroupResource `json:"security-group,omitempty"`
 	StartPort     *int64                 `json:"start-port,omitempty"`
 }
@@ -532,6 +580,9 @@ type CreateElasticIpJSONRequestBody CreateElasticIpJSONBody
 // UpdateElasticIpRequestBody defines body for UpdateElasticIp for application/json ContentType.
 type UpdateElasticIpJSONRequestBody UpdateElasticIpJSONBody
 
+// AttachInstanceToElasticIpRequestBody defines body for AttachInstanceToElasticIp for application/json ContentType.
+type AttachInstanceToElasticIpJSONRequestBody AttachInstanceToElasticIpJSONBody
+
 // CreateInstanceRequestBody defines body for CreateInstance for application/json ContentType.
 type CreateInstanceJSONRequestBody CreateInstanceJSONBody
 
@@ -546,6 +597,9 @@ type EvictInstancePoolMembersJSONRequestBody EvictInstancePoolMembersJSONBody
 
 // ScaleInstancePoolRequestBody defines body for ScaleInstancePool for application/json ContentType.
 type ScaleInstancePoolJSONRequestBody ScaleInstancePoolJSONBody
+
+// UpdateInstanceRequestBody defines body for UpdateInstance for application/json ContentType.
+type UpdateInstanceJSONRequestBody UpdateInstanceJSONBody
 
 // RevertInstanceToSnapshotRequestBody defines body for RevertInstanceToSnapshot for application/json ContentType.
 type RevertInstanceToSnapshotJSONRequestBody RevertInstanceToSnapshotJSONBody
@@ -744,6 +798,12 @@ type ClientInterface interface {
 	// GetAntiAffinityGroup request
 	GetAntiAffinityGroup(ctx context.Context, id string) (*http.Response, error)
 
+	// ListDeployTargets request
+	ListDeployTargets(ctx context.Context) (*http.Response, error)
+
+	// GetDeployTarget request
+	GetDeployTarget(ctx context.Context, id string) (*http.Response, error)
+
 	// ListElasticIps request
 	ListElasticIps(ctx context.Context) (*http.Response, error)
 
@@ -766,13 +826,21 @@ type ClientInterface interface {
 	// ResetElasticIpField request
 	ResetElasticIpField(ctx context.Context, id string, field string) (*http.Response, error)
 
+	// AttachInstanceToElasticIp request  with any body
+	AttachInstanceToElasticIpWithBody(ctx context.Context, id string, contentType string, body io.Reader) (*http.Response, error)
+
+	AttachInstanceToElasticIp(ctx context.Context, id string, body AttachInstanceToElasticIpJSONRequestBody) (*http.Response, error)
+
 	// ListEvents request
 	ListEvents(ctx context.Context, params *ListEventsParams) (*http.Response, error)
 
-	// CreateInstance request  with any body
-	CreateInstanceWithBody(ctx context.Context, params *CreateInstanceParams, contentType string, body io.Reader) (*http.Response, error)
+	// ListInstances request
+	ListInstances(ctx context.Context) (*http.Response, error)
 
-	CreateInstance(ctx context.Context, params *CreateInstanceParams, body CreateInstanceJSONRequestBody) (*http.Response, error)
+	// CreateInstance request  with any body
+	CreateInstanceWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error)
+
+	CreateInstance(ctx context.Context, body CreateInstanceJSONRequestBody) (*http.Response, error)
 
 	// ListInstancePools request
 	ListInstancePools(ctx context.Context) (*http.Response, error)
@@ -811,6 +879,17 @@ type ClientInterface interface {
 
 	// GetInstanceType request
 	GetInstanceType(ctx context.Context, id string) (*http.Response, error)
+
+	// DeleteInstance request
+	DeleteInstance(ctx context.Context, id string) (*http.Response, error)
+
+	// GetInstance request
+	GetInstance(ctx context.Context, id string) (*http.Response, error)
+
+	// UpdateInstance request  with any body
+	UpdateInstanceWithBody(ctx context.Context, id string, contentType string, body io.Reader) (*http.Response, error)
+
+	UpdateInstance(ctx context.Context, id string, body UpdateInstanceJSONRequestBody) (*http.Response, error)
 
 	// CreateSnapshot request
 	CreateSnapshot(ctx context.Context, id string) (*http.Response, error)
@@ -1085,6 +1164,36 @@ func (c *Client) GetAntiAffinityGroup(ctx context.Context, id string) (*http.Res
 	return c.Client.Do(req)
 }
 
+func (c *Client) ListDeployTargets(ctx context.Context) (*http.Response, error) {
+	req, err := NewListDeployTargetsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetDeployTarget(ctx context.Context, id string) (*http.Response, error) {
+	req, err := NewGetDeployTargetRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) ListElasticIps(ctx context.Context) (*http.Response, error) {
 	req, err := NewListElasticIpsRequest(c.Server)
 	if err != nil {
@@ -1205,6 +1314,36 @@ func (c *Client) ResetElasticIpField(ctx context.Context, id string, field strin
 	return c.Client.Do(req)
 }
 
+func (c *Client) AttachInstanceToElasticIpWithBody(ctx context.Context, id string, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := NewAttachInstanceToElasticIpRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AttachInstanceToElasticIp(ctx context.Context, id string, body AttachInstanceToElasticIpJSONRequestBody) (*http.Response, error) {
+	req, err := NewAttachInstanceToElasticIpRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) ListEvents(ctx context.Context, params *ListEventsParams) (*http.Response, error) {
 	req, err := NewListEventsRequest(c.Server, params)
 	if err != nil {
@@ -1220,8 +1359,8 @@ func (c *Client) ListEvents(ctx context.Context, params *ListEventsParams) (*htt
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateInstanceWithBody(ctx context.Context, params *CreateInstanceParams, contentType string, body io.Reader) (*http.Response, error) {
-	req, err := NewCreateInstanceRequestWithBody(c.Server, params, contentType, body)
+func (c *Client) ListInstances(ctx context.Context) (*http.Response, error) {
+	req, err := NewListInstancesRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -1235,8 +1374,23 @@ func (c *Client) CreateInstanceWithBody(ctx context.Context, params *CreateInsta
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateInstance(ctx context.Context, params *CreateInstanceParams, body CreateInstanceJSONRequestBody) (*http.Response, error) {
-	req, err := NewCreateInstanceRequest(c.Server, params, body)
+func (c *Client) CreateInstanceWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := NewCreateInstanceRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateInstance(ctx context.Context, body CreateInstanceJSONRequestBody) (*http.Response, error) {
+	req, err := NewCreateInstanceRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1447,6 +1601,66 @@ func (c *Client) ListInstanceTypes(ctx context.Context) (*http.Response, error) 
 
 func (c *Client) GetInstanceType(ctx context.Context, id string) (*http.Response, error) {
 	req, err := NewGetInstanceTypeRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteInstance(ctx context.Context, id string) (*http.Response, error) {
+	req, err := NewDeleteInstanceRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetInstance(ctx context.Context, id string) (*http.Response, error) {
+	req, err := NewGetInstanceRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateInstanceWithBody(ctx context.Context, id string, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := NewUpdateInstanceRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateInstance(ctx context.Context, id string, body UpdateInstanceJSONRequestBody) (*http.Response, error) {
+	req, err := NewUpdateInstanceRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2674,6 +2888,67 @@ func NewGetAntiAffinityGroupRequest(server string, id string) (*http.Request, er
 	return req, nil
 }
 
+// NewListDeployTargetsRequest generates requests for ListDeployTargets
+func NewListDeployTargetsRequest(server string) (*http.Request, error) {
+	var err error
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/deploy-target")
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetDeployTargetRequest generates requests for GetDeployTarget
+func NewGetDeployTargetRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "id", id)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/deploy-target/%s", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewListElasticIpsRequest generates requests for ListElasticIps
 func NewListElasticIpsRequest(server string) (*http.Request, error) {
 	var err error
@@ -2895,6 +3170,52 @@ func NewResetElasticIpFieldRequest(server string, id string, field string) (*htt
 	return req, nil
 }
 
+// NewAttachInstanceToElasticIpRequest calls the generic AttachInstanceToElasticIp builder with application/json body
+func NewAttachInstanceToElasticIpRequest(server string, id string, body AttachInstanceToElasticIpJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewAttachInstanceToElasticIpRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewAttachInstanceToElasticIpRequestWithBody generates requests for AttachInstanceToElasticIp with any type of body
+func NewAttachInstanceToElasticIpRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "id", id)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/elastic-ip/%s:attach", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryUrl.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+	return req, nil
+}
+
 // NewListEventsRequest generates requests for ListEvents
 func NewListEventsRequest(server string, params *ListEventsParams) (*http.Request, error) {
 	var err error
@@ -2958,19 +3279,8 @@ func NewListEventsRequest(server string, params *ListEventsParams) (*http.Reques
 	return req, nil
 }
 
-// NewCreateInstanceRequest calls the generic CreateInstance builder with application/json body
-func NewCreateInstanceRequest(server string, params *CreateInstanceParams, body CreateInstanceJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewCreateInstanceRequestWithBody(server, params, "application/json", bodyReader)
-}
-
-// NewCreateInstanceRequestWithBody generates requests for CreateInstance with any type of body
-func NewCreateInstanceRequestWithBody(server string, params *CreateInstanceParams, contentType string, body io.Reader) (*http.Request, error) {
+// NewListInstancesRequest generates requests for ListInstances
+func NewListInstancesRequest(server string) (*http.Request, error) {
 	var err error
 
 	queryUrl, err := url.Parse(server)
@@ -2988,25 +3298,43 @@ func NewCreateInstanceRequestWithBody(server string, params *CreateInstanceParam
 		return nil, err
 	}
 
-	queryValues := queryUrl.Query()
-
-	if params.Start != nil {
-
-		if queryFrag, err := runtime.StyleParam("form", true, "start", *params.Start); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
+	req, err := http.NewRequest("GET", queryUrl.String(), nil)
+	if err != nil {
+		return nil, err
 	}
 
-	queryUrl.RawQuery = queryValues.Encode()
+	return req, nil
+}
+
+// NewCreateInstanceRequest calls the generic CreateInstance builder with application/json body
+func NewCreateInstanceRequest(server string, body CreateInstanceJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateInstanceRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateInstanceRequestWithBody generates requests for CreateInstance with any type of body
+func NewCreateInstanceRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/instance")
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := http.NewRequest("POST", queryUrl.String(), body)
 	if err != nil {
@@ -3388,6 +3716,120 @@ func NewGetInstanceTypeRequest(server string, id string) (*http.Request, error) 
 		return nil, err
 	}
 
+	return req, nil
+}
+
+// NewDeleteInstanceRequest generates requests for DeleteInstance
+func NewDeleteInstanceRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "id", id)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/instance/%s", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetInstanceRequest generates requests for GetInstance
+func NewGetInstanceRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "id", id)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/instance/%s", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateInstanceRequest calls the generic UpdateInstance builder with application/json body
+func NewUpdateInstanceRequest(server string, id string, body UpdateInstanceJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateInstanceRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewUpdateInstanceRequestWithBody generates requests for UpdateInstance with any type of body
+func NewUpdateInstanceRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "id", id)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/instance/%s", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryUrl.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 	return req, nil
 }
 
@@ -5520,6 +5962,12 @@ type ClientWithResponsesInterface interface {
 	// GetAntiAffinityGroup request
 	GetAntiAffinityGroupWithResponse(ctx context.Context, id string) (*GetAntiAffinityGroupResponse, error)
 
+	// ListDeployTargets request
+	ListDeployTargetsWithResponse(ctx context.Context) (*ListDeployTargetsResponse, error)
+
+	// GetDeployTarget request
+	GetDeployTargetWithResponse(ctx context.Context, id string) (*GetDeployTargetResponse, error)
+
 	// ListElasticIps request
 	ListElasticIpsWithResponse(ctx context.Context) (*ListElasticIpsResponse, error)
 
@@ -5542,13 +5990,21 @@ type ClientWithResponsesInterface interface {
 	// ResetElasticIpField request
 	ResetElasticIpFieldWithResponse(ctx context.Context, id string, field string) (*ResetElasticIpFieldResponse, error)
 
+	// AttachInstanceToElasticIp request  with any body
+	AttachInstanceToElasticIpWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*AttachInstanceToElasticIpResponse, error)
+
+	AttachInstanceToElasticIpWithResponse(ctx context.Context, id string, body AttachInstanceToElasticIpJSONRequestBody) (*AttachInstanceToElasticIpResponse, error)
+
 	// ListEvents request
 	ListEventsWithResponse(ctx context.Context, params *ListEventsParams) (*ListEventsResponse, error)
 
-	// CreateInstance request  with any body
-	CreateInstanceWithBodyWithResponse(ctx context.Context, params *CreateInstanceParams, contentType string, body io.Reader) (*CreateInstanceResponse, error)
+	// ListInstances request
+	ListInstancesWithResponse(ctx context.Context) (*ListInstancesResponse, error)
 
-	CreateInstanceWithResponse(ctx context.Context, params *CreateInstanceParams, body CreateInstanceJSONRequestBody) (*CreateInstanceResponse, error)
+	// CreateInstance request  with any body
+	CreateInstanceWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*CreateInstanceResponse, error)
+
+	CreateInstanceWithResponse(ctx context.Context, body CreateInstanceJSONRequestBody) (*CreateInstanceResponse, error)
 
 	// ListInstancePools request
 	ListInstancePoolsWithResponse(ctx context.Context) (*ListInstancePoolsResponse, error)
@@ -5587,6 +6043,17 @@ type ClientWithResponsesInterface interface {
 
 	// GetInstanceType request
 	GetInstanceTypeWithResponse(ctx context.Context, id string) (*GetInstanceTypeResponse, error)
+
+	// DeleteInstance request
+	DeleteInstanceWithResponse(ctx context.Context, id string) (*DeleteInstanceResponse, error)
+
+	// GetInstance request
+	GetInstanceWithResponse(ctx context.Context, id string) (*GetInstanceResponse, error)
+
+	// UpdateInstance request  with any body
+	UpdateInstanceWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*UpdateInstanceResponse, error)
+
+	UpdateInstanceWithResponse(ctx context.Context, id string, body UpdateInstanceJSONRequestBody) (*UpdateInstanceResponse, error)
 
 	// CreateSnapshot request
 	CreateSnapshotWithResponse(ctx context.Context, id string) (*CreateSnapshotResponse, error)
@@ -5876,6 +6343,52 @@ func (r GetAntiAffinityGroupResponse) StatusCode() int {
 	return 0
 }
 
+type ListDeployTargetsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		DeployTargets *[]DeployTarget `json:"deploy-targets,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r ListDeployTargetsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListDeployTargetsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetDeployTargetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *DeployTarget
+}
+
+// Status returns HTTPResponse.Status
+func (r GetDeployTargetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetDeployTargetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type ListElasticIpsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -6010,6 +6523,28 @@ func (r ResetElasticIpFieldResponse) StatusCode() int {
 	return 0
 }
 
+type AttachInstanceToElasticIpResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r AttachInstanceToElasticIpResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AttachInstanceToElasticIpResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type ListEventsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -6026,6 +6561,30 @@ func (r ListEventsResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ListEventsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListInstancesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Instances *[]Instance `json:"instances,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r ListInstancesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListInstancesResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -6272,6 +6831,72 @@ func (r GetInstanceTypeResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetInstanceTypeResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteInstanceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteInstanceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteInstanceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetInstanceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Instance
+}
+
+// Status returns HTTPResponse.Status
+func (r GetInstanceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetInstanceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateInstanceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateInstanceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateInstanceResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -7510,6 +8135,24 @@ func (c *ClientWithResponses) GetAntiAffinityGroupWithResponse(ctx context.Conte
 	return ParseGetAntiAffinityGroupResponse(rsp)
 }
 
+// ListDeployTargetsWithResponse request returning *ListDeployTargetsResponse
+func (c *ClientWithResponses) ListDeployTargetsWithResponse(ctx context.Context) (*ListDeployTargetsResponse, error) {
+	rsp, err := c.ListDeployTargets(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListDeployTargetsResponse(rsp)
+}
+
+// GetDeployTargetWithResponse request returning *GetDeployTargetResponse
+func (c *ClientWithResponses) GetDeployTargetWithResponse(ctx context.Context, id string) (*GetDeployTargetResponse, error) {
+	rsp, err := c.GetDeployTarget(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetDeployTargetResponse(rsp)
+}
+
 // ListElasticIpsWithResponse request returning *ListElasticIpsResponse
 func (c *ClientWithResponses) ListElasticIpsWithResponse(ctx context.Context) (*ListElasticIpsResponse, error) {
 	rsp, err := c.ListElasticIps(ctx)
@@ -7580,6 +8223,23 @@ func (c *ClientWithResponses) ResetElasticIpFieldWithResponse(ctx context.Contex
 	return ParseResetElasticIpFieldResponse(rsp)
 }
 
+// AttachInstanceToElasticIpWithBodyWithResponse request with arbitrary body returning *AttachInstanceToElasticIpResponse
+func (c *ClientWithResponses) AttachInstanceToElasticIpWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*AttachInstanceToElasticIpResponse, error) {
+	rsp, err := c.AttachInstanceToElasticIpWithBody(ctx, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAttachInstanceToElasticIpResponse(rsp)
+}
+
+func (c *ClientWithResponses) AttachInstanceToElasticIpWithResponse(ctx context.Context, id string, body AttachInstanceToElasticIpJSONRequestBody) (*AttachInstanceToElasticIpResponse, error) {
+	rsp, err := c.AttachInstanceToElasticIp(ctx, id, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAttachInstanceToElasticIpResponse(rsp)
+}
+
 // ListEventsWithResponse request returning *ListEventsResponse
 func (c *ClientWithResponses) ListEventsWithResponse(ctx context.Context, params *ListEventsParams) (*ListEventsResponse, error) {
 	rsp, err := c.ListEvents(ctx, params)
@@ -7589,17 +8249,26 @@ func (c *ClientWithResponses) ListEventsWithResponse(ctx context.Context, params
 	return ParseListEventsResponse(rsp)
 }
 
+// ListInstancesWithResponse request returning *ListInstancesResponse
+func (c *ClientWithResponses) ListInstancesWithResponse(ctx context.Context) (*ListInstancesResponse, error) {
+	rsp, err := c.ListInstances(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListInstancesResponse(rsp)
+}
+
 // CreateInstanceWithBodyWithResponse request with arbitrary body returning *CreateInstanceResponse
-func (c *ClientWithResponses) CreateInstanceWithBodyWithResponse(ctx context.Context, params *CreateInstanceParams, contentType string, body io.Reader) (*CreateInstanceResponse, error) {
-	rsp, err := c.CreateInstanceWithBody(ctx, params, contentType, body)
+func (c *ClientWithResponses) CreateInstanceWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*CreateInstanceResponse, error) {
+	rsp, err := c.CreateInstanceWithBody(ctx, contentType, body)
 	if err != nil {
 		return nil, err
 	}
 	return ParseCreateInstanceResponse(rsp)
 }
 
-func (c *ClientWithResponses) CreateInstanceWithResponse(ctx context.Context, params *CreateInstanceParams, body CreateInstanceJSONRequestBody) (*CreateInstanceResponse, error) {
-	rsp, err := c.CreateInstance(ctx, params, body)
+func (c *ClientWithResponses) CreateInstanceWithResponse(ctx context.Context, body CreateInstanceJSONRequestBody) (*CreateInstanceResponse, error) {
+	rsp, err := c.CreateInstance(ctx, body)
 	if err != nil {
 		return nil, err
 	}
@@ -7726,6 +8395,41 @@ func (c *ClientWithResponses) GetInstanceTypeWithResponse(ctx context.Context, i
 		return nil, err
 	}
 	return ParseGetInstanceTypeResponse(rsp)
+}
+
+// DeleteInstanceWithResponse request returning *DeleteInstanceResponse
+func (c *ClientWithResponses) DeleteInstanceWithResponse(ctx context.Context, id string) (*DeleteInstanceResponse, error) {
+	rsp, err := c.DeleteInstance(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteInstanceResponse(rsp)
+}
+
+// GetInstanceWithResponse request returning *GetInstanceResponse
+func (c *ClientWithResponses) GetInstanceWithResponse(ctx context.Context, id string) (*GetInstanceResponse, error) {
+	rsp, err := c.GetInstance(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetInstanceResponse(rsp)
+}
+
+// UpdateInstanceWithBodyWithResponse request with arbitrary body returning *UpdateInstanceResponse
+func (c *ClientWithResponses) UpdateInstanceWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*UpdateInstanceResponse, error) {
+	rsp, err := c.UpdateInstanceWithBody(ctx, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateInstanceResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateInstanceWithResponse(ctx context.Context, id string, body UpdateInstanceJSONRequestBody) (*UpdateInstanceResponse, error) {
+	rsp, err := c.UpdateInstance(ctx, id, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateInstanceResponse(rsp)
 }
 
 // CreateSnapshotWithResponse request returning *CreateSnapshotResponse
@@ -8463,6 +9167,60 @@ func ParseGetAntiAffinityGroupResponse(rsp *http.Response) (*GetAntiAffinityGrou
 	return response, nil
 }
 
+// ParseListDeployTargetsResponse parses an HTTP response from a ListDeployTargetsWithResponse call
+func ParseListDeployTargetsResponse(rsp *http.Response) (*ListDeployTargetsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListDeployTargetsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			DeployTargets *[]DeployTarget `json:"deploy-targets,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetDeployTargetResponse parses an HTTP response from a GetDeployTargetWithResponse call
+func ParseGetDeployTargetResponse(rsp *http.Response) (*GetDeployTargetResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetDeployTargetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DeployTarget
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseListElasticIpsResponse parses an HTTP response from a ListElasticIpsWithResponse call
 func ParseListElasticIpsResponse(rsp *http.Response) (*ListElasticIpsResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -8621,6 +9379,32 @@ func ParseResetElasticIpFieldResponse(rsp *http.Response) (*ResetElasticIpFieldR
 	return response, nil
 }
 
+// ParseAttachInstanceToElasticIpResponse parses an HTTP response from a AttachInstanceToElasticIpWithResponse call
+func ParseAttachInstanceToElasticIpResponse(rsp *http.Response) (*AttachInstanceToElasticIpResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AttachInstanceToElasticIpResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseListEventsResponse parses an HTTP response from a ListEventsWithResponse call
 func ParseListEventsResponse(rsp *http.Response) (*ListEventsResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -8637,6 +9421,34 @@ func ParseListEventsResponse(rsp *http.Response) (*ListEventsResponse, error) {
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest []Event
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListInstancesResponse parses an HTTP response from a ListInstancesWithResponse call
+func ParseListInstancesResponse(rsp *http.Response) (*ListInstancesResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListInstancesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Instances *[]Instance `json:"instances,omitempty"`
+		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8927,6 +9739,84 @@ func ParseGetInstanceTypeResponse(rsp *http.Response) (*GetInstanceTypeResponse,
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest InstanceType
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteInstanceResponse parses an HTTP response from a DeleteInstanceWithResponse call
+func ParseDeleteInstanceResponse(rsp *http.Response) (*DeleteInstanceResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteInstanceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetInstanceResponse parses an HTTP response from a GetInstanceWithResponse call
+func ParseGetInstanceResponse(rsp *http.Response) (*GetInstanceResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetInstanceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Instance
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateInstanceResponse parses an HTTP response from a UpdateInstanceWithResponse call
+func ParseUpdateInstanceResponse(rsp *http.Response) (*UpdateInstanceResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateInstanceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/exoscale/egoscale/v2/internal/public-api/snapshot.go
+++ b/vendor/github.com/exoscale/egoscale/v2/internal/public-api/snapshot.go
@@ -1,0 +1,76 @@
+package publicapi
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// UnmarshalJSON unmarshals a Snapshot structure into a temporary structure whose "CreatedAt" field of type
+// string to be able to parse the original timestamp (ISO 8601) into a time.Time object, since json.Unmarshal()
+// only supports RFC 3339 format.
+func (t *Snapshot) UnmarshalJSON(data []byte) error {
+	raw := struct {
+		CreatedAt   *string `json:"created-at,omitempty"`
+		Description *string `json:"description,omitempty"`
+		Export      *struct {
+			Md5sum       *string `json:"md5sum,omitempty"`
+			PresignedUrl *string `json:"presigned-url,omitempty"` // nolint:golint
+		} `json:"export,omitempty"`
+		Id       *string   `json:"id,omitempty"` // nolint:golint
+		Instance *Instance `json:"instance,omitempty"`
+		Name     *string   `json:"name,omitempty"`
+		State    *string   `json:"state,omitempty"`
+	}{}
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	if raw.CreatedAt != nil {
+		createdAt, err := time.Parse(iso8601Format, *raw.CreatedAt)
+		if err != nil {
+			return err
+		}
+		t.CreatedAt = &createdAt
+	}
+
+	t.Description = raw.Description
+	t.Export = raw.Export
+	t.Id = raw.Id
+	t.Instance = raw.Instance
+	t.Name = raw.Name
+	t.State = raw.State
+
+	return nil
+}
+
+// MarshalJSON returns the JSON encoding of a Snapshot structure after having formatted the CreatedAt field
+// in the original timestamp (ISO 8601), since time.MarshalJSON() only supports RFC 3339 format.
+func (t *Snapshot) MarshalJSON() ([]byte, error) {
+	raw := struct {
+		CreatedAt   *string `json:"created-at,omitempty"`
+		Description *string `json:"description,omitempty"`
+		Export      *struct {
+			Md5sum       *string `json:"md5sum,omitempty"`
+			PresignedUrl *string `json:"presigned-url,omitempty"` // nolint:golint
+		} `json:"export,omitempty"`
+		Id       *string   `json:"id,omitempty"` // nolint:golint
+		Instance *Instance `json:"instance,omitempty"`
+		Name     *string   `json:"name,omitempty"`
+		State    *string   `json:"state,omitempty"`
+	}{}
+
+	if t.CreatedAt != nil {
+		createdAt := t.CreatedAt.Format(iso8601Format)
+		raw.CreatedAt = &createdAt
+	}
+
+	raw.Description = t.Description
+	raw.Export = t.Export
+	raw.Id = t.Id
+	raw.Instance = t.Instance
+	raw.Name = t.Name
+	raw.State = t.State
+
+	return json.Marshal(raw)
+}

--- a/vendor/github.com/exoscale/egoscale/v2/internal/public-api/test.go
+++ b/vendor/github.com/exoscale/egoscale/v2/internal/public-api/test.go
@@ -1,0 +1,15 @@
+package publicapi
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+)
+
+func testRandomID(t *testing.T) string {
+	id, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("unable to generate a new UUID: %s", err)
+	}
+	return id.String()
+}

--- a/vendor/github.com/exoscale/egoscale/v2/private_network.go
+++ b/vendor/github.com/exoscale/egoscale/v2/private_network.go
@@ -29,9 +29,16 @@ func privateNetworkFromAPI(p *papi.PrivateNetwork) *PrivateNetwork {
 	}
 }
 
+func (p PrivateNetwork) get(ctx context.Context, client *Client, zone, id string) (interface{}, error) {
+	return client.GetPrivateNetwork(ctx, zone, id)
+}
+
 // CreatePrivateNetwork creates a Private Network in the specified zone.
-func (c *Client) CreatePrivateNetwork(ctx context.Context, zone string,
-	privateNetwork *PrivateNetwork) (*PrivateNetwork, error) {
+func (c *Client) CreatePrivateNetwork(
+	ctx context.Context,
+	zone string,
+	privateNetwork *PrivateNetwork,
+) (*PrivateNetwork, error) {
 	resp, err := c.CreatePrivateNetworkWithResponse(
 		apiv2.WithZone(ctx, zone),
 		papi.CreatePrivateNetworkJSONRequestBody{

--- a/vendor/github.com/exoscale/egoscale/v2/snapshot.go
+++ b/vendor/github.com/exoscale/egoscale/v2/snapshot.go
@@ -1,0 +1,114 @@
+package v2
+
+import (
+	"context"
+	"time"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	papi "github.com/exoscale/egoscale/v2/internal/public-api"
+)
+
+// SnapshotExport represents exported Snapshot information.
+type SnapshotExport struct {
+	MD5sum       string
+	PresignedURL string
+}
+
+// Snapshot represents a Snapshot.
+type Snapshot struct {
+	CreatedAt  time.Time
+	ID         string
+	InstanceID string
+	Name       string
+	State      string
+
+	c    *Client
+	zone string
+}
+
+func snapshotFromAPI(client *Client, zone string, s *papi.Snapshot) *Snapshot {
+	return &Snapshot{
+		CreatedAt:  *s.CreatedAt,
+		ID:         *s.Id,
+		InstanceID: *s.Instance.Id,
+		Name:       papi.OptionalString(s.Name),
+		State:      *s.State,
+
+		c:    client,
+		zone: zone,
+	}
+}
+
+func (s Snapshot) get(ctx context.Context, client *Client, zone, id string) (interface{}, error) {
+	return client.GetSnapshot(ctx, zone, id)
+}
+
+// Export exports the Snapshot and returns the exported Snapshot information.
+func (s *Snapshot) Export(ctx context.Context) (*SnapshotExport, error) {
+	resp, err := s.c.ExportSnapshotWithResponse(apiv2.WithZone(ctx, s.zone), s.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := papi.NewPoller().
+		WithTimeout(s.c.timeout).
+		Poll(ctx, s.c.OperationPoller(s.zone, *resp.JSON200.Id))
+	if err != nil {
+		return nil, err
+	}
+
+	expSnapshot, err := s.c.GetSnapshotWithResponse(apiv2.WithZone(ctx, s.zone), *res.(*papi.Reference).Id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SnapshotExport{
+		MD5sum:       *expSnapshot.JSON200.Export.Md5sum,
+		PresignedURL: *expSnapshot.JSON200.Export.PresignedUrl,
+	}, nil
+}
+
+// ListSnapshots returns the list of existing Snapshots in the specified zone.
+func (c *Client) ListSnapshots(ctx context.Context, zone string) ([]*Snapshot, error) {
+	list := make([]*Snapshot, 0)
+
+	resp, err := c.ListSnapshotsWithResponse(apiv2.WithZone(ctx, zone))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.Snapshots != nil {
+		for i := range *resp.JSON200.Snapshots {
+			list = append(list, snapshotFromAPI(c, zone, &(*resp.JSON200.Snapshots)[i]))
+		}
+	}
+
+	return list, nil
+}
+
+// GetSnapshot returns the Snapshot corresponding to the specified ID in the specified zone.
+func (c *Client) GetSnapshot(ctx context.Context, zone, id string) (*Snapshot, error) {
+	resp, err := c.GetSnapshotWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	return snapshotFromAPI(c, zone, resp.JSON200), nil
+}
+
+// DeleteSnapshot deletes the specified Snapshot in the specified zone.
+func (c *Client) DeleteSnapshot(ctx context.Context, zone, id string) error {
+	resp, err := c.DeleteSnapshotWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/exoscale/egoscale/v2/template.go
+++ b/vendor/github.com/exoscale/egoscale/v2/template.go
@@ -1,0 +1,101 @@
+package v2
+
+import (
+	"context"
+	"time"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	papi "github.com/exoscale/egoscale/v2/internal/public-api"
+)
+
+// Template represents a Compute instance template.
+type Template struct {
+	BootMode        string
+	Build           string
+	Checksum        string
+	CreatedAt       time.Time
+	DefaultUser     string
+	Description     string
+	Family          string
+	ID              string
+	Name            string
+	PasswordEnabled bool
+	SSHKeyEnabled   bool
+	Size            int64
+	URL             string
+	Version         string
+	Visibility      string
+}
+
+func templateFromAPI(t *papi.Template) *Template {
+	return &Template{
+		BootMode:        papi.OptionalString(t.BootMode),
+		Build:           papi.OptionalString(t.Build),
+		Checksum:        papi.OptionalString(t.Checksum),
+		CreatedAt:       *t.CreatedAt,
+		DefaultUser:     papi.OptionalString(t.DefaultUser),
+		Description:     papi.OptionalString(t.Description),
+		Family:          papi.OptionalString(t.Family),
+		ID:              papi.OptionalString(t.Id),
+		Name:            papi.OptionalString(t.Name),
+		PasswordEnabled: papi.OptionalBool(t.PasswordEnabled),
+		SSHKeyEnabled:   papi.OptionalBool(t.SshKeyEnabled),
+		Size:            *t.Size,
+		URL:             papi.OptionalString(t.Url),
+		Version:         papi.OptionalString(t.Version),
+		Visibility:      papi.OptionalString(t.Visibility),
+	}
+}
+
+// ListTemplates returns the list of existing Templates in the specified zone.
+func (c *Client) ListTemplates(ctx context.Context, zone, visibility, family string) ([]*Template, error) {
+	list := make([]*Template, 0)
+
+	resp, err := c.ListTemplatesWithResponse(apiv2.WithZone(ctx, zone), &papi.ListTemplatesParams{
+		Visibility: &visibility,
+		Family: func() *string {
+			if family != "" {
+				return &family
+			}
+			return nil
+		}(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.Templates != nil {
+		for i := range *resp.JSON200.Templates {
+			list = append(list, templateFromAPI(&(*resp.JSON200.Templates)[i]))
+		}
+	}
+
+	return list, nil
+}
+
+// GetTemplate returns the Template corresponding to the specified ID in the specified zone.
+func (c *Client) GetTemplate(ctx context.Context, zone, id string) (*Template, error) {
+	resp, err := c.GetTemplateWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	return templateFromAPI(resp.JSON200), nil
+}
+
+// DeleteTemplate deletes the specified Template in the specified zone.
+func (c *Client) DeleteTemplate(ctx context.Context, zone, id string) error {
+	resp, err := c.DeleteTemplateWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/exoscale/egoscale/v2/v2.go
+++ b/vendor/github.com/exoscale/egoscale/v2/v2.go
@@ -3,9 +3,14 @@
 package v2
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 )
+
+type getter interface {
+	get(ctx context.Context, client *Client, zone, id string) (interface{}, error)
+}
 
 // resetFieldName returns the value corresponding to the `reset:""` struct tag
 // in the struct res for the specified field, for example:

--- a/vendor/github.com/exoscale/egoscale/version.go
+++ b/vendor/github.com/exoscale/egoscale/version.go
@@ -1,4 +1,4 @@
 package egoscale
 
 // Version of the library
-const Version = "0.47.0"
+const Version = "0.48.1"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -147,7 +147,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.0
 ## explicit
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.47.0
+# github.com/exoscale/egoscale v0.48.1
 ## explicit
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/admin


### PR DESCRIPTION
This PR includes minor code changes and refactoring, as well as `exo instancepool` commands rewrite to use the Exoscale API V2 – bringing support for new functionalities such as Elastic IP attachment, Deploy Targets and Instance Prefix.