### PR TITLE
db: new "ca-certificate" command + connection info output label

### DIFF
--- a/cmd/db_cacertificate.go
+++ b/cmd/db_cacertificate.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type dbCACertificateCmd struct {
+	_ bool `cli-cmd:"ca-certificate"`
+
+	Zone string `cli-short:"z"`
+}
+
+func (c *dbCACertificateCmd) cmdAliases() []string { return nil }
+
+func (c *dbCACertificateCmd) cmdShort() string { return "Retrieve the Database CA certificate" }
+
+func (c *dbCACertificateCmd) cmdLong() string {
+	return `This command retrieves the global CA certificate required to access Database
+Services using a TLS connection.`
+}
+
+func (c *dbCACertificateCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	cmdSetZoneFlagFromDefault(cmd)
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *dbCACertificateCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
+
+	dbCACertificate, err := cs.GetDatabaseCACertificate(ctx, c.Zone)
+	if err != nil {
+		return err
+	}
+
+	_, _ = fmt.Print(dbCACertificate)
+
+	return nil
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(dbCmd, &dbCACertificateCmd{}))
+}

--- a/cmd/db_cacertificate.go
+++ b/cmd/db_cacertificate.go
@@ -8,6 +8,8 @@ import (
 )
 
 type dbCACertificateCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
 	_ bool `cli-cmd:"ca-certificate"`
 
 	Zone string `cli-short:"z"`
@@ -41,5 +43,7 @@ func (c *dbCACertificateCmd) cmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(registerCLICommand(dbCmd, &dbCACertificateCmd{}))
+	cobra.CheckErr(registerCLICommand(dbCmd, &dbCACertificateCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/db_service_create.go
+++ b/cmd/db_service_create.go
@@ -10,6 +10,8 @@ import (
 )
 
 type dbServiceCreateCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
 	_ bool `cli-cmd:"create"`
 
 	Type string `cli-arg:"#"`
@@ -84,5 +86,7 @@ func (c *dbServiceCreateCmd) cmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(registerCLICommand(dbCmd, &dbServiceCreateCmd{}))
+	cobra.CheckErr(registerCLICommand(dbCmd, &dbServiceCreateCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/db_service_delete.go
+++ b/cmd/db_service_delete.go
@@ -9,6 +9,8 @@ import (
 )
 
 type dbServiceDeleteCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
 	_ bool `cli-cmd:"delete"`
 
 	Name string `cli-arg:"#"`
@@ -49,5 +51,7 @@ func (c *dbServiceDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(registerCLICommand(dbCmd, &dbServiceDeleteCmd{}))
+	cobra.CheckErr(registerCLICommand(dbCmd, &dbServiceDeleteCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/db_service_list.go
+++ b/cmd/db_service_list.go
@@ -23,6 +23,8 @@ func (o *dbServiceListOutput) toText()  { outputText(o) }
 func (o *dbServiceListOutput) toTable() { outputTable(o) }
 
 type dbServiceListCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
 	_ bool `cli-cmd:"list"`
 
 	Zone string `cli-short:"z" cli-usage:"zone to filter results to"`
@@ -89,5 +91,7 @@ func (c *dbServiceListCmd) cmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(registerCLICommand(dbCmd, &dbServiceListCmd{}))
+	cobra.CheckErr(registerCLICommand(dbCmd, &dbServiceListCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/db_service_show.go
+++ b/cmd/db_service_show.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/exoscale/cli/table"
+	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
 	"github.com/spf13/cobra"
 )
@@ -38,23 +39,24 @@ type dbServiceUserShowOutput struct {
 }
 
 type dbServiceShowOutput struct {
-	Name                  string                          `json:"name"`
-	Type                  string                          `json:"type"`
-	Plan                  string                          `json:"plan"`
-	CreationDate          time.Time                       `json:"creation_date"`
-	Nodes                 int64                           `json:"nodes"`
-	NodeCPUs              int64                           `json:"node_cpus"`
-	NodeMemory            int64                           `json:"node_memory"`
-	UpdateDate            time.Time                       `json:"update_date"`
-	DiskSize              int64                           `json:"disk_size"`
-	State                 string                          `json:"state"`
-	TerminationProtection bool                            `json:"termination_protection"`
-	Maintenance           *dbServiceMaintenanceShowOutput `json:"maintenance"`
-	Users                 []dbServiceUserShowOutput       `json:"users"`
-	ConnectionInfo        map[string]interface{}          `json:"connection_info"`
-	Features              map[string]interface{}          `json:"features"`
-	Metadata              map[string]interface{}          `json:"metadata"`
-	Zone                  string                          `json:"zone"`
+	Name                  string                               `json:"name"`
+	Type                  string                               `json:"type"`
+	Plan                  string                               `json:"plan"`
+	CreationDate          time.Time                            `json:"creation_date"`
+	Nodes                 int64                                `json:"nodes"`
+	NodeCPUs              int64                                `json:"node_cpus"`
+	NodeMemory            int64                                `json:"node_memory"`
+	UpdateDate            time.Time                            `json:"update_date"`
+	DiskSize              int64                                `json:"disk_size"`
+	State                 string                               `json:"state"`
+	TerminationProtection bool                                 `json:"termination_protection"`
+	Maintenance           *dbServiceMaintenanceShowOutput      `json:"maintenance"`
+	Users                 []dbServiceUserShowOutput            `json:"users"`
+	ConnectionInfo        map[string]interface{}               `json:"connection_info"`
+	Components            []*egoscale.DatabaseServiceComponent `json:"components"`
+	Features              map[string]interface{}               `json:"features"`
+	Metadata              map[string]interface{}               `json:"metadata"`
+	Zone                  string                               `json:"zone"`
 }
 
 func (o *dbServiceShowOutput) toJSON() { outputJSON(o) }
@@ -243,6 +245,7 @@ func showDatabaseService(zone, name string) (outputter, error) {
 			return
 		}(),
 		ConnectionInfo: databaseService.ConnectionInfo,
+		Components:     databaseService.Components,
 		Features:       databaseService.Features,
 		Metadata:       databaseService.Metadata,
 		Users: func() []dbServiceUserShowOutput {

--- a/cmd/db_service_show.go
+++ b/cmd/db_service_show.go
@@ -51,6 +51,7 @@ type dbServiceShowOutput struct {
 	TerminationProtection bool                            `json:"termination_protection"`
 	Maintenance           *dbServiceMaintenanceShowOutput `json:"maintenance"`
 	Users                 []dbServiceUserShowOutput       `json:"users"`
+	ConnectionInfo        map[string]interface{}          `json:"connection_info"`
 	Features              map[string]interface{}          `json:"features"`
 	Metadata              map[string]interface{}          `json:"metadata"`
 	Zone                  string                          `json:"zone"`
@@ -70,9 +71,9 @@ func (o *dbServiceShowOutput) toTable() {
 	t.Append([]string{"Creation Date", fmt.Sprint(o.CreationDate)})
 	t.Append([]string{"Nodes", fmt.Sprint(o.Nodes)})
 	t.Append([]string{"Node CPUs", fmt.Sprint(o.NodeCPUs)})
-	t.Append([]string{"Node Memory", humanize.Bytes(uint64(o.NodeMemory))})
+	t.Append([]string{"Node Memory", humanize.IBytes(uint64(o.NodeMemory))})
 	t.Append([]string{"Update Date", fmt.Sprint(o.UpdateDate)})
-	t.Append([]string{"Disk Size", humanize.Bytes(uint64(o.DiskSize))})
+	t.Append([]string{"Disk Size", humanize.IBytes(uint64(o.DiskSize))})
 	t.Append([]string{"State", o.State})
 	t.Append([]string{"Termination Protected", fmt.Sprint(o.TerminationProtection)})
 
@@ -142,6 +143,8 @@ func (o *dbServiceShowOutput) toTable() {
 }
 
 type dbServiceShowCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
 	_ bool `cli-cmd:"show"`
 
 	Name string `cli-arg:"#"`
@@ -239,8 +242,9 @@ func showDatabaseService(zone, name string) (outputter, error) {
 			}
 			return
 		}(),
-		Features: databaseService.Features,
-		Metadata: databaseService.Metadata,
+		ConnectionInfo: databaseService.ConnectionInfo,
+		Features:       databaseService.Features,
+		Metadata:       databaseService.Metadata,
 		Users: func() []dbServiceUserShowOutput {
 			list := make([]dbServiceUserShowOutput, len(databaseService.Users))
 			for i, u := range databaseService.Users {
@@ -258,5 +262,7 @@ func showDatabaseService(zone, name string) (outputter, error) {
 }
 
 func init() {
-	cobra.CheckErr(registerCLICommand(dbCmd, &dbServiceShowCmd{}))
+	cobra.CheckErr(registerCLICommand(dbCmd, &dbServiceShowCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/db_service_update.go
+++ b/cmd/db_service_update.go
@@ -10,6 +10,8 @@ import (
 )
 
 type dbServiceUpdateCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
 	_ bool `cli-cmd:"update"`
 
 	Name string `cli-arg:"#"`
@@ -99,5 +101,7 @@ func (c *dbServiceUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(registerCLICommand(dbCmd, &dbServiceUpdateCmd{}))
+	cobra.CheckErr(registerCLICommand(dbCmd, &dbServiceUpdateCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/db_type_list.go
+++ b/cmd/db_type_list.go
@@ -21,6 +21,8 @@ func (o *dbTypeListOutput) toText()  { outputText(o) }
 func (o *dbTypeListOutput) toTable() { outputTable(o) }
 
 type dbTypeListCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
 	_ bool `cli-cmd:"list"`
 }
 
@@ -64,5 +66,7 @@ func (c *dbTypeListCmd) cmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(registerCLICommand(dbTypeCmd, &dbTypeListCmd{}))
+	cobra.CheckErr(registerCLICommand(dbTypeCmd, &dbTypeListCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/db_type_show.go
+++ b/cmd/db_type_show.go
@@ -60,6 +60,8 @@ func (o *dbTypeShowOutput) toTable() {
 }
 
 type dbTypeShowCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
 	_ bool `cli-cmd:"show"`
 
 	Name string `cli-arg:"#"`
@@ -113,5 +115,7 @@ func (c *dbTypeShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(registerCLICommand(dbTypeCmd, &dbTypeShowCmd{}))
+	cobra.CheckErr(registerCLICommand(dbTypeCmd, &dbTypeShowCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/exoscale/egoscale v0.68.1
+	github.com/exoscale/egoscale v0.69.0
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/exoscale/egoscale v0.69.0
+	github.com/exoscale/egoscale v0.70.0
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/exoscale/egoscale v0.68.1 h1:uLGGRDCSmpFvluqutHmt0bma7HCdzsR0KH527mUh9V8=
-github.com/exoscale/egoscale v0.68.1/go.mod h1:wi0myUxPsV8SdEtdJHQJxFLL/wEw9fiw9Gs1PWRkvkM=
+github.com/exoscale/egoscale v0.69.0 h1:+Unrd28fBR5Po59Rf9Lvn7gFXcDLqydyuybwaJctBqk=
+github.com/exoscale/egoscale v0.69.0/go.mod h1:wi0myUxPsV8SdEtdJHQJxFLL/wEw9fiw9Gs1PWRkvkM=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/exoscale/egoscale v0.69.0 h1:+Unrd28fBR5Po59Rf9Lvn7gFXcDLqydyuybwaJctBqk=
-github.com/exoscale/egoscale v0.69.0/go.mod h1:wi0myUxPsV8SdEtdJHQJxFLL/wEw9fiw9Gs1PWRkvkM=
+github.com/exoscale/egoscale v0.70.0 h1:7Uf0DSkeB1zL5p7y/kaD1Gz2IUMfOnvRogymZL+fBYc=
+github.com/exoscale/egoscale v0.70.0/go.mod h1:wi0myUxPsV8SdEtdJHQJxFLL/wEw9fiw9Gs1PWRkvkM=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.69.0
+------
+
+- feature: v2: add method `Client.GetDatabaseCACertificate()`
+
 0.68.1
 ------
 

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.70.0
+------
+
+- feature: v2: add `DatabaseServiceComponent` struct
+
 0.69.0
 ------
 

--- a/vendor/github.com/exoscale/egoscale/v2/database.go
+++ b/vendor/github.com/exoscale/egoscale/v2/database.go
@@ -228,6 +228,16 @@ func databaseServiceFromAPI(s *papi.DbaasService) *DatabaseService {
 	}
 }
 
+// GetDatabaseCACertificate returns the CA certificate required to access Database Services using a TLS connection.
+func (c *Client) GetDatabaseCACertificate(ctx context.Context, zone string) (string, error) {
+	resp, err := c.GetDbaasCaCertificateWithResponse(apiv2.WithZone(ctx, zone))
+	if err != nil {
+		return "", err
+	}
+
+	return *resp.JSON200.Certificate, nil
+}
+
 // GetDatabaseServiceType returns the Database Service type corresponding to the specified name.
 func (c *Client) GetDatabaseServiceType(ctx context.Context, zone, name string) (*DatabaseServiceType, error) {
 	resp, err := c.GetDbaasServiceTypeWithResponse(apiv2.WithZone(ctx, zone), name)

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.68.1"
+const Version = "0.69.0"

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.69.0"
+const Version = "0.70.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.0
 ## explicit
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.68.1
+# github.com/exoscale/egoscale v0.69.0
 ## explicit
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/v2

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.0
 ## explicit
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.69.0
+# github.com/exoscale/egoscale v0.70.0
 ## explicit
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/v2


### PR DESCRIPTION
##  db: add new "ca-certificate" command

This change adds a new `exo lab db get-certificate` command.

##  db: show: expose service-specific connection info

This change introduces a new `ConnectionInfo` output label to the `exo
lab db show` command, exposing service-specific connection info.

##  db: show: expose service components

This change introduces a new `Components` output label to the `exo
lab db show` command, exposing service-specific components.


