### PR TITLE
compute: instance-pool: fix "delete" command

### DIFF
--- a/cmd/instance_pool_delete.go
+++ b/cmd/instance_pool_delete.go
@@ -38,7 +38,7 @@ func (c *instancePoolDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	}
 
 	// Ensure the Instance Pool is not attached to an NLB service.
-	nlbs, err := cs.ListNetworkLoadBalancers(gContext, c.Zone)
+	nlbs, err := cs.ListNetworkLoadBalancers(ctx, c.Zone)
 	if err != nil {
 		return fmt.Errorf("unable to list Network Load Balancers: %v", err)
 	}


### PR DESCRIPTION
This change fixes a bug in the `exo compute instance-pool delete`
command, preventing users from deleting an Instance Pool in a
non-standard API environment.