### PR TITLE
sks: add support for labels/auto-upgrade

### DIFF
--- a/cmd/sks_create.go
+++ b/cmd/sks_create.go
@@ -22,22 +22,25 @@ type sksCreateCmd struct {
 
 	Name string `cli-arg:"#" cli-usage:"NAME"`
 
-	Description                string   `cli-usage:"SKS cluster description"`
-	KubernetesVersion          string   `cli-usage:"SKS cluster control plane Kubernetes version"`
-	NoCNI                      bool     `cli-usage:"do not deploy a default Container Network Interface plugin in the cluster control plane"`
-	NoExoscaleCCM              bool     `cli-usage:"do not deploy the Exoscale Cloud Controller Manager in the cluster control plane"`
-	NoMetricsServer            bool     `cli-usage:"do not deploy the Kubernetes Metrics Server in the cluster control plane"`
-	NodepoolAntiAffinityGroups []string `cli-flag:"nodepool-anti-affinity-group" cli-usage:"default Nodepool Anti-Affinity Group NAME|ID (can be specified multiple times)"`
-	NodepoolDeployTarget       string   `cli-usage:"default Nodepool Deploy Target NAME|ID"`
-	NodepoolDescription        string   `cli-usage:"default Nodepool description"`
-	NodepoolDiskSize           int64    `cli-usage:"default Nodepool Compute instances disk size"`
-	NodepoolInstancePrefix     string   `cli-usage:"string to prefix default Nodepool member names with"`
-	NodepoolInstanceType       string   `cli-usage:"default Nodepool Compute instances type"`
-	NodepoolName               string   `cli-usage:"default Nodepool name"`
-	NodepoolSecurityGroups     []string `cli-flag:"nodepool-security-group" cli-usage:"default Nodepool Security Group NAME|ID (can be specified multiple times)"`
-	NodepoolSize               int64    `cli-usage:"default Nodepool size. If 0, no default Nodepool will be added to the cluster."`
-	ServiceLevel               string   `cli-usage:"SKS cluster control plane service level (starter|pro)"`
-	Zone                       string   `cli-short:"z" cli-usage:"SKS cluster zone"`
+	Description                string            `cli-usage:"SKS cluster description"`
+	AutoUpgrade                bool              `cli-usage:"enable automatic upgrading of the SKS cluster control plane Kubernetes version"`
+	KubernetesVersion          string            `cli-usage:"SKS cluster control plane Kubernetes version"`
+	Labels                     map[string]string `cli-flag:"label" cli-usage:"SKS cluster label (format: key=value)"`
+	NoCNI                      bool              `cli-usage:"do not deploy a default Container Network Interface plugin in the cluster control plane"`
+	NoExoscaleCCM              bool              `cli-usage:"do not deploy the Exoscale Cloud Controller Manager in the cluster control plane"`
+	NoMetricsServer            bool              `cli-usage:"do not deploy the Kubernetes Metrics Server in the cluster control plane"`
+	NodepoolAntiAffinityGroups []string          `cli-flag:"nodepool-anti-affinity-group" cli-usage:"default Nodepool Anti-Affinity Group NAME|ID (can be specified multiple times)"`
+	NodepoolDeployTarget       string            `cli-usage:"default Nodepool Deploy Target NAME|ID"`
+	NodepoolDescription        string            `cli-usage:"default Nodepool description"`
+	NodepoolDiskSize           int64             `cli-usage:"default Nodepool Compute instances disk size"`
+	NodepoolInstancePrefix     string            `cli-usage:"string to prefix default Nodepool member names with"`
+	NodepoolInstanceType       string            `cli-usage:"default Nodepool Compute instances type"`
+	NodepoolLabels             map[string]string `cli-flag:"nodepool-label" cli-usage:"default Nodepool label (format: key=value)"`
+	NodepoolName               string            `cli-usage:"default Nodepool name"`
+	NodepoolSecurityGroups     []string          `cli-flag:"nodepool-security-group" cli-usage:"default Nodepool Security Group NAME|ID (can be specified multiple times)"`
+	NodepoolSize               int64             `cli-usage:"default Nodepool size. If 0, no default Nodepool will be added to the cluster."`
+	ServiceLevel               string            `cli-usage:"SKS cluster control plane service level (starter|pro)"`
+	Zone                       string            `cli-short:"z" cli-usage:"SKS cluster zone"`
 }
 
 func (c *sksCreateCmd) cmdAliases() []string { return gCreateAlias }
@@ -70,10 +73,17 @@ func (c *sksCreateCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
 
 func (c *sksCreateCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	cluster := &exov2.SKSCluster{
-		CNI: &defaultSKSClusterCNI,
+		AutoUpgrade: &c.AutoUpgrade,
+		CNI:         &defaultSKSClusterCNI,
 		Description: func() (v *string) {
 			if c.Description != "" {
 				v = &c.Description
+			}
+			return
+		}(),
+		Labels: func() (v *map[string]string) {
+			if len(c.Labels) > 0 {
+				return &c.Labels
 			}
 			return
 		}(),
@@ -141,6 +151,12 @@ func (c *sksCreateCmd) cmdRun(_ *cobra.Command, _ []string) error {
 			InstancePrefix: func() (v *string) {
 				if c.NodepoolInstancePrefix != "" {
 					v = &c.NodepoolInstancePrefix
+				}
+				return
+			}(),
+			Labels: func() (v *map[string]string) {
+				if len(c.NodepoolLabels) > 0 {
+					return &c.NodepoolLabels
 				}
 				return
 			}(),

--- a/cmd/sks_nodepool_add.go
+++ b/cmd/sks_nodepool_add.go
@@ -15,15 +15,16 @@ type sksNodepoolAddCmd struct {
 	Cluster string `cli-arg:"#" cli-usage:"CLUSTER-NAME|ID"`
 	Name    string `cli-arg:"#" cli-usage:"NODEPOOL-NAME"`
 
-	AntiAffinityGroups []string `cli-flag:"anti-affinity-group" cli-usage:"Nodepool Anti-Affinity Group NAME|ID (can be specified multiple times)"`
-	DeployTarget       string   `cli-usage:"Nodepool Deploy Target NAME|ID"`
-	Description        string   `cli-usage:"Nodepool description"`
-	DiskSize           int64    `cli-usage:"Nodepool Compute instances disk size"`
-	InstancePrefix     string   `cli-usage:"string to prefix Nodepool member names with"`
-	InstanceType       string   `cli-usage:"Nodepool Compute instances type"`
-	SecurityGroups     []string `cli-flag:"security-group" cli-usage:"Nodepool Security Group NAME|ID (can be specified multiple times)"`
-	Size               int64    `cli-usage:"Nodepool size"`
-	Zone               string   `cli-short:"z" cli-usage:"SKS cluster zone"`
+	AntiAffinityGroups []string          `cli-flag:"anti-affinity-group" cli-usage:"Nodepool Anti-Affinity Group NAME|ID (can be specified multiple times)"`
+	DeployTarget       string            `cli-usage:"Nodepool Deploy Target NAME|ID"`
+	Description        string            `cli-usage:"Nodepool description"`
+	DiskSize           int64             `cli-usage:"Nodepool Compute instances disk size"`
+	InstancePrefix     string            `cli-usage:"string to prefix Nodepool member names with"`
+	InstanceType       string            `cli-usage:"Nodepool Compute instances type"`
+	Labels             map[string]string `cli-flag:"label" cli-usage:"Nodepool label (format: key=value)"`
+	SecurityGroups     []string          `cli-flag:"security-group" cli-usage:"Nodepool Security Group NAME|ID (can be specified multiple times)"`
+	Size               int64             `cli-usage:"Nodepool size"`
+	Zone               string            `cli-short:"z" cli-usage:"SKS cluster zone"`
 }
 
 func (c *sksNodepoolAddCmd) cmdAliases() []string { return nil }
@@ -54,6 +55,12 @@ func (c *sksNodepoolAddCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		InstancePrefix: func() (v *string) {
 			if c.InstancePrefix != "" {
 				v = &c.InstancePrefix
+			}
+			return
+		}(),
+		Labels: func() (v *map[string]string) {
+			if len(c.Labels) > 0 {
+				return &c.Labels
 			}
 			return
 		}(),

--- a/cmd/sks_nodepool_show.go
+++ b/cmd/sks_nodepool_show.go
@@ -11,20 +11,21 @@ import (
 )
 
 type sksNodepoolShowOutput struct {
-	ID                 string   `json:"id"`
-	Name               string   `json:"name"`
-	Description        string   `json:"description"`
-	CreationDate       string   `json:"creation_date"`
-	InstancePoolID     string   `json:"instance_pool_id"`
-	InstancePrefix     string   `json:"instance_prefix"`
-	InstanceType       string   `json:"instance_type"`
-	Template           string   `json:"template"`
-	DiskSize           int64    `json:"disk_size"`
-	AntiAffinityGroups []string `json:"anti_affinity_groups"`
-	SecurityGroups     []string `json:"security_groups"`
-	Version            string   `json:"version"`
-	Size               int64    `json:"size"`
-	State              string   `json:"state"`
+	ID                 string            `json:"id"`
+	Name               string            `json:"name"`
+	Description        string            `json:"description"`
+	CreationDate       string            `json:"creation_date"`
+	InstancePoolID     string            `json:"instance_pool_id"`
+	InstancePrefix     string            `json:"instance_prefix"`
+	InstanceType       string            `json:"instance_type"`
+	Template           string            `json:"template"`
+	DiskSize           int64             `json:"disk_size"`
+	AntiAffinityGroups []string          `json:"anti_affinity_groups"`
+	SecurityGroups     []string          `json:"security_groups"`
+	Version            string            `json:"version"`
+	Size               int64             `json:"size"`
+	State              string            `json:"state"`
+	Labels             map[string]string `json:"labels"`
 }
 
 func (o *sksNodepoolShowOutput) toJSON()      { outputJSON(o) }
@@ -89,11 +90,17 @@ func showSKSNodepool(zone, c, np string) (outputter, error) {
 		ID:                 *nodepool.ID,
 		InstancePoolID:     *nodepool.InstancePoolID,
 		InstancePrefix:     defaultString(nodepool.InstancePrefix, ""),
-		Name:               *nodepool.Name,
-		SecurityGroups:     make([]string, 0),
-		Size:               *nodepool.Size,
-		State:              *nodepool.State,
-		Version:            *nodepool.Version,
+		Labels: func() (v map[string]string) {
+			if nodepool.Labels != nil {
+				v = *nodepool.Labels
+			}
+			return
+		}(),
+		Name:           *nodepool.Name,
+		SecurityGroups: make([]string, 0),
+		Size:           *nodepool.Size,
+		State:          *nodepool.State,
+		Version:        *nodepool.Version,
 	}
 
 	antiAffinityGroups, err := nodepool.AntiAffinityGroups(ctx)

--- a/cmd/sks_nodepool_update.go
+++ b/cmd/sks_nodepool_update.go
@@ -16,15 +16,16 @@ type sksNodepoolUpdateCmd struct {
 	Cluster  string `cli-arg:"#" cli-usage:"CLUSTER-NAME|ID"`
 	Nodepool string `cli-arg:"#" cli-usage:"NODEPOOL-NAME|ID"`
 
-	AntiAffinityGroups []string `cli-flag:"anti-affinity-group" cli-usage:"Nodepool Anti-Affinity Group NAME|ID (can be specified multiple times)"`
-	DeployTarget       string   `cli-usage:"Nodepool Deploy Target NAME|ID"`
-	Description        string   `cli-usage:"Nodepool description"`
-	DiskSize           int64    `cli-usage:"Nodepool Compute instances disk size"`
-	InstancePrefix     string   `cli-usage:"string to prefix Nodepool member names with"`
-	InstanceType       string   `cli-usage:"Nodepool Compute instances type"`
-	Name               string   `cli-usage:"Nodepool name"`
-	SecurityGroups     []string `cli-flag:"security-group" cli-usage:"Nodepool Security Group NAME|ID (can be specified multiple times)"`
-	Zone               string   `cli-short:"z" cli-usage:"SKS cluster zone"`
+	AntiAffinityGroups []string          `cli-flag:"anti-affinity-group" cli-usage:"Nodepool Anti-Affinity Group NAME|ID (can be specified multiple times)"`
+	DeployTarget       string            `cli-usage:"Nodepool Deploy Target NAME|ID"`
+	Description        string            `cli-usage:"Nodepool description"`
+	DiskSize           int64             `cli-usage:"Nodepool Compute instances disk size"`
+	InstancePrefix     string            `cli-usage:"string to prefix Nodepool member names with"`
+	InstanceType       string            `cli-usage:"Nodepool Compute instances type"`
+	Labels             map[string]string `cli-flag:"label" cli-usage:"Nodepool label (format: key=value)"`
+	Name               string            `cli-usage:"Nodepool name"`
+	SecurityGroups     []string          `cli-flag:"security-group" cli-usage:"Nodepool Security Group NAME|ID (can be specified multiple times)"`
+	Zone               string            `cli-short:"z" cli-usage:"SKS cluster zone"`
 }
 
 func (c *sksNodepoolUpdateCmd) cmdAliases() []string { return nil }
@@ -110,6 +111,11 @@ func (c *sksNodepoolUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("error retrieving instance type: %s", err)
 		}
 		nodepool.InstanceTypeID = nodepoolInstanceType.ID
+		updated = true
+	}
+
+	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.Labels)) {
+		nodepool.Labels = &c.Labels
 		updated = true
 	}
 

--- a/cmd/sks_show.go
+++ b/cmd/sks_show.go
@@ -22,6 +22,7 @@ type sksShowOutput struct {
 	CNI          string                  `json:"cni"`
 	AddOns       []string                `json:"addons"`
 	State        string                  `json:"state"`
+	Labels       map[string]string       `json:"labels"`
 	Nodepools    []sksNodepoolShowOutput `json:"nodepools"`
 }
 
@@ -43,6 +44,20 @@ func (o *sksShowOutput) toTable() {
 	t.Append([]string{"CNI", o.CNI})
 	t.Append([]string{"Add-Ons", strings.Join(o.AddOns, "\n")})
 	t.Append([]string{"State", o.State})
+	t.Append([]string{"Labels", func() string {
+		if len(o.Labels) > 0 {
+			return strings.Join(
+				func() []string {
+					labels := make([]string, 0)
+					for k, v := range o.Labels {
+						labels = append(labels, fmt.Sprintf("%s:%s", k, v))
+					}
+					return labels
+				}(),
+				"\n")
+		}
+		return "n/a"
+	}()})
 	t.Append([]string{"Nodepools", func() string {
 		if len(o.Nodepools) > 0 {
 			return strings.Join(
@@ -117,6 +132,12 @@ func showSKSCluster(zone, c string) (outputter, error) {
 		Description:  defaultString(cluster.Description, ""),
 		Endpoint:     *cluster.Endpoint,
 		ID:           *cluster.ID,
+		Labels: func() (v map[string]string) {
+			if cluster.Labels != nil {
+				v = *cluster.Labels
+			}
+			return
+		}(),
 		Name:         *cluster.Name,
 		Nodepools:    sksNodepools,
 		ServiceLevel: *cluster.ServiceLevel,

--- a/cmd/sks_update.go
+++ b/cmd/sks_update.go
@@ -13,9 +13,11 @@ type sksUpdateCmd struct {
 
 	Cluster string `cli-arg:"#" cli-usage:"NAME|ID"`
 
-	Description string `cli-usage:"cluster description"`
-	Name        string `cli-usage:"cluster name"`
-	Zone        string `cli-short:"z" cli-usage:"SKS cluster zone"`
+	AutoUpgrade bool              `cli-usage:"enable automatic upgrading of the SKS cluster control plane Kubernetes version"`
+	Description string            `cli-usage:"SKS cluster description"`
+	Labels      map[string]string `cli-flag:"label" cli-usage:"SKS cluster label (format: key=value)"`
+	Name        string            `cli-usage:"SKS cluster name"`
+	Zone        string            `cli-short:"z" cli-usage:"SKS cluster zone"`
 }
 
 func (c *sksUpdateCmd) cmdAliases() []string { return nil }
@@ -43,6 +45,16 @@ func (c *sksUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
 	if err != nil {
 		return err
+	}
+
+	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.AutoUpgrade)) {
+		cluster.AutoUpgrade = &c.AutoUpgrade
+		updated = true
+	}
+
+	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.Labels)) {
+		cluster.Labels = &c.Labels
+		updated = true
 	}
 
 	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.Name)) {


### PR DESCRIPTION
This change adds support for labels to SKS clusters/nodepools, as well
as auto-upgrade for SKS clusters.