### PR TITLE
lab: db: fix crash during types list/show

### DIFF
--- a/cmd/db_type_list.go
+++ b/cmd/db_type_list.go
@@ -9,8 +9,9 @@ import (
 )
 
 type dbTypeListItemOutput struct {
-	Name          string `json:"name"`
-	LatestVersion string `json:"latest_version"`
+	Name           string `json:"name"`
+	LatestVersion  string `json:"latest_version"`
+	DefaultVersion string `json:"default_version"`
 }
 
 type dbTypeListOutput []dbTypeListItemOutput
@@ -53,8 +54,9 @@ func (c *dbTypeListCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	for _, t := range dbTypes {
 		out = append(out, dbTypeListItemOutput{
-			Name:          *t.Name,
-			LatestVersion: *t.LatestVersion,
+			Name:           *t.Name,
+			DefaultVersion: defaultString(t.DefaultVersion, "-"),
+			LatestVersion:  defaultString(t.LatestVersion, "-"),
 		})
 	}
 

--- a/cmd/db_type_show.go
+++ b/cmd/db_type_show.go
@@ -93,9 +93,9 @@ func (c *dbTypeShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	return output(&dbTypeShowOutput{
 		Name:           *dt.Name,
-		Description:    *dt.Description,
-		LatestVersion:  *dt.LatestVersion,
-		DefaultVersion: *dt.DefaultVersion,
+		Description:    defaultString(dt.Description, ""),
+		LatestVersion:  defaultString(dt.LatestVersion, "-"),
+		DefaultVersion: defaultString(dt.DefaultVersion, "-"),
 		Plans: func() []dbTypePlanShowOutput {
 			plans := make([]dbTypePlanShowOutput, len(dt.Plans))
 			for i := range dt.Plans {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -22,3 +22,12 @@ func ellipString(s string, maxLen int) string {
 
 	return s
 }
+
+// defaultString returns the value of the string pointer s if not nil, otherwise the default value specified.
+func defaultString(s *string, def string) string {
+	if s != nil {
+		return *s
+	}
+
+	return def
+}


### PR DESCRIPTION
This change fixes as crashing bug occuring during `exo lab db types
list|show` commands.