### PR TITLE
Fix Compute instance template registration command

### DIFF
--- a/cmd/instance_template_register.go
+++ b/cmd/instance_template_register.go
@@ -69,15 +69,20 @@ func (c *instanceTemplateRegisterCmd) cmdRun(cmd *cobra.Command, _ []string) err
 
 	// Template registration can take a _long time_, raising
 	// the Exoscale API client timeout as a precaution.
-	cs.Client.SetTimeout(30 * time.Minute)
+	cs.Client.SetTimeout(time.Hour)
 
 	ctx := exoapi.WithEndpoint(
 		gContext,
 		exoapi.NewReqEndpoint(gCurrentAccount.Environment, gCurrentAccount.DefaultZone),
 	)
 
+	passwordEnabled := !c.DisablePassword
+	sshKeyEnabled := !c.DisableSSHKey
+
 	template = &egoscale.Template{
-		Name: &c.Name,
+		Name:            &c.Name,
+		PasswordEnabled: &passwordEnabled,
+		SSHKeyEnabled:   &sshKeyEnabled,
 	}
 
 	if c.FromSnapshot != "" {
@@ -125,16 +130,6 @@ func (c *instanceTemplateRegisterCmd) cmdRun(cmd *cobra.Command, _ []string) err
 
 	if c.Description != "" {
 		template.Description = &c.Description
-	}
-
-	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.DisablePassword)) {
-		passwordEnabled := !c.DisablePassword
-		template.PasswordEnabled = &passwordEnabled
-	}
-
-	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.DisableSSHKey)) {
-		sshKeyEnabled := !c.DisableSSHKey
-		template.SSHKeyEnabled = &sshKeyEnabled
 	}
 
 	if c.URL != "" {


### PR DESCRIPTION
This change fixes a bug preventing users to use the `exo compute
instance-template register` command without passing
`--disable-(password|ssh-key)` flags.