### PR TITLE
Fix crash in deprecated commands

### DIFF
--- a/cmd/instance_pool_create.go
+++ b/cmd/instance_pool_create.go
@@ -259,6 +259,8 @@ func init() {
 
 	// FIXME: remove this someday.
 	cobra.CheckErr(registerCLICommand(deprecatedInstancePoolCmd, &instancePoolCreateCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+
 		DiskSize:       50,
 		InstanceType:   fmt.Sprintf("%s.%s", defaultInstanceTypeFamily, defaultInstanceType),
 		Size:           1,

--- a/cmd/instance_pool_delete.go
+++ b/cmd/instance_pool_delete.go
@@ -78,5 +78,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedInstancePoolCmd, &instancePoolDeleteCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedInstancePoolCmd, &instancePoolDeleteCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/instance_pool_evict.go
+++ b/cmd/instance_pool_evict.go
@@ -90,5 +90,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedInstancePoolCmd, &instancePoolEvictCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedInstancePoolCmd, &instancePoolEvictCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/instance_pool_list.go
+++ b/cmd/instance_pool_list.go
@@ -98,5 +98,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedInstancePoolCmd, &instancePoolListCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedInstancePoolCmd, &instancePoolListCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/instance_pool_scale.go
+++ b/cmd/instance_pool_scale.go
@@ -85,5 +85,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedInstancePoolCmd, &instancePoolScaleCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedInstancePoolCmd, &instancePoolScaleCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/instance_pool_show.go
+++ b/cmd/instance_pool_show.go
@@ -178,5 +178,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedInstancePoolCmd, &instancePoolShowCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedInstancePoolCmd, &instancePoolShowCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/instance_pool_update.go
+++ b/cmd/instance_pool_update.go
@@ -312,6 +312,8 @@ func init() {
 
 	// FIXME: remove this someday.
 	cobra.CheckErr(registerCLICommand(deprecatedInstancePoolCmd, &instancePoolUpdateCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+
 		TemplateFilter: defaultTemplateFilter,
 	}))
 }

--- a/cmd/nlb_create.go
+++ b/cmd/nlb_create.go
@@ -76,5 +76,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedNLBCmd, &nlbCreateCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedNLBCmd, &nlbCreateCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/nlb_delete.go
+++ b/cmd/nlb_delete.go
@@ -62,5 +62,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedNLBCmd, &nlbDeleteCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedNLBCmd, &nlbDeleteCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/nlb_list.go
+++ b/cmd/nlb_list.go
@@ -96,5 +96,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedNLBCmd, &nlbListCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedNLBCmd, &nlbListCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/nlb_show.go
+++ b/cmd/nlb_show.go
@@ -146,5 +146,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedNLBCmd, &nlbShowCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedNLBCmd, &nlbShowCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/nlb_update.go
+++ b/cmd/nlb_update.go
@@ -93,5 +93,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedNLBCmd, &nlbUpdateCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedNLBCmd, &nlbUpdateCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/sks_authority_cert.go
+++ b/cmd/sks_authority_cert.go
@@ -83,5 +83,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksAuthorityCertCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksAuthorityCertCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/sks_create.go
+++ b/cmd/sks_create.go
@@ -266,6 +266,8 @@ func init() {
 
 	// FIXME: remove this someday.
 	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksCreateCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+
 		KubernetesVersion:    "latest",
 		NodepoolDiskSize:     50,
 		NodepoolInstanceType: defaultServiceOffering,

--- a/cmd/sks_delete.go
+++ b/cmd/sks_delete.go
@@ -93,5 +93,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksDeleteCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksDeleteCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/sks_kubeconfig.go
+++ b/cmd/sks_kubeconfig.go
@@ -184,5 +184,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksKubeconfigCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksKubeconfigCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/sks_list.go
+++ b/cmd/sks_list.go
@@ -94,5 +94,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksListCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksListCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/sks_rotate_ccm_credentials.go
+++ b/cmd/sks_rotate_ccm_credentials.go
@@ -61,5 +61,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksRotateCCMCredentialsCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksRotateCCMCredentialsCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/sks_show.go
+++ b/cmd/sks_show.go
@@ -153,5 +153,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksShowCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksShowCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/sks_update.go
+++ b/cmd/sks_update.go
@@ -95,5 +95,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksUpdateCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksUpdateCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/sks_upgrade.go
+++ b/cmd/sks_upgrade.go
@@ -72,5 +72,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksUpgradeCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksUpgradeCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/sks_upgrade_service_level.go
+++ b/cmd/sks_upgrade_service_level.go
@@ -77,5 +77,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksUpgradeServiceLevelCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksUpgradeServiceLevelCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }

--- a/cmd/sks_versions.go
+++ b/cmd/sks_versions.go
@@ -65,5 +65,7 @@ func init() {
 	}))
 
 	// FIXME: remove this someday.
-	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksVersionsCmd{}))
+	cobra.CheckErr(registerCLICommand(deprecatedSKSCmd, &sksVersionsCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
 }


### PR DESCRIPTION
This change fixes a bug crashing deprecated commands using the automatic
CLI commands generation helper.