### PR TITLE
sks: nodepool: add support for Private Networks

### DIFF
--- a/cmd/sks_nodepool_add.go
+++ b/cmd/sks_nodepool_add.go
@@ -22,6 +22,7 @@ type sksNodepoolAddCmd struct {
 	InstancePrefix     string            `cli-usage:"string to prefix Nodepool member names with"`
 	InstanceType       string            `cli-usage:"Nodepool Compute instances type"`
 	Labels             map[string]string `cli-flag:"label" cli-usage:"Nodepool label (format: key=value)"`
+	PrivateNetworks    []string          `cli-flag:"private-network" cli-usage:"Nodepool Private Network NAME|ID (can be specified multiple times)"`
 	SecurityGroups     []string          `cli-flag:"security-group" cli-usage:"Nodepool Security Group NAME|ID (can be specified multiple times)"`
 	Size               int64             `cli-usage:"Nodepool size"`
 	Zone               string            `cli-short:"z" cli-usage:"SKS cluster zone"`
@@ -100,6 +101,18 @@ func (c *sksNodepoolAddCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("error retrieving instance type: %s", err)
 	}
 	nodepool.InstanceTypeID = nodepoolInstanceType.ID
+
+	if l := len(c.PrivateNetworks); l > 0 {
+		nodepoolPrivateNetworkIDs := make([]string, l)
+		for i := range c.PrivateNetworks {
+			privateNetwork, err := cs.FindPrivateNetwork(ctx, c.Zone, c.PrivateNetworks[i])
+			if err != nil {
+				return fmt.Errorf("error retrieving Private Network: %s", err)
+			}
+			nodepoolPrivateNetworkIDs[i] = *privateNetwork.ID
+		}
+		nodepool.PrivateNetworkIDs = &nodepoolPrivateNetworkIDs
+	}
 
 	if l := len(c.SecurityGroups); l > 0 {
 		nodepoolSecurityGroupIDs := make([]string, l)

--- a/cmd/sks_nodepool_show.go
+++ b/cmd/sks_nodepool_show.go
@@ -22,6 +22,7 @@ type sksNodepoolShowOutput struct {
 	DiskSize           int64             `json:"disk_size"`
 	AntiAffinityGroups []string          `json:"anti_affinity_groups"`
 	SecurityGroups     []string          `json:"security_groups"`
+	PrivateNetworks    []string          `json:"private_networks"`
 	Version            string            `json:"version"`
 	Size               int64             `json:"size"`
 	State              string            `json:"state"`
@@ -96,11 +97,12 @@ func showSKSNodepool(zone, c, np string) (outputter, error) {
 			}
 			return
 		}(),
-		Name:           *nodepool.Name,
-		SecurityGroups: make([]string, 0),
-		Size:           *nodepool.Size,
-		State:          *nodepool.State,
-		Version:        *nodepool.Version,
+		Name:            *nodepool.Name,
+		SecurityGroups:  make([]string, 0),
+		PrivateNetworks: make([]string, 0),
+		Size:            *nodepool.Size,
+		State:           *nodepool.State,
+		Version:         *nodepool.Version,
 	}
 
 	antiAffinityGroups, err := nodepool.AntiAffinityGroups(ctx)
@@ -117,6 +119,14 @@ func showSKSNodepool(zone, c, np string) (outputter, error) {
 	}
 	for _, securityGroup := range securityGroups {
 		out.SecurityGroups = append(out.SecurityGroups, *securityGroup.Name)
+	}
+
+	privateNetworks, err := nodepool.PrivateNetworks(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, privateNetwork := range privateNetworks {
+		out.PrivateNetworks = append(out.PrivateNetworks, *privateNetwork.Name)
 	}
 
 	serviceOffering, err := cs.GetInstanceType(ctx, zone, *nodepool.InstanceTypeID)

--- a/cmd/sks_nodepool_update.go
+++ b/cmd/sks_nodepool_update.go
@@ -24,6 +24,7 @@ type sksNodepoolUpdateCmd struct {
 	InstanceType       string            `cli-usage:"Nodepool Compute instances type"`
 	Labels             map[string]string `cli-flag:"label" cli-usage:"Nodepool label (format: key=value)"`
 	Name               string            `cli-usage:"Nodepool name"`
+	PrivateNetworks    []string          `cli-flag:"private-network" cli-usage:"Nodepool Private Network NAME|ID (can be specified multiple times)"`
 	SecurityGroups     []string          `cli-flag:"security-group" cli-usage:"Nodepool Security Group NAME|ID (can be specified multiple times)"`
 	Zone               string            `cli-short:"z" cli-usage:"SKS cluster zone"`
 }
@@ -121,6 +122,19 @@ func (c *sksNodepoolUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 
 	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.Name)) {
 		nodepool.Name = &c.Name
+		updated = true
+	}
+
+	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.PrivateNetworks)) {
+		nodepoolPrivateNetworkIDs := make([]string, len(c.PrivateNetworks))
+		for i, v := range c.PrivateNetworks {
+			privateNetwork, err := cs.FindPrivateNetwork(ctx, c.Zone, v)
+			if err != nil {
+				return fmt.Errorf("error retrieving Private Network: %s", err)
+			}
+			nodepoolPrivateNetworkIDs[i] = *privateNetwork.ID
+		}
+		nodepool.PrivateNetworkIDs = &nodepoolPrivateNetworkIDs
 		updated = true
 	}
 


### PR DESCRIPTION
This change adds support for Private Networks to the `exo sks nodepool`
commands via the `--private-network` flag.