### PR TITLE
Deprecations and various fixes

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/exoscale/egoscale"
 	exov2 "github.com/exoscale/egoscale/v2"
@@ -62,13 +63,14 @@ func buildClient() {
 		egoscale.WithoutV2Client())
 
 	// During the Exoscale API V1 -> V2 transition, we need to initialize the
-	// V2 client independently from the V1 client because of HTTP middleware
+	// V2 client independently of the V1 client because of HTTP middleware
 	// (http.Transport) clashes.
 	// This can be removed once the only API used is V2.
 	clientExoV2, err := exov2.NewClient(
 		gCurrentAccount.Key,
 		gCurrentAccount.APISecret(),
 		exov2.ClientOptWithAPIEndpoint(gCurrentAccount.Endpoint),
+		exov2.ClientOptWithTimeout(5*time.Minute),
 		exov2.ClientOptWithHTTPClient(func() *http.Client {
 			hc := &http.Client{Transport: http.DefaultTransport}
 			if gCurrentAccount.CustomHeaders != nil {

--- a/cmd/instance_pool.go
+++ b/cmd/instance_pool.go
@@ -9,8 +9,9 @@ import (
 )
 
 var instancePoolCmd = &cobra.Command{
-	Use:   "instance-pool",
-	Short: "Instance Pools management",
+	Use:     "instance-pool",
+	Short:   "Instance Pools management",
+	Aliases: []string{"pool"},
 }
 
 var deprecatedInstancePoolCmd = &cobra.Command{

--- a/cmd/instance_pool_create.go
+++ b/cmd/instance_pool_create.go
@@ -20,15 +20,17 @@ type instancePoolCreateCmd struct {
 	CloudInitFile      string            `cli-flag:"cloud-init" cli-short:"c" cli-usage:"cloud-init user data configuration file path"`
 	DeployTarget       string            `cli-usage:"managed Compute instances Deploy Target NAME|ID"`
 	Description        string            `cli-usage:"Instance Pool description"`
-	DiskSize           int64             `cli-flag:"disk" cli-short:"d" cli-usage:"managed Compute instances disk size"`
+	Disk               int64             `cli-flag:"disk" cli-short:"d" cli-usage:"[DEPRECATED] use --disk-size"`
+	DiskSize           int64             `cli-usage:"managed Compute instances disk size"`
 	ElasticIPs         []string          `cli-flag:"elastic-ip" cli-short:"e" cli-usage:"managed Compute instances Elastic IP ADDRESS|ID (can be specified multiple times)"`
 	IPv6               bool              `cli-flag:"ipv6" cli-short:"6" cli-usage:"enable IPv6 on managed Compute instances"`
 	InstancePrefix     string            `cli-usage:"string to prefix managed Compute instances names with"`
-	InstanceType       string            `cli-flag:"service-offering" cli-short:"o" cli-usage:"managed Compute instances type"`
+	InstanceType       string            `cli-usage:"managed Compute instances type (format: [FAMILY.]SIZE)"`
 	Labels             map[string]string `cli-flag:"label" cli-usage:"Instance Pool label (format: key=value)"`
 	PrivateNetworks    []string          `cli-flag:"privnet" cli-short:"p" cli-usage:"managed Compute instances Private Network NAME|ID (can be specified multiple times)"`
 	SSHKey             string            `cli-short:"k" cli-flag:"keypair" cli-usage:"SSH key to deploy on managed Compute instances"`
 	SecurityGroups     []string          `cli-flag:"security-group" cli-short:"s" cli-usage:"managed Compute instances Security Group NAME|ID (can be specified multiple times)"`
+	ServiceOffering    string            `cli-short:"o" cli-usage:"[DEPRECATED] use --instance-type"`
 	Size               int64             `cli-usage:"Instance Pool size"`
 	Template           string            `cli-short:"t" cli-usage:"managed Compute instances template NAME|ID"`
 	TemplateFilter     string            `cli-usage:"managed Compute instances template filter"`
@@ -47,6 +49,42 @@ Supported output template annotations: %s`,
 }
 
 func (c *instancePoolCreateCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	// TODO: remove this once the `--disk` flag is retired.
+	if cmd.Flags().Changed("disk") {
+		cmd.PrintErr(`**********************************************************************
+WARNING: flag "--disk" has been deprecated and will be removed in a
+future release, please use "--disk-size" instead.
+**********************************************************************
+`)
+		if !cmd.Flags().Changed("disk-size") {
+			diskFlagValue, err := cmd.Flags().GetInt64("disk")
+			if err != nil {
+				return fmt.Errorf("invalid value for flag --disk: %v", err)
+			}
+			if err = cmd.Flags().Set("disk-size", fmt.Sprint(diskFlagValue)); err == nil {
+				return err
+			}
+		}
+	}
+
+	// TODO: remove this once the `--service-offering` flag is retired.
+	if cmd.Flags().Changed("service-offering") {
+		cmd.PrintErr(`**********************************************************************
+WARNING: flag "--service-offering" has been deprecated and will be removed
+in a future release, please use "--instance-type" instead.
+**********************************************************************
+`)
+		if !cmd.Flags().Changed("instance-type") {
+			serviceOfferingFlagValue, err := cmd.Flags().GetString("service-offering")
+			if err != nil {
+				return fmt.Errorf("invalid value for flag --service-offering: %v", err)
+			}
+			if err = cmd.Flags().Set("instance-type", serviceOfferingFlagValue); err != nil {
+				return err
+			}
+		}
+	}
+
 	cmdSetZoneFlagFromDefault(cmd)
 	return cliCommandDefaultPreRun(c, cmd, args)
 }
@@ -201,7 +239,7 @@ func init() {
 		cliCommandSettings: defaultCLICmdSettings(),
 
 		DiskSize:       50,
-		InstanceType:   defaultServiceOffering,
+		InstanceType:   fmt.Sprintf("%s.%s", defaultInstanceTypeFamily, defaultInstanceType),
 		Size:           1,
 		Template:       defaultTemplate,
 		TemplateFilter: defaultTemplateFilter,
@@ -210,7 +248,7 @@ func init() {
 	// FIXME: remove this someday.
 	cobra.CheckErr(registerCLICommand(deprecatedInstancePoolCmd, &instancePoolCreateCmd{
 		DiskSize:       50,
-		InstanceType:   defaultServiceOffering,
+		InstanceType:   fmt.Sprintf("%s.%s", defaultInstanceTypeFamily, defaultInstanceType),
 		Size:           1,
 		Template:       defaultTemplate,
 		TemplateFilter: defaultTemplateFilter,

--- a/cmd/instance_pool_evict.go
+++ b/cmd/instance_pool_evict.go
@@ -25,7 +25,8 @@ func (c *instancePoolEvictCmd) cmdShort() string { return "Evict Instance Pool m
 
 func (c *instancePoolEvictCmd) cmdLong() string {
 	return `This command evicts specific members from an Instance Pool, effectively
-scaling down the Instance Pool similar to the "exo instancepool scale" command.`
+scaling down the Instance Pool similar to the "exo compute instance-pool scale"
+command.`
 }
 
 func (c *instancePoolEvictCmd) cmdPreRun(cmd *cobra.Command, args []string) error {

--- a/cmd/instance_pool_scale.go
+++ b/cmd/instance_pool_scale.go
@@ -28,9 +28,10 @@ func (c *instancePoolScaleCmd) cmdLong() string {
 	return `This command scales an Instance Pool size up (growing) or down
 (shrinking).
 
-In case of a scale-down, operators should use the "exo instancepool evict"
-variant, allowing them to specify which specific instance should be evicted
-from the Instance Pool rather than leaving the decision to the orchestrator.`
+In case of a scale-down, operators should use the
+"exo compute instance-pool evict" command, allowing them to specify which
+specific instance should be evicted from the Instance Pool rather than leaving
+the decision to the orchestrator.`
 }
 
 func (c *instancePoolScaleCmd) cmdPreRun(cmd *cobra.Command, args []string) error {

--- a/cmd/instance_pool_show.go
+++ b/cmd/instance_pool_show.go
@@ -13,7 +13,7 @@ type instancePoolShowOutput struct {
 	ID                 string            `json:"id"`
 	Name               string            `json:"name"`
 	Description        string            `json:"description"`
-	ServiceOffering    string            `json:"service_offering"`
+	InstanceType       string            `json:"instance_type"`
 	Template           string            `json:"template_id"`
 	Zone               string            `json:"zoneid"`
 	AntiAffinityGroups []string          `json:"anti_affinity_groups" outputLabel:"Anti-Affinity Groups"`
@@ -152,7 +152,7 @@ func showInstancePool(zone, x string) (outputter, error) {
 	if err != nil {
 		return nil, err
 	}
-	out.ServiceOffering = *instanceType.Size
+	out.InstanceType = fmt.Sprintf("%s.%s", *instanceType.Family, *instanceType.Size)
 
 	if instancePool.PrivateNetworkIDs != nil {
 		for _, id := range *instancePool.PrivateNetworkIDs {

--- a/cmd/sks_nodepool_evict.go
+++ b/cmd/sks_nodepool_evict.go
@@ -29,7 +29,8 @@ func (c *sksNodepoolEvictCmd) cmdShort() string { return "Evict SKS cluster Node
 
 func (c *sksNodepoolEvictCmd) cmdLong() string {
 	return fmt.Sprintf(`This command evicts specific members from an SKS cluster Nodepool, effectively
-scaling down the Nodepool similar to the "exo sks nodepool scale" command.
+scaling down the Nodepool similar to the "exo compute sks nodepool scale"
+command.
 
 Note: Kubernetes Nodes should be drained from their workload prior to being
 evicted from their Nodepool, e.g. using "kubectl drain".

--- a/cmd/sks_nodepool_scale.go
+++ b/cmd/sks_nodepool_scale.go
@@ -31,9 +31,10 @@ func (c *sksNodepoolScaleCmd) cmdLong() string {
 	return fmt.Sprintf(`This command scales an SKS cluster Nodepool size up (growing) or down
 (shrinking).
 
-In case of a scale-down, operators should use the "exo sks nodepool evict"
-variant, allowing them to specify which specific Nodes should be evicted from
-the pool rather than leaving the decision to the SKS manager.
+In case of a scale-down, operators should use the
+"exo compute sks nodepool evict" command, allowing them to specify which
+specific Nodes should be evicted from the pool rather than leaving the
+decision to the SKS manager.
 
 Supported output template annotations: %s`,
 		strings.Join(outputterTemplateAnnotations(&sksNodepoolShowOutput{}), ", "))


### PR DESCRIPTION
*  compute: instance-pool: deprecate flags

This change deprecates the `--disk`/`--service-offering` from the
`exo compute intance-pool (create|update)` commands, replaced with
`--disk-size`/`--instance-type`.

* Set default client timeout to 5 minutes

* compute: alias "exo compute instance-pool"

This change adds a new convenience alias `exo compute pool` for
`exo compute instance-pool`.

* compute: instance-pool: rename template label

This change renames the `.ServiceOffering` label from the `exo compute
instance-pool show` command into `.InstanceType`.

