### PR TITLE
firewall: support ICMP SG rules with code/type -1

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -14,44 +14,8 @@ import (
 // nilValue is returned by a flag when the value is not set
 const nilValue = "nil"
 
-type uint8PtrValue struct {
-	*uint8
-}
-
-func (v *uint8PtrValue) Set(val string) error {
-	r, err := strconv.ParseUint(val, 10, 8)
-	if err != nil {
-		return err
-	}
-	res := uint8(r)
-	v.uint8 = &res
-	return nil
-}
-
-func (v *uint8PtrValue) Type() string {
-	return "uint8"
-}
-
-func (v *uint8PtrValue) String() string {
-	if v.uint8 == nil {
-		return nilValue
-	}
-	return strconv.FormatUint(uint64(*v.uint8), 10)
-}
-
 // XXX use reflect to factor those out.
 //     e.g. getCustomFlag(cmd *cobra.Command, name string, out interface{}) error {}
-
-func getUint8CustomFlag(cmd *cobra.Command, name string) (*uint8PtrValue, error) {
-	it := cmd.Flags().Lookup(name)
-	if it != nil {
-		r := it.Value.(*uint8PtrValue)
-		if r != nil {
-			return r, nil
-		}
-	}
-	return nil, fmt.Errorf("unable to get flag %q", name)
-}
 
 type int64PtrValue struct {
 	*int64

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/dustin/go-humanize v1.0.0
-	github.com/exoscale/egoscale v0.55.0
+	github.com/exoscale/egoscale v0.56.0
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/exoscale/egoscale v0.55.0 h1:6hq22JZuPrZfWGDu0bHZRRHWg/KD674MvboOVOvvdkE=
-github.com/exoscale/egoscale v0.55.0/go.mod h1:wi0myUxPsV8SdEtdJHQJxFLL/wEw9fiw9Gs1PWRkvkM=
+github.com/exoscale/egoscale v0.56.0 h1:N8nt0wMrNWEg4l+D8fJu6Q4lpRyMasnql3K8On+Uk0o=
+github.com/exoscale/egoscale v0.56.0/go.mod h1:wi0myUxPsV8SdEtdJHQJxFLL/wEw9fiw9Gs1PWRkvkM=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.56.0
+------
+
+- change: the `AuthorizeSecurityGroupIngress` struct now uses an `int` type for `Icmp(Code|Type)` fields (#499)
+
 0.55.0
 ------
 

--- a/vendor/github.com/exoscale/egoscale/security_groups.go
+++ b/vendor/github.com/exoscale/egoscale/security_groups.go
@@ -124,8 +124,8 @@ type AuthorizeSecurityGroupIngress struct {
 	CIDRList              []CIDR              `json:"cidrlist,omitempty" doc:"the cidr list associated"`
 	Description           string              `json:"description,omitempty" doc:"the description of the ingress/egress rule"`
 	EndPort               uint16              `json:"endport,omitempty" doc:"end port for this ingress/egress rule"`
-	IcmpCode              uint8               `json:"icmpcode,omitempty" doc:"error code for this icmp message"`
-	IcmpType              uint8               `json:"icmptype,omitempty" doc:"type of the icmp message being sent"`
+	IcmpCode              int                 `json:"icmpcode,omitempty" doc:"error code for this icmp message"`
+	IcmpType              int                 `json:"icmptype,omitempty" doc:"type of the icmp message being sent"`
 	Protocol              string              `json:"protocol,omitempty" doc:"TCP is default. UDP, ICMP, ICMPv6, AH, ESP, GRE, IPIP are the other supported protocols"`
 	SecurityGroupID       *UUID               `json:"securitygroupid,omitempty" doc:"The ID of the security group. Mutually exclusive with securitygroupname parameter"`
 	SecurityGroupName     string              `json:"securitygroupname,omitempty" doc:"The name of the security group. Mutually exclusive with securitygroupid parameter"`

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.55.0"
+const Version = "0.56.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -146,7 +146,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.0
 ## explicit
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.55.0
+# github.com/exoscale/egoscale v0.56.0
 ## explicit
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/admin


### PR DESCRIPTION
This change allows users to specify ICMP code/type -1 when adding new
firewall rules.