### PR TITLE
Fix "exo compute instance create" command

### DIFF
--- a/cmd/instance_create.go
+++ b/cmd/instance_create.go
@@ -208,7 +208,7 @@ func (c *instanceCreateCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		}
 
 		for _, p := range privateNetworks {
-			if err = cs.AttachInstanceToPrivateNetwork(ctx, c.Zone, instance, p, nil); err != nil {
+			if err = cs.AttachInstanceToPrivateNetwork(ctx, c.Zone, instance, p); err != nil {
 				return
 			}
 		}


### PR DESCRIPTION
This change fixes a bug in the `exo compute instance create` command,
where the CLI would crash if the user provides the `--private-network`
flag.

Fixes #400