### PR TITLE
dbaas show: add missing version for types mysql/pg

### DIFF
--- a/cmd/dbaas_service_show_mysql.go
+++ b/cmd/dbaas_service_show_mysql.go
@@ -215,6 +215,8 @@ func (c *dbServiceShowCmd) showDatabaseServiceMysql(ctx context.Context) (output
 				}
 				return
 			}(),
+
+			Version: defaultString(databaseService.Version, ""),
 		},
 	}
 

--- a/cmd/dbaas_service_show_pg.go
+++ b/cmd/dbaas_service_show_pg.go
@@ -271,6 +271,8 @@ func (c *dbServiceShowCmd) showDatabaseServicePG(ctx context.Context) (outputter
 				}
 				return
 			}(),
+
+			Version: defaultString(databaseService.Version, ""),
 		},
 	}
 

--- a/cmd/dbaas_service_show_redis.go
+++ b/cmd/dbaas_service_show_redis.go
@@ -33,11 +33,9 @@ type dbServiceRedisShowOutput struct {
 	URI        string                              `json:"uri"`
 	URIParams  map[string]interface{}              `json:"uri_params"`
 	Users      []dbServiceRedisUserShowOutput      `json:"users"`
-	Version    string                              `json:"version"`
 }
 
 func formatDatabaseServiceRedisTable(t *table.Table, o *dbServiceRedisShowOutput) {
-	t.Append([]string{"Version", o.Version})
 	t.Append([]string{"URI", redactDatabaseServiceURI(o.URI)})
 	t.Append([]string{"IP Filter", strings.Join(o.IPFilter, ", ")})
 


### PR DESCRIPTION
This change fixes a bug in the `exo dbaas show` where the version would
not be properly reported for service types mysql/pg.