### PR TITLE
vm: fix a bug in the "create" command

### DIFF
--- a/cmd/vm_create.go
+++ b/cmd/vm_create.go
@@ -147,7 +147,7 @@ Supported output template annotations: %s`,
 		}
 
 		if !gQuiet {
-			return output(showVM(vm.Name))
+			return output(showVM(vm.ID.String()))
 		}
 
 		return nil


### PR DESCRIPTION
This change fixes a bug displaying the `error: multiple Compute
instances found, specify an ID instead` message after creating a Compute
instance sharing the same name as an existing one.