### PR TITLE
compute: instance: raise default timeout

### DIFF
--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 )
 
@@ -30,6 +32,11 @@ var instanceCmd = &cobra.Command{
 	Use:     "instance",
 	Short:   "Compute instances management",
 	Aliases: []string{"i"},
+	PersistentPreRun: func(_ *cobra.Command, _ []string) {
+		// Some instance operations can take a long time, raising
+		// the Exoscale API client timeout as a precaution.
+		cs.Client.SetTimeout(10 * time.Minute)
+	},
 }
 
 func init() {


### PR DESCRIPTION
This change raises the default timeout for Compute instance operations
to 10 minutes.