### PR TITLE
compute: add new "anti-affinity-group" commands

### DIFF
--- a/cmd/affinitygroup.go
+++ b/cmd/affinitygroup.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"time"
 
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
@@ -11,6 +13,16 @@ var affinitygroupCmd = &cobra.Command{
 	Use:     "anti-affinity-group",
 	Aliases: []string{"aag", "affinitygroup"},
 	Short:   "Anti-Affinity Groups management",
+	PersistentPreRun: func(_ *cobra.Command, _ []string) {
+		fmt.Fprintln(os.Stderr,
+			`**********************************************************************
+The "exo anti-affinity-group" commands are deprecated and will be removed in
+a future version, please use "exo compute anti-affinity-group" replacement
+commands.
+**********************************************************************`)
+		time.Sleep(3 * time.Second)
+	},
+	Hidden: true,
 }
 
 func getAntiAffinityGroupByNameOrID(v string) (*egoscale.AffinityGroup, error) {

--- a/cmd/anti_affinity_group.go
+++ b/cmd/anti_affinity_group.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var antiAffinityGroupCmd = &cobra.Command{
+	Use:     "anti-affinity-group",
+	Short:   "Compute instance Anti-Affinity Groups management",
+	Aliases: []string{"aag"},
+}
+
+func init() {
+	computeCmd.AddCommand(antiAffinityGroupCmd)
+}

--- a/cmd/anti_affinity_group_create.go
+++ b/cmd/anti_affinity_group_create.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	egoscale "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type antiAffinityGroupCreateCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"create"`
+
+	Name string `cli-arg:"#"`
+
+	Description string `cli-usage:"Anti-Affinity Group description"`
+}
+
+func (c *antiAffinityGroupCreateCmd) cmdAliases() []string { return gCreateAlias }
+
+func (c *antiAffinityGroupCreateCmd) cmdShort() string {
+	return "Create an Anti-Affinity Group"
+}
+
+func (c *antiAffinityGroupCreateCmd) cmdLong() string {
+	return fmt.Sprintf(`This command creates a Compute instance Anti-Affinity Group.
+
+Supported output template annotations: %s`,
+		strings.Join(outputterTemplateAnnotations(&antiAffinityGroupShowOutput{}), ", "))
+}
+
+func (c *antiAffinityGroupCreateCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *antiAffinityGroupCreateCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	zone := gCurrentAccount.DefaultZone
+
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+
+	antiAffinityGroup := &egoscale.AntiAffinityGroup{
+		Description: func() (v *string) {
+			if c.Description != "" {
+				v = &c.Description
+			}
+			return
+		}(),
+		Name: &c.Name,
+	}
+
+	var err error
+	decorateAsyncOperation(fmt.Sprintf("Creating Anti-Affinity Group %q...", c.Name), func() {
+		antiAffinityGroup, err = cs.CreateAntiAffinityGroup(ctx, zone, antiAffinityGroup)
+	})
+	if err != nil {
+		return err
+	}
+
+	return output(showAntiAffinityGroup(zone, *antiAffinityGroup.ID))
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(antiAffinityGroupCmd, &antiAffinityGroupCreateCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/anti_affinity_group_delete.go
+++ b/cmd/anti_affinity_group_delete.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type antiAffinityGroupDeleteCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"delete"`
+
+	AntiAffinityGroup string `cli-arg:"#" cli-usage:"ANTI-AFFINITY-GROUP-NAME|ID"`
+
+	Force bool `cli-short:"f" cli-usage:"don't prompt for confirmation"`
+}
+
+func (c *antiAffinityGroupDeleteCmd) cmdAliases() []string { return gRemoveAlias }
+
+func (c *antiAffinityGroupDeleteCmd) cmdShort() string {
+	return "Delete an Anti-Affinity Group"
+}
+
+func (c *antiAffinityGroupDeleteCmd) cmdLong() string { return "" }
+
+func (c *antiAffinityGroupDeleteCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *antiAffinityGroupDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	zone := gCurrentAccount.DefaultZone
+
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+
+	antiAffinityGroup, err := cs.FindAntiAffinityGroup(ctx, zone, c.AntiAffinityGroup)
+	if err != nil {
+		return err
+	}
+
+	if !c.Force {
+		if !askQuestion(fmt.Sprintf(
+			"Are you sure you want to delete Anti-Affinity Group %s?",
+			c.AntiAffinityGroup,
+		)) {
+			return nil
+		}
+	}
+
+	decorateAsyncOperation(fmt.Sprintf("Deleting Anti-Affinity Group %s...", c.AntiAffinityGroup), func() {
+		err = cs.DeleteAntiAffinityGroup(ctx, zone, antiAffinityGroup)
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(antiAffinityGroupCmd, &antiAffinityGroupDeleteCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/anti_affinity_group_list.go
+++ b/cmd/anti_affinity_group_list.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type antiAffinityGroupListItemOutput struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type antiAffinityGroupListOutput []antiAffinityGroupListItemOutput
+
+func (o *antiAffinityGroupListOutput) toJSON()  { outputJSON(o) }
+func (o *antiAffinityGroupListOutput) toText()  { outputText(o) }
+func (o *antiAffinityGroupListOutput) toTable() { outputTable(o) }
+
+type antiAffinityGroupListCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"list"`
+}
+
+func (c *antiAffinityGroupListCmd) cmdAliases() []string { return gListAlias }
+
+func (c *antiAffinityGroupListCmd) cmdShort() string { return "List Anti-Affinity Groups" }
+
+func (c *antiAffinityGroupListCmd) cmdLong() string {
+	return fmt.Sprintf(`This command lists Compute instance Anti-Affinity Groups.
+
+Supported output template annotations: %s`,
+		strings.Join(outputterTemplateAnnotations(&antiAffinityGroupListItemOutput{}), ", "))
+}
+
+func (c *antiAffinityGroupListCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *antiAffinityGroupListCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	ctx := exoapi.WithEndpoint(
+		gContext,
+		exoapi.NewReqEndpoint(gCurrentAccount.Environment, gCurrentAccount.DefaultZone),
+	)
+
+	antiAffinityGroups, err := cs.ListAntiAffinityGroups(ctx, gCurrentAccount.DefaultZone)
+	if err != nil {
+		return err
+	}
+
+	out := make(antiAffinityGroupListOutput, 0)
+
+	for _, t := range antiAffinityGroups {
+		out = append(out, antiAffinityGroupListItemOutput{
+			ID:   *t.ID,
+			Name: *t.Name,
+		})
+	}
+
+	return output(&out, nil)
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(antiAffinityGroupCmd, &antiAffinityGroupListCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/anti_affinity_group_show.go
+++ b/cmd/anti_affinity_group_show.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type antiAffinityGroupShowOutput struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Instances   []string `json:"instances"`
+}
+
+func (o *antiAffinityGroupShowOutput) toJSON()  { outputJSON(o) }
+func (o *antiAffinityGroupShowOutput) toText()  { outputText(o) }
+func (o *antiAffinityGroupShowOutput) toTable() { outputTable(o) }
+
+type antiAffinityGroupShowCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"show"`
+
+	AntiAffinityGroup string `cli-arg:"#" cli-usage:"NAME|ID"`
+}
+
+func (c *antiAffinityGroupShowCmd) cmdAliases() []string { return gShowAlias }
+
+func (c *antiAffinityGroupShowCmd) cmdShort() string {
+	return "Show an Anti-Affinity Group details"
+}
+
+func (c *antiAffinityGroupShowCmd) cmdLong() string {
+	return fmt.Sprintf(`This command shows a Compute instance Anti-Affinity Group details.
+
+Supported output template annotations: %s`,
+		strings.Join(outputterTemplateAnnotations(&antiAffinityGroupShowOutput{}), ", "))
+}
+
+func (c *antiAffinityGroupShowCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *antiAffinityGroupShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	return output(showAntiAffinityGroup(gCurrentAccount.DefaultZone, c.AntiAffinityGroup))
+}
+
+func showAntiAffinityGroup(zone, x string) (outputter, error) {
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+
+	antiAffinityGroup, err := cs.FindAntiAffinityGroup(ctx, zone, x)
+	if err != nil {
+		return nil, err
+	}
+
+	out := antiAffinityGroupShowOutput{
+		ID:          *antiAffinityGroup.ID,
+		Name:        *antiAffinityGroup.Name,
+		Description: defaultString(antiAffinityGroup.Description, ""),
+	}
+
+	if antiAffinityGroup.InstanceIDs != nil {
+		out.Instances = make([]string, len(*antiAffinityGroup.InstanceIDs))
+		for i, id := range *antiAffinityGroup.InstanceIDs {
+			instance, err := cs.GetInstance(ctx, zone, id)
+			if err != nil {
+				return nil, fmt.Errorf("unable to retrieve Compute instance %s: %v", id, err)
+			}
+			out.Instances[i] = *instance.Name
+		}
+	}
+
+	return &out, nil
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(antiAffinityGroupCmd, &antiAffinityGroupShowCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/deploy_target.go
+++ b/cmd/deploy_target.go
@@ -6,7 +6,7 @@ import (
 
 var deployTargetCmd = &cobra.Command{
 	Use:     "deploy-target",
-	Short:   "Deploy Targets management",
+	Short:   "Compute instance Deploy Targets management",
 	Aliases: []string{"dt"},
 }
 

--- a/cmd/security_group.go
+++ b/cmd/security_group.go
@@ -6,7 +6,7 @@ import (
 
 var securityGroupCmd = &cobra.Command{
 	Use:     "security-group",
-	Short:   "Compute instance Security Group management",
+	Short:   "Compute instance Security Groups management",
 	Aliases: []string{"sg"},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/exoscale/egoscale v0.71.1
+	github.com/exoscale/egoscale v0.72.0
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/exoscale/egoscale v0.71.1 h1:JWzFQboDIJ4kb5sClg52byk6h8hl1Mz3WWIEh9tVTcE=
-github.com/exoscale/egoscale v0.71.1/go.mod h1:wi0myUxPsV8SdEtdJHQJxFLL/wEw9fiw9Gs1PWRkvkM=
+github.com/exoscale/egoscale v0.72.0 h1:lQrggs/KS668WHPl5VinvWKfplTqYpJgNISyImmjIlY=
+github.com/exoscale/egoscale v0.72.0/go.mod h1:wi0myUxPsV8SdEtdJHQJxFLL/wEw9fiw9Gs1PWRkvkM=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.72.0
+------
+
+- feature: v2: add `AntiAffinityGroup.InstanceIDs` field
+
 0.71.1
 ------
 

--- a/vendor/github.com/exoscale/egoscale/v2/anti_affinity_group.go
+++ b/vendor/github.com/exoscale/egoscale/v2/anti_affinity_group.go
@@ -11,6 +11,7 @@ import (
 type AntiAffinityGroup struct {
 	Description *string
 	ID          *string
+	InstanceIDs *[]string
 	Name        *string `req-for:"create"`
 }
 
@@ -18,7 +19,17 @@ func antiAffinityGroupFromAPI(a *papi.AntiAffinityGroup) *AntiAffinityGroup {
 	return &AntiAffinityGroup{
 		Description: a.Description,
 		ID:          a.Id,
-		Name:        a.Name,
+		InstanceIDs: func() (v *[]string) {
+			if a.Instances != nil && len(*a.Instances) > 0 {
+				ids := make([]string, len(*a.Instances))
+				for i, item := range *a.Instances {
+					ids[i] = *item.Id
+				}
+				v = &ids
+			}
+			return
+		}(),
+		Name: a.Name,
 	}
 }
 

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.71.1"
+const Version = "0.72.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.0
 ## explicit
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.71.1
+# github.com/exoscale/egoscale v0.72.0
 ## explicit
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/v2


### PR DESCRIPTION
This change adds new `exo compute anti-affinity-group *` and deprecates
`exo anti-affinity-group *` commands.