### PR TITLE
compute: add new "security-group" commands

### DIFF
--- a/cmd/firewall.go
+++ b/cmd/firewall.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
+	"time"
 
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
@@ -17,6 +19,15 @@ var (
 var firewallCmd = &cobra.Command{
 	Use:   "firewall",
 	Short: "Security Groups management",
+	PersistentPreRun: func(_ *cobra.Command, _ []string) {
+		fmt.Fprintln(os.Stderr,
+			`**********************************************************************
+The "exo firewall" commands are deprecated and will be removed in a future
+version, please use "exo compute security-group" replacement commands.
+**********************************************************************`)
+		time.Sleep(3 * time.Second)
+	},
+	Hidden: true,
 }
 
 func init() {

--- a/cmd/firewall_list.go
+++ b/cmd/firewall_list.go
@@ -8,18 +8,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type securityGroupListItemOutput struct {
+type firewallListItemOutput struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	NumRules    int    `json:"num_rules" outputLabel:"Rules"`
 }
 
-type securityGroupListOutput []securityGroupListItemOutput
+type firewallListOutput []firewallListItemOutput
 
-func (o *securityGroupListOutput) toJSON()  { outputJSON(o) }
-func (o *securityGroupListOutput) toText()  { outputText(o) }
-func (o *securityGroupListOutput) toTable() { outputTable(o) }
+func (o *firewallListOutput) toJSON()  { outputJSON(o) }
+func (o *firewallListOutput) toText()  { outputText(o) }
+func (o *firewallListOutput) toTable() { outputTable(o) }
 
 func init() {
 	firewallCmd.AddCommand(&cobra.Command{
@@ -29,7 +29,7 @@ func init() {
 Optional patterns can be provided to filter results by ID, name or description.
 
 Supported output template annotations: %s`,
-			strings.Join(outputterTemplateAnnotations(&securityGroupListOutput{}), ", ")),
+			strings.Join(outputterTemplateAnnotations(&firewallListOutput{}), ", ")),
 		Aliases: gListAlias,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return output(listSecurityGroups(args))
@@ -43,7 +43,7 @@ func listSecurityGroups(filters []string) (outputter, error) {
 		return nil, err
 	}
 
-	out := securityGroupListOutput{}
+	out := firewallListOutput{}
 
 	for _, s := range sgs {
 		sg := s.(*egoscale.SecurityGroup)
@@ -66,7 +66,7 @@ func listSecurityGroups(filters []string) (outputter, error) {
 			continue
 		}
 
-		out = append(out, securityGroupListItemOutput{
+		out = append(out, firewallListItemOutput{
 			ID:          sg.ID.String(),
 			Name:        sg.Name,
 			Description: sg.Description,

--- a/cmd/firewall_show.go
+++ b/cmd/firewall_show.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type securityGroupShowItemOutput struct {
+type firewallShowItemOutput struct {
 	ID          string `json:"id"`
 	Type        string `json:"type"`
 	Source      string `json:"source"`
@@ -18,11 +18,11 @@ type securityGroupShowItemOutput struct {
 	Description string `json:"description,omitempty"`
 }
 
-type securityGroupShowOutput []securityGroupShowItemOutput
+type firewallShowOutput []firewallShowItemOutput
 
-func (o *securityGroupShowOutput) toJSON()  { outputJSON(o) }
-func (o *securityGroupShowOutput) toText()  { outputText(o) }
-func (o *securityGroupShowOutput) toTable() { outputTable(o) }
+func (o *firewallShowOutput) toJSON()  { outputJSON(o) }
+func (o *firewallShowOutput) toText()  { outputText(o) }
+func (o *firewallShowOutput) toTable() { outputTable(o) }
 
 func init() {
 	firewallCmd.AddCommand(&cobra.Command{
@@ -31,28 +31,28 @@ func init() {
 		Long: fmt.Sprintf(`This command shows a Security Group details.
 
 Supported output template annotations: %s`,
-			strings.Join(outputterTemplateAnnotations(&securityGroupShowOutput{}), ", ")),
+			strings.Join(outputterTemplateAnnotations(&firewallShowOutput{}), ", ")),
 		Aliases: gListAlias,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("show expects one Security Group by name or id")
 			}
 
-			return output(showSecurityGroup(args[0]))
+			return output(showFirewall(args[0]))
 		},
 	})
 }
 
-func showSecurityGroup(name string) (outputter, error) {
+func showFirewall(name string) (outputter, error) {
 	sg, err := getSecurityGroupByNameOrID(name)
 	if err != nil {
 		return nil, err
 	}
 
-	out := securityGroupShowOutput{}
+	out := firewallShowOutput{}
 
 	for _, rule := range sg.IngressRule {
-		out = append(out, securityGroupShowItemOutput{
+		out = append(out, firewallShowItemOutput{
 			Type:        "ingress",
 			ID:          rule.RuleID.String(),
 			Source:      formatRuleSource(rule),
@@ -63,7 +63,7 @@ func showSecurityGroup(name string) (outputter, error) {
 	}
 
 	for _, rule := range sg.EgressRule {
-		out = append(out, securityGroupShowItemOutput{
+		out = append(out, firewallShowItemOutput{
 			Type:        "egress",
 			ID:          rule.RuleID.String(),
 			Source:      formatRuleSource((egoscale.IngressRule)(rule)),

--- a/cmd/security_group.go
+++ b/cmd/security_group.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var securityGroupCmd = &cobra.Command{
+	Use:     "security-group",
+	Short:   "Compute instance Security Group management",
+	Aliases: []string{"sg"},
+}
+
+func init() {
+	computeCmd.AddCommand(securityGroupCmd)
+}

--- a/cmd/security_group_create.go
+++ b/cmd/security_group_create.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	egoscale "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type securityGroupCreateCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"create"`
+
+	Name string `cli-arg:"#"`
+
+	Description string `cli-usage:"Security Group description"`
+}
+
+func (c *securityGroupCreateCmd) cmdAliases() []string { return gCreateAlias }
+
+func (c *securityGroupCreateCmd) cmdShort() string {
+	return "Create a Security Group"
+}
+
+func (c *securityGroupCreateCmd) cmdLong() string {
+	return fmt.Sprintf(`This command creates a Compute instance Security Group.
+
+Supported output template annotations: %s`,
+		strings.Join(outputterTemplateAnnotations(&securityGroupShowOutput{}), ", "))
+}
+
+func (c *securityGroupCreateCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *securityGroupCreateCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	zone := gCurrentAccount.DefaultZone
+
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+
+	securityGroup := &egoscale.SecurityGroup{
+		Description: func() (v *string) {
+			if c.Description != "" {
+				v = &c.Description
+			}
+			return
+		}(),
+		Name: &c.Name,
+	}
+
+	var err error
+	decorateAsyncOperation(fmt.Sprintf("Creating Security Group %q...", c.Name), func() {
+		securityGroup, err = cs.CreateSecurityGroup(ctx, zone, securityGroup)
+	})
+	if err != nil {
+		return err
+	}
+
+	return output(showSecurityGroup(zone, *securityGroup.ID))
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(securityGroupCmd, &securityGroupCreateCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/security_group_delete.go
+++ b/cmd/security_group_delete.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"fmt"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type securityGroupDeleteCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"delete"`
+
+	SecurityGroup string `cli-arg:"#" cli-usage:"SECURITY-GROUP-NAME|ID"`
+
+	Force bool `cli-short:"f" cli-usage:"don't prompt for confirmation"`
+}
+
+func (c *securityGroupDeleteCmd) cmdAliases() []string { return gRemoveAlias }
+
+func (c *securityGroupDeleteCmd) cmdShort() string {
+	return "Delete a Security Group"
+}
+
+func (c *securityGroupDeleteCmd) cmdLong() string { return "" }
+
+func (c *securityGroupDeleteCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *securityGroupDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	zone := gCurrentAccount.DefaultZone
+
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+
+	securityGroup, err := cs.FindSecurityGroup(ctx, zone, c.SecurityGroup)
+	if err != nil {
+		return err
+	}
+
+	if !c.Force {
+		if !askQuestion(fmt.Sprintf("Are you sure you want to delete Security Group %s?", c.SecurityGroup)) {
+			return nil
+		}
+	}
+
+	decorateAsyncOperation(fmt.Sprintf("Deleting Security Group %s...", c.SecurityGroup), func() {
+		err = cs.DeleteSecurityGroup(ctx, zone, securityGroup)
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(securityGroupCmd, &securityGroupDeleteCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/security_group_list.go
+++ b/cmd/security_group_list.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type securityGroupListItemOutput struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type securityGroupListOutput []securityGroupListItemOutput
+
+func (o *securityGroupListOutput) toJSON()  { outputJSON(o) }
+func (o *securityGroupListOutput) toText()  { outputText(o) }
+func (o *securityGroupListOutput) toTable() { outputTable(o) }
+
+type securityGroupListCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"list"`
+}
+
+func (c *securityGroupListCmd) cmdAliases() []string { return gListAlias }
+
+func (c *securityGroupListCmd) cmdShort() string { return "List Security Groups" }
+
+func (c *securityGroupListCmd) cmdLong() string {
+	return fmt.Sprintf(`This command lists Compute instance Security Groups.
+
+Supported output template annotations: %s`,
+		strings.Join(outputterTemplateAnnotations(&securityGroupListItemOutput{}), ", "))
+}
+
+func (c *securityGroupListCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *securityGroupListCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	ctx := exoapi.WithEndpoint(
+		gContext,
+		exoapi.NewReqEndpoint(gCurrentAccount.Environment, gCurrentAccount.DefaultZone),
+	)
+
+	securityGroups, err := cs.ListSecurityGroups(ctx, gCurrentAccount.DefaultZone)
+	if err != nil {
+		return err
+	}
+
+	out := make(securityGroupListOutput, 0)
+
+	for _, t := range securityGroups {
+		out = append(out, securityGroupListItemOutput{
+			ID:   *t.ID,
+			Name: *t.Name,
+		})
+	}
+
+	return output(&out, nil)
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(securityGroupCmd, &securityGroupListCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/security_group_rule.go
+++ b/cmd/security_group_rule.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var securityGroupRuleCmd = &cobra.Command{
+	Use:   "rule",
+	Short: "Security Group rules management",
+}
+
+func init() {
+	securityGroupCmd.AddCommand(securityGroupRuleCmd)
+}

--- a/cmd/security_group_rule_add.go
+++ b/cmd/security_group_rule_add.go
@@ -1,0 +1,171 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	egoscale "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+var securityGroupRuleProtocols = []string{
+	"ah",
+	"esp",
+	"gre",
+	"icmp",
+	"icmpv6",
+	"ipip",
+	"tcp",
+	"udp",
+}
+
+type securityGroupAddRuleCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"add"`
+
+	SecurityGroup string `cli-arg:"#" cli-usage:"SECURITY-GROUP-ID|NAME"`
+
+	Description         string `cli-usage:"rule description"`
+	FlowDirection       string `cli-flag:"flow" cli-usage:"rule network flow direction (ingress|egress)"`
+	ICMPCode            int64  `cli-usage:"rule ICMP code"`
+	ICMPType            int64  `cli-usage:"rule ICMP type"`
+	Port                string `cli-usage:"rule network port (format: PORT|START-END)"`
+	Protocol            string `cli-usage:"rule network protocol"`
+	TargetNetwork       string `cli-flag:"network" cli-usage:"rule target network address (in CIDR format)"`
+	TargetSecurityGroup string `cli-flag:"security-group" cli-usage:"rule target Security Group NAME|ID"`
+}
+
+func (c *securityGroupAddRuleCmd) cmdAliases() []string { return nil }
+
+func (c *securityGroupAddRuleCmd) cmdShort() string {
+	return "Add a Security Group rule"
+}
+
+func (c *securityGroupAddRuleCmd) cmdLong() string {
+	return fmt.Sprintf(`This command adds a rule to a Compute instance Security Group.
+
+Supported network protocols: %s
+
+Supported output template annotations: %s`,
+		strings.Join(securityGroupRuleProtocols, ", "),
+		strings.Join(outputterTemplateAnnotations(&securityGroupShowOutput{}), ", "))
+}
+
+func (c *securityGroupAddRuleCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *securityGroupAddRuleCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	zone := gCurrentAccount.DefaultZone
+
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+
+	securityGroup, err := cs.FindSecurityGroup(ctx, zone, c.SecurityGroup)
+	if err != nil {
+		return err
+	}
+
+	c.Protocol = strings.ToLower(c.Protocol)
+	if !isInList(securityGroupRuleProtocols, c.Protocol) {
+		return fmt.Errorf("unsupported network protocol %q", c.Protocol)
+	}
+
+	securityGroupRule := &egoscale.SecurityGroupRule{
+		Description: func() (v *string) {
+			if c.Description != "" {
+				v = &c.Description
+			}
+			return
+		}(),
+		FlowDirection: &c.FlowDirection,
+		Protocol:      &c.Protocol,
+	}
+
+	if (c.TargetNetwork == "" && c.TargetSecurityGroup == "") || (c.TargetNetwork != "" && c.TargetSecurityGroup != "") {
+		return fmt.Errorf("either a target network address or Security Group name/ID must be specified")
+	}
+
+	if c.TargetSecurityGroup != "" {
+		targetSecurityGroup, err := cs.FindSecurityGroup(ctx, zone, c.TargetSecurityGroup)
+		if err != nil {
+			return fmt.Errorf("unable to retrieve Security Group %q: %v", c.TargetSecurityGroup, err)
+		}
+		securityGroupRule.SecurityGroupID = targetSecurityGroup.ID
+	} else {
+		_, network, err := net.ParseCIDR(c.TargetNetwork)
+		if err != nil {
+			return fmt.Errorf("invalid value for network %q: %v", c.TargetNetwork, err)
+		}
+		securityGroupRule.Network = network
+	}
+
+	if c.Port != "" {
+		startPort, endPort, err := func(portSpec string) (uint16, uint16, error) {
+			parts := strings.SplitN(portSpec, "-", 2)
+			if len(parts) == 2 {
+				s, err := strconv.ParseUint(parts[0], 10, 32)
+				if err != nil {
+					return 0, 0, err
+				}
+
+				e, err := strconv.ParseUint(parts[1], 10, 32)
+				if err != nil {
+					return 0, 0, err
+				}
+
+				return uint16(s), uint16(e), nil
+			}
+
+			p, err := strconv.ParseUint(parts[0], 10, 32)
+			if err != nil {
+				return 0, 0, err
+			}
+
+			return uint16(p), uint16(p), nil
+		}(c.Port)
+		if err != nil {
+			return fmt.Errorf("invalid port value %q: %s", c.Port, err)
+		}
+
+		for _, v := range []uint16{startPort, endPort} {
+			if v < 1 || v > uint16(65535) {
+				return errors.New("a port value must be between 1 and 65535")
+			}
+		}
+
+		if endPort < startPort {
+			return fmt.Errorf("end port must be greater than start port")
+		}
+
+		securityGroupRule.StartPort = &startPort
+		securityGroupRule.EndPort = &endPort
+	}
+
+	if strings.HasPrefix(c.Protocol, "icmp") {
+		securityGroupRule.ICMPCode = &c.ICMPCode
+		securityGroupRule.ICMPType = &c.ICMPType
+	}
+
+	decorateAsyncOperation(fmt.Sprintf("Adding rule to Security Group %q...", *securityGroup.Name), func() {
+		_, err = cs.CreateSecurityGroupRule(ctx, zone, securityGroup, securityGroupRule)
+	})
+	if err != nil {
+		return err
+	}
+
+	return output(showSecurityGroup(zone, *securityGroup.ID))
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(securityGroupRuleCmd, &securityGroupAddRuleCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+
+		FlowDirection: "ingress",
+		Protocol:      "tcp",
+	}))
+}

--- a/cmd/security_group_rule_delete.go
+++ b/cmd/security_group_rule_delete.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	egoscale "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type securityGroupDeleteRuleCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"delete"`
+
+	SecurityGroup string `cli-arg:"#" cli-usage:"SECURITY-GROUP-ID|NAME"`
+	Rule          string `cli-arg:"#"`
+
+	Force bool `cli-short:"f" cli-usage:"don't prompt for confirmation"`
+}
+
+func (c *securityGroupDeleteRuleCmd) cmdAliases() []string { return gRemoveAlias }
+
+func (c *securityGroupDeleteRuleCmd) cmdShort() string {
+	return "Delete a Security Group rule"
+}
+
+func (c *securityGroupDeleteRuleCmd) cmdLong() string {
+	return fmt.Sprintf(`This command deletes a rule from a Compute instance Security Group.
+
+Supported output template annotations: %s`,
+		strings.Join(outputterTemplateAnnotations(&securityGroupShowOutput{}), ", "))
+}
+
+func (c *securityGroupDeleteRuleCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *securityGroupDeleteRuleCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	zone := gCurrentAccount.DefaultZone
+
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+
+	securityGroup, err := cs.FindSecurityGroup(ctx, zone, c.SecurityGroup)
+	if err != nil {
+		return err
+	}
+
+	if !c.Force {
+		if !askQuestion(fmt.Sprintf(
+			"Are you sure you want to delete rule %s from Security Group %q?",
+			c.Rule,
+			*securityGroup.Name,
+		)) {
+			return nil
+		}
+	}
+
+	decorateAsyncOperation(fmt.Sprintf("Deleting Security Group rule %s...", c.Rule), func() {
+		err = cs.DeleteSecurityGroupRule(ctx, zone, securityGroup, &egoscale.SecurityGroupRule{ID: &c.Rule})
+	})
+	if err != nil {
+		return err
+	}
+
+	return output(showSecurityGroup(zone, *securityGroup.ID))
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(securityGroupRuleCmd, &securityGroupDeleteRuleCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/security_group_show.go
+++ b/cmd/security_group_show.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/exoscale/cli/table"
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+type securityGroupRuleOutput struct {
+	ID            string  `json:"id"`
+	Description   string  `json:"description"`
+	ICMPCode      *int64  `json:"icmp_code,omitempty"`
+	ICMPType      *int64  `json:"icmp_type,omitempty"`
+	Network       *string `json:"network,omitempty"`
+	Protocol      string  `json:"protocol"`
+	SecurityGroup *string `json:"security_group,omitempty"`
+	StartPort     *uint16 `json:"start_port,omitempty"`
+	EndPort       *uint16 `json:"end_port,omitempty"`
+}
+
+type securityGroupShowOutput struct {
+	ID           string                    `json:"id"`
+	Name         string                    `json:"name"`
+	Description  string                    `json:"description"`
+	IngressRules []securityGroupRuleOutput `json:"ingress_rules"`
+	EgressRules  []securityGroupRuleOutput `json:"egress_rules"`
+}
+
+func (o *securityGroupShowOutput) toJSON() { outputJSON(o) }
+func (o *securityGroupShowOutput) toText() { outputText(o) }
+func (o *securityGroupShowOutput) toTable() {
+	formatRule := func(rules []securityGroupRuleOutput) string {
+		if len(rules) > 0 {
+			buf := bytes.NewBuffer(nil)
+			at := table.NewEmbeddedTable(buf)
+			at.SetHeader([]string{" "})
+			at.SetAlignment(tablewriter.ALIGN_LEFT)
+
+			for _, rule := range rules {
+				r := []string{rule.ID, rule.Description, strings.ToUpper(rule.Protocol)}
+
+				if rule.Network != nil {
+					r = append(r, *rule.Network)
+				} else {
+					r = append(r, "SG:"+*rule.SecurityGroup)
+				}
+
+				if strings.HasPrefix(rule.Protocol, "icmp") {
+					r = append(r, fmt.Sprintf("ICMP code:%d type:%d", *rule.ICMPCode, *rule.ICMPType))
+				} else if rule.StartPort != nil {
+					r = append(r, func() string {
+						if *rule.StartPort == *rule.EndPort {
+							return fmt.Sprint(*rule.StartPort)
+						}
+						return fmt.Sprintf("%d-%d", *rule.StartPort, *rule.EndPort)
+					}())
+				}
+
+				at.Append(r)
+			}
+			at.Render()
+
+			return buf.String()
+		}
+		return "-"
+	}
+
+	t := table.NewTable(os.Stdout)
+	t.SetHeader([]string{"Security Group"})
+	defer t.Render()
+
+	t.Append([]string{"ID", o.ID})
+	t.Append([]string{"Name", o.Name})
+	t.Append([]string{"Description", o.Description})
+	t.Append([]string{"Ingress Rules", formatRule(o.IngressRules)})
+	t.Append([]string{"Egress Rules", formatRule(o.EgressRules)})
+}
+
+type securityGroupShowCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"show"`
+
+	SecurityGroup string `cli-arg:"#" cli-usage:"NAME|ID"`
+}
+
+func (c *securityGroupShowCmd) cmdAliases() []string { return gShowAlias }
+
+func (c *securityGroupShowCmd) cmdShort() string {
+	return "Show a Security Group details"
+}
+
+func (c *securityGroupShowCmd) cmdLong() string {
+	return fmt.Sprintf(`This command shows a Compute instance Security Group details.
+
+Supported output template annotations for Security Group: %s
+
+Supported output template annotations for Security Group rules: %s`,
+		strings.Join(outputterTemplateAnnotations(&securityGroupShowOutput{}), ", "),
+		strings.Join(outputterTemplateAnnotations(&securityGroupRuleOutput{}), ", "))
+}
+
+func (c *securityGroupShowCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *securityGroupShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	return output(showSecurityGroup(gCurrentAccount.DefaultZone, c.SecurityGroup))
+}
+
+func showSecurityGroup(zone, x string) (outputter, error) {
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+
+	securityGroup, err := cs.FindSecurityGroup(ctx, zone, x)
+	if err != nil {
+		return nil, err
+	}
+
+	out := securityGroupShowOutput{
+		ID:           *securityGroup.ID,
+		Name:         *securityGroup.Name,
+		Description:  defaultString(securityGroup.Description, ""),
+		IngressRules: make([]securityGroupRuleOutput, 0),
+		EgressRules:  make([]securityGroupRuleOutput, 0),
+	}
+
+	for _, rule := range securityGroup.Rules {
+		or := securityGroupRuleOutput{
+			ID:          *rule.ID,
+			Description: defaultString(rule.Description, ""),
+			ICMPCode:    rule.ICMPCode,
+			ICMPType:    rule.ICMPType,
+			Network: func() *string {
+				if rule.Network != nil {
+					v := rule.Network.String()
+					return &v
+				}
+				return nil
+			}(),
+			Protocol:  *rule.Protocol,
+			StartPort: rule.StartPort,
+			EndPort:   rule.EndPort,
+		}
+
+		if rule.SecurityGroupID != nil {
+			ruleSecurityGroup, err := cs.GetSecurityGroup(ctx, zone, *rule.SecurityGroupID)
+			if err != nil {
+				return nil, fmt.Errorf("error retrieving Security Group: %v", err)
+			}
+			or.SecurityGroup = ruleSecurityGroup.Name
+		}
+
+		if *rule.FlowDirection == "ingress" {
+			out.IngressRules = append(out.IngressRules, or)
+		} else {
+			out.EgressRules = append(out.EgressRules, or)
+		}
+	}
+
+	return &out, nil
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(securityGroupCmd, &securityGroupShowCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/exoscale/egoscale v0.71.0
+	github.com/exoscale/egoscale v0.71.1
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/exoscale/egoscale v0.71.0 h1:+NL4N8Y9c8RrmxXo/KWaO2c4C1TQmME/kympyqUkbrM=
-github.com/exoscale/egoscale v0.71.0/go.mod h1:wi0myUxPsV8SdEtdJHQJxFLL/wEw9fiw9Gs1PWRkvkM=
+github.com/exoscale/egoscale v0.71.1 h1:JWzFQboDIJ4kb5sClg52byk6h8hl1Mz3WWIEh9tVTcE=
+github.com/exoscale/egoscale v0.71.1/go.mod h1:wi0myUxPsV8SdEtdJHQJxFLL/wEw9fiw9Gs1PWRkvkM=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.71.1
+------
+
+- fix: v2: fix `CreateSecurityGroupRule()` method
+
 0.71.0
 ------
 

--- a/vendor/github.com/exoscale/egoscale/v2/security_group.go
+++ b/vendor/github.com/exoscale/egoscale/v2/security_group.go
@@ -220,9 +220,7 @@ func (c *Client) CreateSecurityGroupRule(
 
 	// Look for an unknown rule: if we find one we hope it's the one we've just created.
 	for _, r := range sgUpdated.Rules {
-		if _, ok := rules[*r.ID]; !ok && (*r.Protocol == *rule.Protocol &&
-			*r.StartPort == *rule.StartPort &&
-			*r.EndPort == *rule.EndPort) {
+		if _, ok := rules[*r.ID]; !ok && (*r.FlowDirection == *rule.FlowDirection && *r.Protocol == *rule.Protocol) {
 			return r, nil
 		}
 	}

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.71.0"
+const Version = "0.71.1"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.0
 ## explicit
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.71.0
+# github.com/exoscale/egoscale v0.71.1
 ## explicit
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/v2


### PR DESCRIPTION
This change adds new `exo compute security-group *` and deprecates
`exo firewall *` commands.