### PR TITLE
Fix a bug in the "exo dbaas create" command

### DIFF
--- a/cmd/dbaas_service_create_pg.go
+++ b/cmd/dbaas_service_create_pg.go
@@ -66,7 +66,7 @@ func (c *dbServiceCreateCmd) createPG(_ *cobra.Command, _ []string) error {
 	if c.PGBouncerSettings != "" {
 		settings, err := validateDatabaseServiceSettings(
 			c.PGBouncerSettings,
-			settingsSchema.JSON200.Settings.Pglookout,
+			settingsSchema.JSON200.Settings.Pgbouncer,
 		)
 		if err != nil {
 			return fmt.Errorf("invalid settings: %w", err)


### PR DESCRIPTION
This change fixes a bug in the `exo dbaas create` command, where the use
of the `--pg-bouncer-settings` flag would return a JSON validation error
message.