### PR TITLE
compute instance-type list: add new flag "--verbose"

### DIFF
--- a/cmd/instance_type_list.go
+++ b/cmd/instance_type_list.go
@@ -2,28 +2,63 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
+	"github.com/dustin/go-humanize"
+	"github.com/exoscale/cli/table"
 	exoapi "github.com/exoscale/egoscale/v2/api"
 	"github.com/spf13/cobra"
 )
 
 type instanceTypeListItemOutput struct {
-	ID     string `json:"id"`
-	Family string `json:"family"`
-	Size   string `json:"name"`
+	ID         string `json:"id"`
+	Family     string `json:"family"`
+	Size       string `json:"name"`
+	CPUs       int64  `json:"cpus"`
+	Memory     int64  `json:"memory"`
+	Authorized bool   `json:"authorized"`
 }
 
-type instanceTypeListOutput []instanceTypeListItemOutput
+type instanceTypeListOutput struct {
+	data    []instanceTypeListItemOutput
+	verbose bool
+}
 
-func (o *instanceTypeListOutput) toJSON()  { outputJSON(o) }
-func (o *instanceTypeListOutput) toText()  { outputText(o) }
-func (o *instanceTypeListOutput) toTable() { outputTable(o) }
+func (o *instanceTypeListOutput) toJSON() { outputJSON(o.data) }
+func (o *instanceTypeListOutput) toText() { outputText(o.data) }
+func (o *instanceTypeListOutput) toTable() {
+	header := []string{"ID", "Family", "Size"}
+	if o.verbose {
+		header = append(header, "# CPUs", "Memory", "Authorized")
+	}
+
+	t := table.NewTable(os.Stdout)
+	t.SetHeader(header)
+	defer t.Render()
+
+	for _, p := range o.data {
+		cols := []string{p.ID, p.Family, p.Size}
+
+		if o.verbose {
+			cols = append(
+				cols,
+				fmt.Sprint(p.CPUs),
+				humanize.Bytes(uint64(p.Memory)),
+				fmt.Sprint(p.Authorized),
+			)
+		}
+
+		t.Append(cols)
+	}
+}
 
 type instanceTypeListCmd struct {
 	cliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"list"`
+
+	Verbose bool `cli-short:"v" cli-help:"show additional information about Compute instance types"`
 }
 
 func (c *instanceTypeListCmd) cmdAliases() []string { return nil }
@@ -52,13 +87,19 @@ func (c *instanceTypeListCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	out := make(instanceTypeListOutput, 0)
+	out := instanceTypeListOutput{
+		data:    make([]instanceTypeListItemOutput, 0),
+		verbose: c.Verbose,
+	}
 
 	for _, t := range instanceTypes {
-		out = append(out, instanceTypeListItemOutput{
-			ID:     *t.ID,
-			Family: *t.Family,
-			Size:   *t.Size,
+		out.data = append(out.data, instanceTypeListItemOutput{
+			ID:         *t.ID,
+			Family:     *t.Family,
+			Size:       *t.Size,
+			Memory:     *t.Memory,
+			CPUs:       *t.CPUs,
+			Authorized: *t.Authorized,
 		})
 	}
 

--- a/cmd/instance_type_show.go
+++ b/cmd/instance_type_show.go
@@ -12,12 +12,13 @@ import (
 )
 
 type instanceTypeShowOutput struct {
-	ID     string `json:"id"`
-	Family string `json:"family"`
-	Size   string `json:"name"`
-	Memory int64  `json:"memory"`
-	CPUs   int64  `json:"cpus"`
-	GPUs   int64  `json:"gpus"`
+	ID         string `json:"id"`
+	Family     string `json:"family"`
+	Size       string `json:"name"`
+	Memory     int64  `json:"memory"`
+	CPUs       int64  `json:"cpus"`
+	GPUs       int64  `json:"gpus"`
+	Authorized bool   `json:"authorized"`
 }
 
 func (o *instanceTypeShowOutput) toJSON() { outputJSON(o) }
@@ -36,6 +37,8 @@ func (o *instanceTypeShowOutput) toTable() {
 	if o.GPUs > 0 {
 		t.Append([]string{"# GPUs", fmt.Sprint(o.GPUs)})
 	}
+
+	t.Append([]string{"Authorized", fmt.Sprint(o.Authorized)})
 }
 
 type instanceTypeShowCmd struct {
@@ -86,6 +89,7 @@ func (c *instanceTypeShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 			}
 			return
 		}(),
+		Authorized: *t.Authorized,
 	}, nil)
 }
 


### PR DESCRIPTION
This change introduces a new `exo compute instance-type list --verbose`
flag offering an alternative output reporting more information about
Compute instance types.