### PR TITLE
output: fix decorateAsyncOperation output

### DIFF
--- a/cmd/output.go
+++ b/cmd/output.go
@@ -295,6 +295,7 @@ func outputTable(o interface{}) {
 // terminal.
 func decorateAsyncOperation(message string, fn func()) {
 	p := mpb.New(
+		mpb.WithOutput(os.Stderr),
 		mpb.WithWidth(1),
 		mpb.ContainerOptOn(mpb.WithOutput(nil), func() bool { return gQuiet }),
 	)


### PR DESCRIPTION
This change fixes a bug in the `decorateAsyncOperation` helper, which
should output to *stderr* instead of *stdout*.

Fixes #364.