### PR TITLE
sks: add new "upgrade-service-level" command

### DIFF
--- a/cmd/sks_upgrade_service_level.go
+++ b/cmd/sks_upgrade_service_level.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type sksUpgradeServiceLevelCmd struct {
+	_ bool `cli-cmd:"upgrade-service-level"`
+
+	Cluster string `cli-arg:"#" cli-usage:"NAME|ID"`
+
+	Force bool   `cli-short:"f" cli-usage:"don't prompt for confirmation"`
+	Zone  string `cli-short:"z" cli-usage:"SKS cluster zone"`
+}
+
+func (c *sksUpgradeServiceLevelCmd) cmdAliases() []string { return nil }
+
+func (c *sksUpgradeServiceLevelCmd) cmdShort() string {
+	return "Upgrade an SKS cluster service level"
+}
+
+func (c *sksUpgradeServiceLevelCmd) cmdLong() string {
+	return `This command upgrades an SKS cluster's service level to "pro".
+
+Note: once upgraded to pro, an SKS cluster service level cannot be downgraded
+to a lower level.`
+}
+
+func (c *sksUpgradeServiceLevelCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	cmdSetZoneFlagFromDefault(cmd)
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *sksUpgradeServiceLevelCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	if !c.Force {
+		if !askQuestion(fmt.Sprintf(
+			"Are you sure you want to upgrade the cluster %q to service level pro?",
+			c.Cluster,
+		)) {
+			return nil
+		}
+	}
+
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
+
+	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
+	if err != nil {
+		return err
+	}
+
+	decorateAsyncOperation(fmt.Sprintf("Upgrading SKS cluster %q service level...", c.Cluster), func() {
+		err = cs.UpgradeSKSClusterServiceLevel(ctx, c.Zone, cluster)
+	})
+	if err != nil {
+		return err
+	}
+
+	if !gQuiet {
+		return output(showSKSCluster(c.Zone, *cluster.ID))
+	}
+
+	return nil
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(sksCmd, &sksUpgradeServiceLevelCmd{}))
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/exoscale/egoscale v0.70.0
+	github.com/exoscale/egoscale v0.71.0
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/exoscale/egoscale v0.70.0 h1:7Uf0DSkeB1zL5p7y/kaD1Gz2IUMfOnvRogymZL+fBYc=
-github.com/exoscale/egoscale v0.70.0/go.mod h1:wi0myUxPsV8SdEtdJHQJxFLL/wEw9fiw9Gs1PWRkvkM=
+github.com/exoscale/egoscale v0.71.0 h1:+NL4N8Y9c8RrmxXo/KWaO2c4C1TQmME/kympyqUkbrM=
+github.com/exoscale/egoscale v0.71.0/go.mod h1:wi0myUxPsV8SdEtdJHQJxFLL/wEw9fiw9Gs1PWRkvkM=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.71.0
+------
+
+- feature: v2: add `Client.UpgradeSKSClusterServiceLevel()` method
+
 0.70.0
 ------
 

--- a/vendor/github.com/exoscale/egoscale/v2/sks.go
+++ b/vendor/github.com/exoscale/egoscale/v2/sks.go
@@ -805,3 +805,21 @@ func (c *Client) UpgradeSKSCluster(ctx context.Context, zone string, cluster *SK
 
 	return nil
 }
+
+// UpgradeSKSClusterServiceLevel upgrades an SKS cluster to service level "pro".
+func (c *Client) UpgradeSKSClusterServiceLevel(ctx context.Context, zone string, cluster *SKSCluster) error {
+	resp, err := c.UpgradeSksClusterServiceLevelWithResponse(apiv2.WithZone(ctx, zone), *cluster.ID)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.70.0"
+const Version = "0.71.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.0
 ## explicit
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.70.0
+# github.com/exoscale/egoscale v0.71.0
 ## explicit
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/v2


### PR DESCRIPTION
This change adds a new `exo sks upgrade-service-level` command.