### PR TITLE
Add new "exo iam access-key *" commands

### DIFF
--- a/cmd/iam_access_key.go
+++ b/cmd/iam_access_key.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	egoscale "github.com/exoscale/egoscale/v2"
+	"github.com/spf13/cobra"
+)
+
+var iamAccessKeyCmd = &cobra.Command{
+	Use:     "access-key",
+	Aliases: []string{"key"},
+	Short:   "IAM access keys management",
+}
+
+// parseIAMAccessKeyResource parses a string-encoded IAM access key resource formatted such as
+// DOMAIN/TYPE:NAME and deserializes it into an egoscale.IAMAccessKeyResource struct.
+func parseIAMAccessKeyResource(v string) (*egoscale.IAMAccessKeyResource, error) {
+	var iamAccessKeyResource egoscale.IAMAccessKeyResource
+
+	parts := strings.SplitN(v, ":", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format")
+	}
+	iamAccessKeyResource.ResourceName = parts[1]
+
+	parts = strings.SplitN(parts[0], "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format")
+	}
+	iamAccessKeyResource.Domain = parts[0]
+	iamAccessKeyResource.ResourceType = parts[1]
+
+	if iamAccessKeyResource.Domain == "" ||
+		iamAccessKeyResource.ResourceType == "" ||
+		iamAccessKeyResource.ResourceName == "" {
+		return nil, fmt.Errorf("invalid format")
+	}
+
+	return &iamAccessKeyResource, nil
+}
+
+func init() {
+	iamCmd.AddCommand(iamAccessKeyCmd)
+}

--- a/cmd/iam_access_key_create.go
+++ b/cmd/iam_access_key_create.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	egoscale "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type iamAccessKeyCreateCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"create"`
+
+	Name string `cli-arg:"#"`
+
+	Operations []string `cli-flag:"operation" cli-usage:"API operation to restrict the access key to. Can be repeated multiple times."`
+	Resources  []string `cli-flag:"resource" cli-usage:"API resource to restrict the access key to (format: DOMAIN/TYPE:NAME). Can be repeated multiple times."`
+	Tags       []string `cli-flag:"tag" cli-usage:"API operations tag to restrict the access key to. Can be repeated multiple times."`
+}
+
+func (c *iamAccessKeyCreateCmd) cmdAliases() []string { return gCreateAlias }
+
+func (c *iamAccessKeyCreateCmd) cmdShort() string {
+	return "Create an IAM access key"
+}
+
+func (c *iamAccessKeyCreateCmd) cmdLong() string {
+	return fmt.Sprintf(`This command creates an IAM access key.
+
+Supported output template annotations: %s`,
+		strings.Join(outputterTemplateAnnotations(&iamAccessKeyShowOutput{}), ", "))
+}
+
+func (c *iamAccessKeyCreateCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *iamAccessKeyCreateCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	zone := gCurrentAccount.DefaultZone
+
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+
+	opts := make([]egoscale.CreateIAMAccessKeyOpt, 0)
+
+	if len(c.Operations) > 0 {
+		opts = append(opts, egoscale.CreateIAMAccessKeyWithOperations(c.Operations))
+	}
+
+	if len(c.Resources) > 0 {
+		resources := make([]egoscale.IAMAccessKeyResource, len(c.Resources))
+		for i, rs := range c.Resources {
+			r, err := parseIAMAccessKeyResource(rs)
+			if err != nil {
+				return fmt.Errorf("invalid API resource %q", rs)
+			}
+			resources[i] = *r
+		}
+		opts = append(opts, egoscale.CreateIAMAccessKeyWithResources(resources))
+	}
+
+	if len(c.Tags) > 0 {
+		opts = append(opts, egoscale.CreateIAMAccessKeyWithTags(c.Tags))
+	}
+
+	iamAccessKey, err := cs.CreateIAMAccessKey(ctx, zone, c.Name, opts...)
+	if err != nil {
+		return fmt.Errorf("unable to create a new IAM access key: %w", err)
+	}
+
+	out := iamAccessKeyShowOutput{
+		Name:       *iamAccessKey.Name,
+		APIKey:     *iamAccessKey.Key,
+		APISecret:  iamAccessKey.Secret,
+		Operations: iamAccessKey.Operations,
+		Resources: func() *[]string {
+			if iamAccessKey.Resources != nil {
+				list := make([]string, len(*iamAccessKey.Resources))
+				for i, r := range *iamAccessKey.Resources {
+					list[i] = fmt.Sprintf("%s/%s:%s", r.Domain, r.ResourceType, r.ResourceName)
+				}
+				return &list
+			}
+			return nil
+		}(),
+		Tags: iamAccessKey.Tags,
+		Type: *iamAccessKey.Type,
+	}
+
+	if !gQuiet {
+		return c.outputFunc(&out, nil)
+	}
+
+	return nil
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(iamAccessKeyCmd, &iamAccessKeyCreateCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/iam_access_key_list.go
+++ b/cmd/iam_access_key_list.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type iamAccessKeyListItemOutput struct {
+	Key  string `json:"key"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type iamAccessKeyListOutput []iamAccessKeyListItemOutput
+
+func (o *iamAccessKeyListOutput) toJSON()  { outputJSON(o) }
+func (o *iamAccessKeyListOutput) toText()  { outputText(o) }
+func (o *iamAccessKeyListOutput) toTable() { outputTable(o) }
+
+type iamAccessKeyListCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"list"`
+}
+
+func (c *iamAccessKeyListCmd) cmdAliases() []string { return gListAlias }
+
+func (c *iamAccessKeyListCmd) cmdShort() string { return "List IAM access keys" }
+
+func (c *iamAccessKeyListCmd) cmdLong() string {
+	return fmt.Sprintf(`This command lists existing IAM access keys.
+
+Supported output template annotations: %s`,
+		strings.Join(outputterTemplateAnnotations(&iamAccessKeyListOutput{}), ", "))
+}
+
+func (c *iamAccessKeyListCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *iamAccessKeyListCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	zone := gCurrentAccount.DefaultZone
+
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+
+	iamAccessKeys, err := cs.ListIAMAccessKeys(ctx, zone)
+	if err != nil {
+		return err
+	}
+
+	out := make(iamAccessKeyListOutput, 0)
+
+	for _, k := range iamAccessKeys {
+		out = append(out, iamAccessKeyListItemOutput{
+			Name: *k.Name,
+			Key:  *k.Key,
+			Type: *k.Type,
+		})
+	}
+
+	return c.outputFunc(&out, err)
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(iamAccessKeyCmd, &iamAccessKeyListCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/iam_access_key_listoperations.go
+++ b/cmd/iam_access_key_listoperations.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/exoscale/cli/table"
+	egoscale "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type iamAccessKeyListOperationsItemOutput struct {
+	Operation string   `json:"operation"`
+	Tags      []string `json:"tags"`
+}
+
+type iamAccessKeyListOperationsOutput []iamAccessKeyListOperationsItemOutput
+
+func (o *iamAccessKeyListOperationsOutput) toJSON() { outputJSON(o) }
+func (o *iamAccessKeyListOperationsOutput) toText() { outputText(o) }
+func (o *iamAccessKeyListOperationsOutput) toTable() {
+	operationByTag := make(map[string][]string)
+
+	for _, op := range *o {
+		for _, tag := range op.Tags {
+			if _, ok := operationByTag[tag]; !ok {
+				operationByTag[tag] = make([]string, 0)
+			}
+			operationByTag[tag] = append(operationByTag[tag], op.Operation)
+		}
+	}
+
+	t := table.NewTable(os.Stdout)
+	defer t.Render()
+
+	t.SetHeader([]string{"Tag", "Operations"})
+
+	sortedTags := make([]string, 0)
+	for tag := range operationByTag {
+		sortedTags = append(sortedTags, tag)
+	}
+	sort.Strings(sortedTags)
+
+	for _, tag := range sortedTags {
+		operations := operationByTag[tag]
+		sort.Strings(operations)
+		t.Append([]string{tag, strings.Join(operations, "\n")})
+	}
+}
+
+type iamAccessKeyListOperationsCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"list-operations"`
+
+	Mine bool `cli-usage:"only report operations available to the IAM access key used to perform the API request"`
+}
+
+func (c *iamAccessKeyListOperationsCmd) cmdAliases() []string { return gListAlias }
+
+func (c *iamAccessKeyListOperationsCmd) cmdShort() string { return "List IAM access keys operations" }
+
+func (c *iamAccessKeyListOperationsCmd) cmdLong() string {
+	return fmt.Sprintf(`This command lists operations available to IAM access keys.
+
+Supported output template annotations: %s`,
+		strings.Join(outputterTemplateAnnotations(&iamAccessKeyListOperationsOutput{}), ", "))
+}
+
+func (c *iamAccessKeyListOperationsCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *iamAccessKeyListOperationsCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	var (
+		iamAccessKeyOperations []*egoscale.IAMAccessKeyOperation
+		err                    error
+	)
+
+	zone := gCurrentAccount.DefaultZone
+
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+
+	if c.Mine {
+		iamAccessKeyOperations, err = cs.ListMyIAMAccessKeyOperations(ctx, zone)
+	} else {
+		iamAccessKeyOperations, err = cs.ListIAMAccessKeyOperations(ctx, zone)
+	}
+	if err != nil {
+		return err
+	}
+
+	out := make(iamAccessKeyListOperationsOutput, 0)
+
+	for _, o := range iamAccessKeyOperations {
+		out = append(out, iamAccessKeyListOperationsItemOutput{
+			Operation: o.Name,
+			Tags:      o.Tags,
+		})
+	}
+
+	return c.outputFunc(&out, err)
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(iamAccessKeyCmd, &iamAccessKeyListOperationsCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/iam_access_key_revoke.go
+++ b/cmd/iam_access_key_revoke.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+
+	egoscale "github.com/exoscale/egoscale/v2"
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type iamAccessKeyRevokeCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"revoke"`
+
+	APIKey string `cli-arg:"#"`
+
+	Force bool `cli-short:"f" cli-usage:"don't prompt for confirmation"`
+}
+
+func (c *iamAccessKeyRevokeCmd) cmdAliases() []string { return gCreateAlias }
+
+func (c *iamAccessKeyRevokeCmd) cmdShort() string {
+	return "Revoke an IAM access key"
+}
+
+func (c *iamAccessKeyRevokeCmd) cmdLong() string { return "" }
+
+func (c *iamAccessKeyRevokeCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *iamAccessKeyRevokeCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	zone := gCurrentAccount.DefaultZone
+
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+
+	if !c.Force {
+		if !askQuestion(fmt.Sprintf("Are you sure you want to revoke IAM access key IP %s?", c.APIKey)) {
+			return nil
+		}
+	}
+
+	var err error
+	decorateAsyncOperation(fmt.Sprintf("Revoking IAM access key %s...", c.APIKey), func() {
+		err = cs.RevokeIAMAccessKey(ctx, zone, &egoscale.IAMAccessKey{Key: &c.APIKey})
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(iamAccessKeyCmd, &iamAccessKeyRevokeCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/iam_access_key_show.go
+++ b/cmd/iam_access_key_show.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/exoscale/cli/table"
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type iamAccessKeyShowOutput struct {
+	Name       string    `json:"name"`
+	Type       string    `json:"type"`
+	APIKey     string    `json:"api_key"`
+	APISecret  *string   `json:"api_secret,omitempty"`
+	Operations *[]string `json:"operations,omitempty"`
+	Tags       *[]string `json:"tags,omitempty"`
+	Resources  *[]string `json:"resources,omitempty"`
+}
+
+func (o *iamAccessKeyShowOutput) toJSON() { outputJSON(o) }
+func (o *iamAccessKeyShowOutput) toText() { outputText(o) }
+func (o *iamAccessKeyShowOutput) toTable() {
+	if o.APISecret != nil {
+		defer fmt.Fprint(os.Stderr, `
+/!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\
+/!\    Ensure to save your API Secret somewhere,    /!\
+/!\   as there is no way to recover it afterwards   /!\
+/!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\
+`)
+	}
+
+	t := table.NewTable(os.Stdout)
+	t.SetHeader([]string{"IAM Access Key"})
+	defer t.Render()
+
+	t.Append([]string{"Name", o.Name})
+	t.Append([]string{"Type", o.Type})
+	t.Append([]string{"API Key", o.APIKey})
+	t.Append([]string{"API Secret", defaultString(o.APISecret, strings.Repeat("*", 43))})
+
+	if o.Operations != nil {
+		t.Append([]string{"Operations", strings.Join(*o.Operations, "\n")})
+	}
+
+	if o.Tags != nil {
+		t.Append([]string{"Tags", strings.Join(*o.Tags, "\n")})
+	}
+
+	if o.Resources != nil {
+		t.Append([]string{"Resources", strings.Join(*o.Resources, "\n")})
+	}
+}
+
+type iamAccessKeyShowCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"show"`
+
+	APIKey string `cli-arg:"#" cli-usage:"API-KEY"`
+}
+
+func (c *iamAccessKeyShowCmd) cmdAliases() []string { return gShowAlias }
+
+func (c *iamAccessKeyShowCmd) cmdShort() string {
+	return "Show an IAM access key details"
+}
+
+func (c *iamAccessKeyShowCmd) cmdLong() string {
+	return fmt.Sprintf(`This command shows an IAM access key details.
+
+Supported output template annotations: %s`,
+		strings.Join(outputterTemplateAnnotations(&iamAccessKeyShowOutput{}), ", "))
+}
+
+func (c *iamAccessKeyShowCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *iamAccessKeyShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	zone := gCurrentAccount.DefaultZone
+
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, zone))
+
+	iamAccessKey, err := cs.GetIAMAccessKey(ctx, zone, c.APIKey)
+	if err != nil {
+		return err
+	}
+
+	out := iamAccessKeyShowOutput{
+		Name:       *iamAccessKey.Name,
+		APIKey:     *iamAccessKey.Key,
+		Operations: iamAccessKey.Operations,
+		Resources: func() *[]string {
+			if iamAccessKey.Resources != nil {
+				list := make([]string, len(*iamAccessKey.Resources))
+				for i, r := range *iamAccessKey.Resources {
+					list[i] = fmt.Sprintf("%s/%s:%s", r.Domain, r.ResourceType, r.ResourceName)
+				}
+				return &list
+			}
+			return nil
+		}(),
+		Tags: iamAccessKey.Tags,
+		Type: *iamAccessKey.Type,
+	}
+
+	return c.outputFunc(&out, nil)
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(iamAccessKeyCmd, &iamAccessKeyShowCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/iam_apikey.go
+++ b/cmd/iam_apikey.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"sort"
+	"time"
 
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
@@ -12,6 +14,15 @@ import (
 var apiKeyCmd = &cobra.Command{
 	Use:   "apikey",
 	Short: "API Keys management",
+	PersistentPreRun: func(_ *cobra.Command, _ []string) {
+		fmt.Fprintln(os.Stderr,
+			`**********************************************************************
+The "exo iam apikey" commands are deprecated and will be removed in a future
+version, please use "exo iam access-key" replacement commands.
+**********************************************************************`)
+		time.Sleep(3 * time.Second)
+	},
+	Hidden: true,
 }
 
 func getAPIKeyByKey(key string) (*egoscale.APIKey, error) {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/exoscale/egoscale v0.82.1
+	github.com/exoscale/egoscale v0.83.0
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/exoscale/egoscale v0.82.1 h1:J8HTniVdgFw7As6sbaS3/xq4H0yqod2Hq8ziwa08u70=
-github.com/exoscale/egoscale v0.82.1/go.mod h1:C1e4bJE8Ml1GylP14hOMGdCfgDDf9hMLsbny1QWsemw=
+github.com/exoscale/egoscale v0.83.0 h1:mo+eKegti0ALe6bHYfdeDb74w89tjcBPOTYn2rQ+Iss=
+github.com/exoscale/egoscale v0.83.0/go.mod h1:C1e4bJE8Ml1GylP14hOMGdCfgDDf9hMLsbny1QWsemw=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.83.0
+------
+
+- feature: v2: add support for IAM access key resources
+
 0.82.1
 ------
 

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.82.1"
+const Version = "0.83.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.0
 ## explicit
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.82.1
+# github.com/exoscale/egoscale v0.83.0
 ## explicit
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/v2


### PR DESCRIPTION
This change introduces new `exo iam access-key *` commands using the new
IAM v2 API, deprecating the `exo iam apikeys *` commands.