### PR TITLE
compute: private-network: display zone in command output

### DIFF
--- a/cmd/private_network_delete.go
+++ b/cmd/private_network_delete.go
@@ -12,7 +12,7 @@ type privateNetworkDeleteCmd struct {
 
 	_ bool `cli-cmd:"delete"`
 
-	PrivateNetwork string `cli-arg:"#" cli-usage:"PRIVATE-NETWORK-NAME|ID"`
+	PrivateNetwork string `cli-arg:"#" cli-usage:"NAME|ID"`
 
 	Force bool   `cli-short:"f" cli-usage:"don't prompt for confirmation"`
 	Zone  string `cli-short:"z" cli-usage:"Private Network zone"`

--- a/cmd/private_network_list.go
+++ b/cmd/private_network_list.go
@@ -12,6 +12,7 @@ import (
 type privateNetworkListItemOutput struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
+	Zone string `json:"zone"`
 }
 
 type privateNetworkListOutput []privateNetworkListItemOutput
@@ -73,6 +74,7 @@ func (c *privateNetworkListCmd) cmdRun(_ *cobra.Command, _ []string) error {
 			res <- privateNetworkListItemOutput{
 				ID:   *p.ID,
 				Name: *p.Name,
+				Zone: zone,
 			}
 		}
 

--- a/cmd/private_network_show.go
+++ b/cmd/private_network_show.go
@@ -21,6 +21,7 @@ type privateNetworkShowOutput struct {
 	ID          string                      `json:"id"`
 	Name        string                      `json:"name"`
 	Description string                      `json:"description"`
+	Zone        string                      `json:"zone"`
 	Type        string                      `json:"type"`
 	StartIP     *string                     `json:"start_ip,omitempty"`
 	EndIP       *string                     `json:"end_ip,omitempty"`
@@ -38,6 +39,7 @@ func (o *privateNetworkShowOutput) toTable() {
 	t.Append([]string{"ID", o.ID})
 	t.Append([]string{"Name", o.Name})
 	t.Append([]string{"Description", o.Description})
+	t.Append([]string{"Zone", o.Zone})
 	t.Append([]string{"Type", o.Type})
 
 	if o.Type == "managed" {
@@ -110,6 +112,7 @@ func showPrivateNetwork(zone, x string) (outputter, error) {
 
 	out := privateNetworkShowOutput{
 		ID:          *privateNetwork.ID,
+		Zone:        zone,
 		Name:        *privateNetwork.Name,
 		Description: defaultString(privateNetwork.Description, ""),
 		Type:        "manual",


### PR DESCRIPTION
This change adds the resource zone to the output of `exo compute
private-network list|show` commands.