### PR TITLE
dbaas: improve maintenance-related flags handling

### DIFF
--- a/cmd/dbaas_service_create.go
+++ b/cmd/dbaas_service_create.go
@@ -78,6 +78,16 @@ func (c *dbServiceCreateCmd) cmdPreRun(cmd *cobra.Command, args []string) error 
 }
 
 func (c *dbServiceCreateCmd) cmdRun(cmd *cobra.Command, args []string) error {
+	if (cmd.Flags().Changed(mustCLICommandFlagName(c, &c.MaintenanceDOW)) ||
+		cmd.Flags().Changed(mustCLICommandFlagName(c, &c.MaintenanceTime))) &&
+		(!cmd.Flags().Changed(mustCLICommandFlagName(c, &c.MaintenanceDOW)) ||
+			!cmd.Flags().Changed(mustCLICommandFlagName(c, &c.MaintenanceTime))) {
+		return fmt.Errorf(
+			"both --%s and --%s must be specified",
+			mustCLICommandFlagName(c, &c.MaintenanceDOW),
+			mustCLICommandFlagName(c, &c.MaintenanceTime))
+	}
+
 	switch c.Type {
 	case "kafka":
 		return c.createKafka(cmd, args)

--- a/cmd/dbaas_service_update.go
+++ b/cmd/dbaas_service_update.go
@@ -72,6 +72,16 @@ func (c *dbServiceUpdateCmd) cmdPreRun(cmd *cobra.Command, args []string) error 
 }
 
 func (c *dbServiceUpdateCmd) cmdRun(cmd *cobra.Command, args []string) error {
+	if (cmd.Flags().Changed(mustCLICommandFlagName(c, &c.MaintenanceDOW)) ||
+		cmd.Flags().Changed(mustCLICommandFlagName(c, &c.MaintenanceTime))) &&
+		(!cmd.Flags().Changed(mustCLICommandFlagName(c, &c.MaintenanceDOW)) ||
+			!cmd.Flags().Changed(mustCLICommandFlagName(c, &c.MaintenanceTime))) {
+		return fmt.Errorf(
+			"both --%s and --%s must be specified",
+			mustCLICommandFlagName(c, &c.MaintenanceDOW),
+			mustCLICommandFlagName(c, &c.MaintenanceTime))
+	}
+
 	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
 
 	databaseServices, err := cs.ListDatabaseServices(ctx, c.Zone)


### PR DESCRIPTION
This change adds a check in the `exo dbaas (create|update)` commands
returning an error if only either one of the maintenance DoW/time is
specified.