### PR TITLE
dbaas: update termination protection flag help

### DIFF
--- a/cmd/dbaas_create.go
+++ b/cmd/dbaas_create.go
@@ -23,7 +23,7 @@ type dbServiceCreateCmd struct {
 	HelpRedis             bool   `cli-usage:"show usage for flags specific to the redis type"`
 	MaintenanceDOW        string `cli-flag:"maintenance-dow" cli-usage:"automated Database Service maintenance day-of-week"`
 	MaintenanceTime       string `cli-usage:"automated Database Service maintenance time (format HH:MM:SS)"`
-	TerminationProtection bool   `cli-usage:"enable Database Service termination protection"`
+	TerminationProtection bool   `cli-usage:"enable Database Service termination protection; set --termination-protection=false to disable"`
 	Zone                  string `cli-short:"z" cli-usage:"Database Service zone"`
 
 	// "kafka" type specific flags

--- a/cmd/dbaas_update.go
+++ b/cmd/dbaas_update.go
@@ -24,7 +24,7 @@ type dbServiceUpdateCmd struct {
 	MaintenanceDOW        string `cli-flag:"maintenance-dow" cli-usage:"automated Database Service maintenance day-of-week"`
 	MaintenanceTime       string `cli-usage:"automated Database Service maintenance time (format HH:MM:SS)"`
 	Plan                  string `cli-usage:"Database Service plan"`
-	TerminationProtection bool   `cli-usage:"enable Database Service termination protection"`
+	TerminationProtection bool   `cli-usage:"enable Database Service termination protection; set --termination-protection=false to disable"`
 	Zone                  string `cli-short:"z" cli-usage:"Database Service zone"`
 
 	// "kafka" type specific flags


### PR DESCRIPTION
This change documents the proper `exo dbaas (create|update)
--termination-protection` flag usage.