### PR TITLE
DBaaS: add logs/metrics retrieval commands

### DIFF
--- a/cmd/dbaas.go
+++ b/cmd/dbaas.go
@@ -5,9 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 
+	"github.com/exoscale/cli/table"
+	"github.com/mitchellh/go-wordwrap"
 	"github.com/spf13/cobra"
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -95,4 +98,58 @@ func redactDatabaseServiceURI(u string) string {
 	}
 
 	return u
+}
+
+// dbaasShowSettings outputs a table-formatted list of key/value settings.
+func dbaasShowSettings(settings map[string]interface{}) {
+	t := table.NewTable(os.Stdout)
+	defer t.Render()
+
+	t.SetHeader([]string{"key", "type", "description"})
+
+	for k, v := range settings {
+		s, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		row := []string{k}
+
+		typ := "-"
+		if v, ok := s["type"]; ok {
+			typ = fmt.Sprint(v)
+		}
+		row = append(row, typ)
+
+		var description string
+		if v, ok := s["description"]; ok {
+			description = wordwrap.WrapString(v.(string), 50)
+
+			if v, ok := s["enum"]; ok {
+				description = fmt.Sprintf("%s\n  * Supported values:\n%s", description, func() string {
+					values := make([]string, len(v.([]interface{})))
+					for i, val := range v.([]interface{}) {
+						values[i] = fmt.Sprintf("    - %v", val)
+					}
+					return strings.Join(values, "\n")
+				}())
+			}
+
+			min, hasMin := s["minimum"]
+			max, hasMax := s["maximum"]
+			if hasMin && hasMax {
+				description = fmt.Sprintf("%s\n  * Minimum: %v / Maximum: %v", description, min, max)
+			}
+
+			if v, ok := s["default"]; ok {
+				description = fmt.Sprintf("%s\n  * Default: %v", description, v)
+			}
+
+			if v, ok := s["example"]; ok {
+				description = fmt.Sprintf("%s\n  * Example: %v", description, v)
+			}
+		}
+		row = append(row, description)
+
+		t.Append(row)
+	}
 }

--- a/cmd/dbaas_cacertificate.go
+++ b/cmd/dbaas_cacertificate.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type dbCACertificateCmd struct {
+type dbaasCACertificateCmd struct {
 	cliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"ca-certificate"`
@@ -15,35 +15,35 @@ type dbCACertificateCmd struct {
 	Zone string `cli-short:"z"`
 }
 
-func (c *dbCACertificateCmd) cmdAliases() []string { return nil }
+func (c *dbaasCACertificateCmd) cmdAliases() []string { return nil }
 
-func (c *dbCACertificateCmd) cmdShort() string { return "Retrieve the Database CA certificate" }
+func (c *dbaasCACertificateCmd) cmdShort() string { return "Retrieve the Database CA certificate" }
 
-func (c *dbCACertificateCmd) cmdLong() string {
+func (c *dbaasCACertificateCmd) cmdLong() string {
 	return `This command retrieves the Exoscale organization-level CA certificate
 required to access Database Services using a TLS connection.`
 }
 
-func (c *dbCACertificateCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+func (c *dbaasCACertificateCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
 	cmdSetZoneFlagFromDefault(cmd)
 	return cliCommandDefaultPreRun(c, cmd, args)
 }
 
-func (c *dbCACertificateCmd) cmdRun(_ *cobra.Command, _ []string) error {
+func (c *dbaasCACertificateCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
 
-	dbCACertificate, err := cs.GetDatabaseCACertificate(ctx, c.Zone)
+	caCertificate, err := cs.GetDatabaseCACertificate(ctx, c.Zone)
 	if err != nil {
 		return err
 	}
 
-	_, _ = fmt.Print(dbCACertificate)
+	_, _ = fmt.Print(caCertificate)
 
 	return nil
 }
 
 func init() {
-	cobra.CheckErr(registerCLICommand(dbaasCmd, &dbCACertificateCmd{
+	cobra.CheckErr(registerCLICommand(dbaasCmd, &dbaasCACertificateCmd{
 		cliCommandSettings: defaultCLICmdSettings(),
 	}))
 }

--- a/cmd/dbaas_create.go
+++ b/cmd/dbaas_create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type dbServiceCreateCmd struct {
+type dbaasServiceCreateCmd struct {
 	cliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"create"`
@@ -68,11 +68,11 @@ type dbServiceCreateCmd struct {
 	RedisSettings           string   `cli-flag:"redis-settings" cli-usage:"Redis configuration settings (JSON format)" cli-hidden:""`
 }
 
-func (c *dbServiceCreateCmd) cmdAliases() []string { return gCreateAlias }
+func (c *dbaasServiceCreateCmd) cmdAliases() []string { return gCreateAlias }
 
-func (c *dbServiceCreateCmd) cmdShort() string { return "Create a Database Service" }
+func (c *dbaasServiceCreateCmd) cmdShort() string { return "Create a Database Service" }
 
-func (c *dbServiceCreateCmd) cmdLong() string {
+func (c *dbaasServiceCreateCmd) cmdLong() string {
 	return fmt.Sprintf(`This command creates a Database Service.
 
 Supported values for --maintenance-dow: %s
@@ -82,7 +82,7 @@ Supported output template annotations: %s`,
 		strings.Join(outputterTemplateAnnotations(&dbServiceShowOutput{}), ", "))
 }
 
-func (c *dbServiceCreateCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+func (c *dbaasServiceCreateCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
 	switch {
 	case cmd.Flags().Changed("help-kafka"):
 		cmdShowHelpFlags(cmd.Flags(), "kafka-")
@@ -102,7 +102,7 @@ func (c *dbServiceCreateCmd) cmdPreRun(cmd *cobra.Command, args []string) error 
 	return cliCommandDefaultPreRun(c, cmd, args)
 }
 
-func (c *dbServiceCreateCmd) cmdRun(cmd *cobra.Command, args []string) error {
+func (c *dbaasServiceCreateCmd) cmdRun(cmd *cobra.Command, args []string) error {
 	if (cmd.Flags().Changed(mustCLICommandFlagName(c, &c.MaintenanceDOW)) ||
 		cmd.Flags().Changed(mustCLICommandFlagName(c, &c.MaintenanceTime))) &&
 		(!cmd.Flags().Changed(mustCLICommandFlagName(c, &c.MaintenanceDOW)) ||
@@ -128,7 +128,7 @@ func (c *dbServiceCreateCmd) cmdRun(cmd *cobra.Command, args []string) error {
 }
 
 func init() {
-	cobra.CheckErr(registerCLICommand(dbaasCmd, &dbServiceCreateCmd{
+	cobra.CheckErr(registerCLICommand(dbaasCmd, &dbaasServiceCreateCmd{
 		cliCommandSettings: defaultCLICmdSettings(),
 
 		TerminationProtection: true,

--- a/cmd/dbaas_create_kafka.go
+++ b/cmd/dbaas_create_kafka.go
@@ -94,9 +94,10 @@ func (c *dbaasServiceCreateCmd) createKafka(_ *cobra.Command, _ []string) error 
 		databaseService.SchemaRegistrySettings = &settings
 	}
 
-	fmt.Printf("Creating Database Service %q...\n", c.Name)
-
-	res, err := cs.CreateDbaasServiceKafkaWithResponse(ctx, oapi.DbaasServiceName(c.Name), databaseService)
+	var res *oapi.CreateDbaasServiceKafkaResponse
+	decorateAsyncOperation(fmt.Sprintf("Creating Database Service %q...", c.Name), func() {
+		res, err = cs.CreateDbaasServiceKafkaWithResponse(ctx, oapi.DbaasServiceName(c.Name), databaseService)
+	})
 	if err != nil {
 		return err
 	}

--- a/cmd/dbaas_create_kafka.go
+++ b/cmd/dbaas_create_kafka.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *dbServiceCreateCmd) createKafka(_ *cobra.Command, _ []string) error {
+func (c *dbaasServiceCreateCmd) createKafka(_ *cobra.Command, _ []string) error {
 	var err error
 
 	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
@@ -105,7 +105,7 @@ func (c *dbServiceCreateCmd) createKafka(_ *cobra.Command, _ []string) error {
 	}
 
 	if !gQuiet {
-		return c.outputFunc((&dbServiceShowCmd{
+		return c.outputFunc((&dbaasServiceShowCmd{
 			Name: c.Name,
 			Zone: c.Zone,
 		}).showDatabaseServiceKafka(ctx))

--- a/cmd/dbaas_create_mysql.go
+++ b/cmd/dbaas_create_mysql.go
@@ -75,9 +75,10 @@ func (c *dbaasServiceCreateCmd) createMysql(_ *cobra.Command, _ []string) error 
 		databaseService.MysqlSettings = &settings
 	}
 
-	fmt.Printf("Creating Database Service %q...\n", c.Name)
-
-	res, err := cs.CreateDbaasServiceMysqlWithResponse(ctx, oapi.DbaasServiceName(c.Name), databaseService)
+	var res *oapi.CreateDbaasServiceMysqlResponse
+	decorateAsyncOperation(fmt.Sprintf("Creating Database Service %q...", c.Name), func() {
+		res, err = cs.CreateDbaasServiceMysqlWithResponse(ctx, oapi.DbaasServiceName(c.Name), databaseService)
+	})
 	if err != nil {
 		return err
 	}

--- a/cmd/dbaas_create_mysql.go
+++ b/cmd/dbaas_create_mysql.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *dbServiceCreateCmd) createMysql(_ *cobra.Command, _ []string) error {
+func (c *dbaasServiceCreateCmd) createMysql(_ *cobra.Command, _ []string) error {
 	var err error
 
 	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
@@ -86,7 +86,7 @@ func (c *dbServiceCreateCmd) createMysql(_ *cobra.Command, _ []string) error {
 	}
 
 	if !gQuiet {
-		return c.outputFunc((&dbServiceShowCmd{
+		return c.outputFunc((&dbaasServiceShowCmd{
 			Name: c.Name,
 			Zone: c.Zone,
 		}).showDatabaseServiceMysql(ctx))

--- a/cmd/dbaas_create_pg.go
+++ b/cmd/dbaas_create_pg.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *dbServiceCreateCmd) createPG(_ *cobra.Command, _ []string) error {
+func (c *dbaasServiceCreateCmd) createPG(_ *cobra.Command, _ []string) error {
 	var err error
 
 	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
@@ -111,7 +111,7 @@ func (c *dbServiceCreateCmd) createPG(_ *cobra.Command, _ []string) error {
 	}
 
 	if !gQuiet {
-		return c.outputFunc((&dbServiceShowCmd{
+		return c.outputFunc((&dbaasServiceShowCmd{
 			Name: c.Name,
 			Zone: c.Zone,
 		}).showDatabaseServicePG(ctx))

--- a/cmd/dbaas_create_pg.go
+++ b/cmd/dbaas_create_pg.go
@@ -100,9 +100,10 @@ func (c *dbaasServiceCreateCmd) createPG(_ *cobra.Command, _ []string) error {
 		databaseService.PgSettings = &settings
 	}
 
-	fmt.Printf("Creating Database Service %q...\n", c.Name)
-
-	res, err := cs.CreateDbaasServicePgWithResponse(ctx, oapi.DbaasServiceName(c.Name), databaseService)
+	var res *oapi.CreateDbaasServicePgResponse
+	decorateAsyncOperation(fmt.Sprintf("Creating Database Service %q...", c.Name), func() {
+		res, err = cs.CreateDbaasServicePgWithResponse(ctx, oapi.DbaasServiceName(c.Name), databaseService)
+	})
 	if err != nil {
 		return err
 	}

--- a/cmd/dbaas_create_redis.go
+++ b/cmd/dbaas_create_redis.go
@@ -51,9 +51,10 @@ func (c *dbaasServiceCreateCmd) createRedis(_ *cobra.Command, _ []string) error 
 		databaseService.RedisSettings = &settings
 	}
 
-	fmt.Printf("Creating Database Service %q...\n", c.Name)
-
-	res, err := cs.CreateDbaasServiceRedisWithResponse(ctx, oapi.DbaasServiceName(c.Name), databaseService)
+	var res *oapi.CreateDbaasServiceRedisResponse
+	decorateAsyncOperation(fmt.Sprintf("Creating Database Service %q...", c.Name), func() {
+		res, err = cs.CreateDbaasServiceRedisWithResponse(ctx, oapi.DbaasServiceName(c.Name), databaseService)
+	})
 	if err != nil {
 		return err
 	}

--- a/cmd/dbaas_create_redis.go
+++ b/cmd/dbaas_create_redis.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *dbServiceCreateCmd) createRedis(_ *cobra.Command, _ []string) error {
+func (c *dbaasServiceCreateCmd) createRedis(_ *cobra.Command, _ []string) error {
 	var err error
 
 	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
@@ -62,7 +62,7 @@ func (c *dbServiceCreateCmd) createRedis(_ *cobra.Command, _ []string) error {
 	}
 
 	if !gQuiet {
-		return c.outputFunc((&dbServiceShowCmd{
+		return c.outputFunc((&dbaasServiceShowCmd{
 			Name: c.Name,
 			Zone: c.Zone,
 		}).showDatabaseServiceRedis(ctx))

--- a/cmd/dbaas_delete.go
+++ b/cmd/dbaas_delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type dbServiceDeleteCmd struct {
+type dbaasServiceDeleteCmd struct {
 	cliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"delete"`
@@ -19,18 +19,18 @@ type dbServiceDeleteCmd struct {
 	Zone  string `cli-short:"z" cli-usage:"Database Service zone"`
 }
 
-func (c *dbServiceDeleteCmd) cmdAliases() []string { return gRemoveAlias }
+func (c *dbaasServiceDeleteCmd) cmdAliases() []string { return gRemoveAlias }
 
-func (c *dbServiceDeleteCmd) cmdShort() string { return "Delete a Database Service" }
+func (c *dbaasServiceDeleteCmd) cmdShort() string { return "Delete a Database Service" }
 
-func (c *dbServiceDeleteCmd) cmdLong() string { return "" }
+func (c *dbaasServiceDeleteCmd) cmdLong() string { return "" }
 
-func (c *dbServiceDeleteCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+func (c *dbaasServiceDeleteCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
 	cmdSetZoneFlagFromDefault(cmd)
 	return cliCommandDefaultPreRun(c, cmd, args)
 }
 
-func (c *dbServiceDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
+func (c *dbaasServiceDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
 
 	if !c.Force {
@@ -51,7 +51,7 @@ func (c *dbServiceDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(registerCLICommand(dbaasCmd, &dbServiceDeleteCmd{
+	cobra.CheckErr(registerCLICommand(dbaasCmd, &dbaasServiceDeleteCmd{
 		cliCommandSettings: defaultCLICmdSettings(),
 	}))
 }

--- a/cmd/dbaas_list.go
+++ b/cmd/dbaas_list.go
@@ -9,20 +9,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type dbServiceListItemOutput struct {
+type dbaasServiceListItemOutput struct {
 	Name string `json:"name"`
 	Type string `json:"type"`
 	Plan string `json:"plan"`
 	Zone string `json:"zone"`
 }
 
-type dbServiceListOutput []dbServiceListItemOutput
+type dbaasServiceListOutput []dbaasServiceListItemOutput
 
-func (o *dbServiceListOutput) toJSON()  { outputJSON(o) }
-func (o *dbServiceListOutput) toText()  { outputText(o) }
-func (o *dbServiceListOutput) toTable() { outputTable(o) }
+func (o *dbaasServiceListOutput) toJSON()  { outputJSON(o) }
+func (o *dbaasServiceListOutput) toText()  { outputText(o) }
+func (o *dbaasServiceListOutput) toTable() { outputTable(o) }
 
-type dbServiceListCmd struct {
+type dbaasServiceListCmd struct {
 	cliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"list"`
@@ -30,22 +30,22 @@ type dbServiceListCmd struct {
 	Zone string `cli-short:"z" cli-usage:"zone to filter results to"`
 }
 
-func (c *dbServiceListCmd) cmdAliases() []string { return gListAlias }
+func (c *dbaasServiceListCmd) cmdAliases() []string { return gListAlias }
 
-func (c *dbServiceListCmd) cmdShort() string { return "List Database Services" }
+func (c *dbaasServiceListCmd) cmdShort() string { return "List Database Services" }
 
-func (c *dbServiceListCmd) cmdLong() string {
+func (c *dbaasServiceListCmd) cmdLong() string {
 	return fmt.Sprintf(`This command lists Database Services.
 
 Supported output template annotations: %s`,
-		strings.Join(outputterTemplateAnnotations(&dbServiceListItemOutput{}), ", "))
+		strings.Join(outputterTemplateAnnotations(&dbaasServiceListItemOutput{}), ", "))
 }
 
-func (c *dbServiceListCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+func (c *dbaasServiceListCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
 	return cliCommandDefaultPreRun(c, cmd, args)
 }
 
-func (c *dbServiceListCmd) cmdRun(_ *cobra.Command, _ []string) error {
+func (c *dbaasServiceListCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	var zones []string
 
 	if c.Zone != "" {
@@ -54,8 +54,8 @@ func (c *dbServiceListCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		zones = allZones
 	}
 
-	out := make(dbServiceListOutput, 0)
-	res := make(chan dbServiceListItemOutput)
+	out := make(dbaasServiceListOutput, 0)
+	res := make(chan dbaasServiceListItemOutput)
 	defer close(res)
 
 	go func() {
@@ -72,7 +72,7 @@ func (c *dbServiceListCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		}
 
 		for _, dbService := range list {
-			res <- dbServiceListItemOutput{
+			res <- dbaasServiceListItemOutput{
 				Name: *dbService.Name,
 				Type: *dbService.Type,
 				Plan: *dbService.Plan,
@@ -91,7 +91,7 @@ func (c *dbServiceListCmd) cmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(registerCLICommand(dbaasCmd, &dbServiceListCmd{
+	cobra.CheckErr(registerCLICommand(dbaasCmd, &dbaasServiceListCmd{
 		cliCommandSettings: defaultCLICmdSettings(),
 	}))
 }

--- a/cmd/dbaas_logs.go
+++ b/cmd/dbaas_logs.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/exoscale/cli/table"
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/exoscale/egoscale/v2/oapi"
+	"github.com/spf13/cobra"
+)
+
+type dbServiceLogsItemOutput struct {
+	Time    time.Time `json:"time"`
+	Node    string    `json:"node"`
+	Unit    string    `json:"unit"`
+	Message string    `json:"message"`
+}
+
+type dbServiceLogsOutput struct {
+	FirstLogOffset string                    `json:"first_log_offset"`
+	Offset         string                    `json:"offset"`
+	Logs           []dbServiceLogsItemOutput `json:"logs"`
+}
+
+func (o *dbServiceLogsOutput) toJSON() { outputJSON(o) }
+func (o *dbServiceLogsOutput) toText() { outputText(o) }
+func (o *dbServiceLogsOutput) toTable() {
+	t := table.NewTable(os.Stdout)
+	defer t.Render()
+
+	t.SetHeader([]string{"Time", "Node", "Unit", "Message"})
+	for _, notification := range o.Logs {
+		t.Append([]string{
+			notification.Time.String(),
+			notification.Node,
+			notification.Unit,
+			notification.Message,
+		})
+	}
+}
+
+type dbaasServiceLogsCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"logs"`
+
+	Name string `cli-arg:"#"`
+
+	Limit  int64  `cli-short:"l" cli-usage:"number of log messages to retrieve"`
+	Offset string `cli-short:"o" cli-usage:"log listing offset"`
+	Sort   string `cli-usage:"log messages sorting order (asc|desc)"`
+	Zone   string `cli-short:"z" cli-usage:"Database Service zone"`
+}
+
+func (c *dbaasServiceLogsCmd) cmdAliases() []string { return gShowAlias }
+
+func (c *dbaasServiceLogsCmd) cmdShort() string {
+	return "Query a Database Service logs"
+}
+
+func (c *dbaasServiceLogsCmd) cmdLong() string {
+	return fmt.Sprintf(`This command outputs a Database Service logs.
+
+Supported output template annotations: %s
+  - .Logs: %s
+
+Example usage with custom output containing only the actual log messages:
+
+    exo dbaas logs MY-SERVICE --output-template \
+        '{{range $l := .Logs}}{{println $l.Message}}{{end}}'
+`,
+		strings.Join(outputterTemplateAnnotations(&dbServiceLogsOutput{}), ", "),
+		strings.Join(outputterTemplateAnnotations(&dbServiceLogsItemOutput{}), ", "))
+}
+
+func (c *dbaasServiceLogsCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	cmdSetZoneFlagFromDefault(cmd)
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *dbaasServiceLogsCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
+
+	res, err := cs.GetDbaasServiceLogsWithResponse(
+		ctx,
+		c.Name,
+		oapi.GetDbaasServiceLogsJSONRequestBody{
+			Limit:     &c.Limit,
+			Offset:    nonEmptyStringPtr(c.Offset),
+			SortOrder: (*oapi.EnumSortOrder)(nonEmptyStringPtr(c.Sort)),
+		},
+	)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode() != http.StatusOK {
+		return fmt.Errorf("API request error: unexpected status %s", res.Status())
+	}
+
+	out := dbServiceLogsOutput{
+		FirstLogOffset: *res.JSON200.FirstLogOffset,
+		Offset:         *res.JSON200.Offset,
+		Logs:           make([]dbServiceLogsItemOutput, len(*res.JSON200.Logs)),
+	}
+
+	for i, log := range *res.JSON200.Logs {
+		ts, err := time.Parse("2006-01-02T15:04:05.000000", *log.Time)
+		if err != nil {
+			return fmt.Errorf("unable to parse log timestamp: %w", err)
+		}
+		out.Logs[i].Time = ts
+
+		out.Logs[i].Node = defaultString(log.Node, "-")
+		out.Logs[i].Unit = defaultString(log.Unit, "-")
+		out.Logs[i].Message = defaultString(log.Message, "-")
+	}
+
+	return c.outputFunc(&out, nil)
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(dbaasCmd, &dbaasServiceLogsCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+
+		Limit: 10,
+		Sort:  "desc",
+	}))
+}

--- a/cmd/dbaas_metrics.go
+++ b/cmd/dbaas_metrics.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/exoscale/egoscale/v2/oapi"
+	"github.com/spf13/cobra"
+)
+
+type dbaasServiceMetricsCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"metrics"`
+
+	Name string `cli-arg:"#"`
+
+	Period string `cli-usage:"metrics time period to retrieve"`
+	Zone   string `cli-short:"z" cli-usage:"Database Service zone"`
+}
+
+func (c *dbaasServiceMetricsCmd) cmdAliases() []string { return gShowAlias }
+
+func (c *dbaasServiceMetricsCmd) cmdShort() string {
+	return "Query a Database Service metrics over time"
+}
+
+func (c *dbaasServiceMetricsCmd) cmdLong() string {
+	return `This command outputs a Database Service raw metrics for the specified time
+period in JSON format.`
+}
+
+func (c *dbaasServiceMetricsCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	cmdSetZoneFlagFromDefault(cmd)
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *dbaasServiceMetricsCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
+
+	res, err := cs.GetDbaasServiceMetricsWithResponse(
+		ctx,
+		c.Name,
+		oapi.GetDbaasServiceMetricsJSONRequestBody{Period: (*oapi.GetDbaasServiceMetricsJSONBodyPeriod)(&c.Period)},
+	)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode() != http.StatusOK {
+		return fmt.Errorf("API request error: unexpected status %s", res.Status())
+	}
+
+	fmt.Println(string(res.Body))
+
+	return nil
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(dbaasCmd, &dbaasServiceMetricsCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+
+		Period: "hour",
+	}))
+}

--- a/cmd/dbaas_show.go
+++ b/cmd/dbaas_show.go
@@ -113,7 +113,7 @@ func (o *dbServiceShowOutput) toTable() {
 	}
 }
 
-type dbServiceShowCmd struct {
+type dbaasServiceShowCmd struct {
 	cliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"show"`
@@ -127,11 +127,11 @@ type dbServiceShowCmd struct {
 	Zone              string `cli-short:"z" cli-usage:"Database Service zone"`
 }
 
-func (c *dbServiceShowCmd) cmdAliases() []string { return gShowAlias }
+func (c *dbaasServiceShowCmd) cmdAliases() []string { return gShowAlias }
 
-func (c *dbServiceShowCmd) cmdShort() string { return "Show a Database Service details" }
+func (c *dbaasServiceShowCmd) cmdShort() string { return "Show a Database Service details" }
 
-func (c *dbServiceShowCmd) cmdLong() string {
+func (c *dbaasServiceShowCmd) cmdLong() string {
 	return fmt.Sprintf(`This command shows a Database Service details.
 
 Supported output template annotations:
@@ -178,12 +178,12 @@ Supported output template annotations:
 		strings.Join(outputterTemplateAnnotations(&dbServiceNotificationListItemOutput{}), ", "))
 }
 
-func (c *dbServiceShowCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+func (c *dbaasServiceShowCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
 	cmdSetZoneFlagFromDefault(cmd)
 	return cliCommandDefaultPreRun(c, cmd, args)
 }
 
-func (c *dbServiceShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
+func (c *dbaasServiceShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
 
 	databaseServices, err := cs.ListDatabaseServices(ctx, c.Zone)
@@ -220,7 +220,7 @@ func (c *dbServiceShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(registerCLICommand(dbaasCmd, &dbServiceShowCmd{
+	cobra.CheckErr(registerCLICommand(dbaasCmd, &dbaasServiceShowCmd{
 		cliCommandSettings: defaultCLICmdSettings(),
 	}))
 }

--- a/cmd/dbaas_show_kafka.go
+++ b/cmd/dbaas_show_kafka.go
@@ -138,7 +138,7 @@ func formatDatabaseServiceKafkaTable(t *table.Table, o *dbServiceKafkaShowOutput
 	}()})
 }
 
-func (c *dbServiceShowCmd) showDatabaseServiceKafka(ctx context.Context) (outputter, error) {
+func (c *dbaasServiceShowCmd) showDatabaseServiceKafka(ctx context.Context) (outputter, error) {
 	res, err := cs.GetDbaasServiceKafkaWithResponse(ctx, oapi.DbaasServiceName(c.Name))
 	if err != nil {
 		return nil, err

--- a/cmd/dbaas_show_mysql.go
+++ b/cmd/dbaas_show_mysql.go
@@ -76,7 +76,7 @@ func formatDatabaseServiceMysqlTable(t *table.Table, o *dbServiceMysqlShowOutput
 	}()})
 }
 
-func (c *dbServiceShowCmd) showDatabaseServiceMysql(ctx context.Context) (outputter, error) {
+func (c *dbaasServiceShowCmd) showDatabaseServiceMysql(ctx context.Context) (outputter, error) {
 	res, err := cs.GetDbaasServiceMysqlWithResponse(ctx, oapi.DbaasServiceName(c.Name))
 	if err != nil {
 		return nil, err

--- a/cmd/dbaas_show_pg.go
+++ b/cmd/dbaas_show_pg.go
@@ -106,7 +106,7 @@ func formatDatabaseServicePGTable(t *table.Table, o *dbServicePGShowOutput) {
 	}()})
 }
 
-func (c *dbServiceShowCmd) showDatabaseServicePG(ctx context.Context) (outputter, error) {
+func (c *dbaasServiceShowCmd) showDatabaseServicePG(ctx context.Context) (outputter, error) {
 	res, err := cs.GetDbaasServicePgWithResponse(ctx, oapi.DbaasServiceName(c.Name))
 	if err != nil {
 		return nil, err

--- a/cmd/dbaas_show_redis.go
+++ b/cmd/dbaas_show_redis.go
@@ -72,7 +72,7 @@ func formatDatabaseServiceRedisTable(t *table.Table, o *dbServiceRedisShowOutput
 	}()})
 }
 
-func (c *dbServiceShowCmd) showDatabaseServiceRedis(ctx context.Context) (outputter, error) {
+func (c *dbaasServiceShowCmd) showDatabaseServiceRedis(ctx context.Context) (outputter, error) {
 	res, err := cs.GetDbaasServiceRedisWithResponse(ctx, oapi.DbaasServiceName(c.Name))
 	if err != nil {
 		return nil, err

--- a/cmd/dbaas_type.go
+++ b/cmd/dbaas_type.go
@@ -4,11 +4,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var dbTypeCmd = &cobra.Command{
+var dbaasTypeCmd = &cobra.Command{
 	Use:   "type",
 	Short: "Database Services types management",
 }
 
 func init() {
-	dbaasCmd.AddCommand(dbTypeCmd)
+	dbaasCmd.AddCommand(dbaasTypeCmd)
 }

--- a/cmd/dbaas_type_list.go
+++ b/cmd/dbaas_type_list.go
@@ -10,17 +10,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type dbTypeListItemOutput struct {
+type dbaasTypeListItemOutput struct {
 	Name              string   `json:"name"`
 	AvailableVersions []string `json:"available_versions"`
 	DefaultVersion    string   `json:"default_version"`
 }
 
-type dbTypeListOutput []dbTypeListItemOutput
+type dbaasTypeListOutput []dbaasTypeListItemOutput
 
-func (o *dbTypeListOutput) toJSON() { outputJSON(o) }
-func (o *dbTypeListOutput) toText() { outputText(o) }
-func (o *dbTypeListOutput) toTable() {
+func (o *dbaasTypeListOutput) toJSON() { outputJSON(o) }
+func (o *dbaasTypeListOutput) toText() { outputText(o) }
+func (o *dbaasTypeListOutput) toTable() {
 	t := table.NewTable(os.Stdout)
 	t.SetHeader([]string{"Name", "Available Versions", "Default Version"})
 	defer t.Render()
@@ -34,28 +34,28 @@ func (o *dbTypeListOutput) toTable() {
 	}
 }
 
-type dbTypeListCmd struct {
+type dbaasTypeListCmd struct {
 	cliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"list"`
 }
 
-func (c *dbTypeListCmd) cmdAliases() []string { return nil }
+func (c *dbaasTypeListCmd) cmdAliases() []string { return nil }
 
-func (c *dbTypeListCmd) cmdShort() string { return "List Database Service types" }
+func (c *dbaasTypeListCmd) cmdShort() string { return "List Database Service types" }
 
-func (c *dbTypeListCmd) cmdLong() string {
+func (c *dbaasTypeListCmd) cmdLong() string {
 	return fmt.Sprintf(`This command lists available Database Service types.
 
 Supported output template annotations: %s`,
-		strings.Join(outputterTemplateAnnotations(&dbTypeListItemOutput{}), ", "))
+		strings.Join(outputterTemplateAnnotations(&dbaasTypeListItemOutput{}), ", "))
 }
 
-func (c *dbTypeListCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+func (c *dbaasTypeListCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
 	return cliCommandDefaultPreRun(c, cmd, args)
 }
 
-func (c *dbTypeListCmd) cmdRun(_ *cobra.Command, _ []string) error {
+func (c *dbaasTypeListCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	ctx := exoapi.WithEndpoint(
 		gContext,
 		exoapi.NewReqEndpoint(gCurrentAccount.Environment, gCurrentAccount.DefaultZone),
@@ -66,10 +66,10 @@ func (c *dbTypeListCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	out := make(dbTypeListOutput, 0)
+	out := make(dbaasTypeListOutput, 0)
 
 	for _, t := range dbTypes {
-		out = append(out, dbTypeListItemOutput{
+		out = append(out, dbaasTypeListItemOutput{
 			Name:           *t.Name,
 			DefaultVersion: defaultString(t.DefaultVersion, "-"),
 			AvailableVersions: func() (v []string) {
@@ -85,7 +85,7 @@ func (c *dbTypeListCmd) cmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(registerCLICommand(dbTypeCmd, &dbTypeListCmd{
+	cobra.CheckErr(registerCLICommand(dbaasTypeCmd, &dbaasTypeListCmd{
 		cliCommandSettings: defaultCLICmdSettings(),
 	}))
 }

--- a/cmd/dbaas_update.go
+++ b/cmd/dbaas_update.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type dbServiceUpdateCmd struct {
+type dbaasServiceUpdateCmd struct {
 	cliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"update"`
@@ -56,11 +56,11 @@ type dbServiceUpdateCmd struct {
 	RedisSettings string   `cli-flag:"redis-settings" cli-usage:"Redis configuration settings (JSON format)" cli-hidden:""`
 }
 
-func (c *dbServiceUpdateCmd) cmdAliases() []string { return nil }
+func (c *dbaasServiceUpdateCmd) cmdAliases() []string { return nil }
 
-func (c *dbServiceUpdateCmd) cmdShort() string { return "Update Database Service" }
+func (c *dbaasServiceUpdateCmd) cmdShort() string { return "Update Database Service" }
 
-func (c *dbServiceUpdateCmd) cmdLong() string {
+func (c *dbaasServiceUpdateCmd) cmdLong() string {
 	return fmt.Sprintf(`This command updates a Database Service.
 
 Supported values for --maintenance-dow: %s
@@ -71,7 +71,7 @@ Supported output template annotations: %s`,
 	)
 }
 
-func (c *dbServiceUpdateCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+func (c *dbaasServiceUpdateCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
 	switch {
 	case cmd.Flags().Changed("help-kafka"):
 		cmdShowHelpFlags(cmd.Flags(), "kafka-")
@@ -91,7 +91,7 @@ func (c *dbServiceUpdateCmd) cmdPreRun(cmd *cobra.Command, args []string) error 
 	return cliCommandDefaultPreRun(c, cmd, args)
 }
 
-func (c *dbServiceUpdateCmd) cmdRun(cmd *cobra.Command, args []string) error {
+func (c *dbaasServiceUpdateCmd) cmdRun(cmd *cobra.Command, args []string) error {
 	if (cmd.Flags().Changed(mustCLICommandFlagName(c, &c.MaintenanceDOW)) ||
 		cmd.Flags().Changed(mustCLICommandFlagName(c, &c.MaintenanceTime))) &&
 		(!cmd.Flags().Changed(mustCLICommandFlagName(c, &c.MaintenanceDOW)) ||
@@ -138,7 +138,7 @@ func (c *dbServiceUpdateCmd) cmdRun(cmd *cobra.Command, args []string) error {
 }
 
 func init() {
-	cobra.CheckErr(registerCLICommand(dbaasCmd, &dbServiceUpdateCmd{
+	cobra.CheckErr(registerCLICommand(dbaasCmd, &dbaasServiceUpdateCmd{
 		cliCommandSettings: defaultCLICmdSettings(),
 	}))
 }

--- a/cmd/dbaas_update_kafka.go
+++ b/cmd/dbaas_update_kafka.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *dbServiceUpdateCmd) updateKafka(cmd *cobra.Command, _ []string) error {
+func (c *dbaasServiceUpdateCmd) updateKafka(cmd *cobra.Command, _ []string) error {
 	var updated bool
 
 	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
@@ -142,7 +142,7 @@ func (c *dbServiceUpdateCmd) updateKafka(cmd *cobra.Command, _ []string) error {
 	}
 
 	if !gQuiet {
-		return c.outputFunc((&dbServiceShowCmd{
+		return c.outputFunc((&dbaasServiceShowCmd{
 			Name: c.Name,
 			Zone: c.Zone,
 		}).showDatabaseServiceKafka(ctx))

--- a/cmd/dbaas_update_kafka.go
+++ b/cmd/dbaas_update_kafka.go
@@ -130,9 +130,10 @@ func (c *dbaasServiceUpdateCmd) updateKafka(cmd *cobra.Command, _ []string) erro
 	}
 
 	if updated {
-		fmt.Printf("Updating Database Service %q...\n", c.Name)
-
-		res, err := cs.UpdateDbaasServiceKafkaWithResponse(ctx, oapi.DbaasServiceName(c.Name), databaseService)
+		var res *oapi.UpdateDbaasServiceKafkaResponse
+		decorateAsyncOperation(fmt.Sprintf("Updating Database Service %q...", c.Name), func() {
+			res, err = cs.UpdateDbaasServiceKafkaWithResponse(ctx, oapi.DbaasServiceName(c.Name), databaseService)
+		})
 		if err != nil {
 			return err
 		}

--- a/cmd/dbaas_update_mysql.go
+++ b/cmd/dbaas_update_mysql.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *dbServiceUpdateCmd) updateMysql(cmd *cobra.Command, _ []string) error {
+func (c *dbaasServiceUpdateCmd) updateMysql(cmd *cobra.Command, _ []string) error {
 	var updated bool
 
 	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
@@ -93,7 +93,7 @@ func (c *dbServiceUpdateCmd) updateMysql(cmd *cobra.Command, _ []string) error {
 	}
 
 	if !gQuiet {
-		return c.outputFunc((&dbServiceShowCmd{
+		return c.outputFunc((&dbaasServiceShowCmd{
 			Name: c.Name,
 			Zone: c.Zone,
 		}).showDatabaseServiceMysql(ctx))

--- a/cmd/dbaas_update_mysql.go
+++ b/cmd/dbaas_update_mysql.go
@@ -81,9 +81,10 @@ func (c *dbaasServiceUpdateCmd) updateMysql(cmd *cobra.Command, _ []string) erro
 	}
 
 	if updated {
-		fmt.Printf("Updating Database Service %q...\n", c.Name)
-
-		res, err := cs.UpdateDbaasServiceMysqlWithResponse(ctx, oapi.DbaasServiceName(c.Name), databaseService)
+		var res *oapi.UpdateDbaasServiceMysqlResponse
+		decorateAsyncOperation(fmt.Sprintf("Updating Database Service %q...", c.Name), func() {
+			res, err = cs.UpdateDbaasServiceMysqlWithResponse(ctx, oapi.DbaasServiceName(c.Name), databaseService)
+		})
 		if err != nil {
 			return err
 		}

--- a/cmd/dbaas_update_pg.go
+++ b/cmd/dbaas_update_pg.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *dbServiceUpdateCmd) updatePG(cmd *cobra.Command, _ []string) error {
+func (c *dbaasServiceUpdateCmd) updatePG(cmd *cobra.Command, _ []string) error {
 	var updated bool
 
 	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
@@ -117,7 +117,7 @@ func (c *dbServiceUpdateCmd) updatePG(cmd *cobra.Command, _ []string) error {
 	}
 
 	if !gQuiet {
-		return c.outputFunc((&dbServiceShowCmd{
+		return c.outputFunc((&dbaasServiceShowCmd{
 			Name: c.Name,
 			Zone: c.Zone,
 		}).showDatabaseServicePG(ctx))

--- a/cmd/dbaas_update_pg.go
+++ b/cmd/dbaas_update_pg.go
@@ -105,9 +105,10 @@ func (c *dbaasServiceUpdateCmd) updatePG(cmd *cobra.Command, _ []string) error {
 	}
 
 	if updated {
-		fmt.Printf("Updating Database Service %q...\n", c.Name)
-
-		res, err := cs.UpdateDbaasServicePgWithResponse(ctx, oapi.DbaasServiceName(c.Name), databaseService)
+		var res *oapi.UpdateDbaasServicePgResponse
+		decorateAsyncOperation(fmt.Sprintf("Updating Database Service %q...", c.Name), func() {
+			res, err = cs.UpdateDbaasServicePgWithResponse(ctx, oapi.DbaasServiceName(c.Name), databaseService)
+		})
 		if err != nil {
 			return err
 		}

--- a/cmd/dbaas_update_redis.go
+++ b/cmd/dbaas_update_redis.go
@@ -64,9 +64,10 @@ func (c *dbaasServiceUpdateCmd) updateRedis(cmd *cobra.Command, _ []string) erro
 	}
 
 	if updated {
-		fmt.Printf("Updating Database Service %q...\n", c.Name)
-
-		res, err := cs.UpdateDbaasServiceRedisWithResponse(ctx, oapi.DbaasServiceName(c.Name), databaseService)
+		var res *oapi.UpdateDbaasServiceRedisResponse
+		decorateAsyncOperation(fmt.Sprintf("Updating Database Service %q...", c.Name), func() {
+			res, err = cs.UpdateDbaasServiceRedisWithResponse(ctx, oapi.DbaasServiceName(c.Name), databaseService)
+		})
 		if err != nil {
 			return err
 		}

--- a/cmd/dbaas_update_redis.go
+++ b/cmd/dbaas_update_redis.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *dbServiceUpdateCmd) updateRedis(cmd *cobra.Command, _ []string) error {
+func (c *dbaasServiceUpdateCmd) updateRedis(cmd *cobra.Command, _ []string) error {
 	var updated bool
 
 	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
@@ -76,7 +76,7 @@ func (c *dbServiceUpdateCmd) updateRedis(cmd *cobra.Command, _ []string) error {
 	}
 
 	if !gQuiet {
-		return c.outputFunc((&dbServiceShowCmd{
+		return c.outputFunc((&dbaasServiceShowCmd{
 			Name: c.Name,
 			Zone: c.Zone,
 		}).showDatabaseServiceRedis(ctx))

--- a/cmd/internal/x/x.gen.go
+++ b/cmd/internal/x/x.gen.go
@@ -620,8 +620,50 @@ func XListDbaasIntegrationTypes(params *viper.Viper) (*gentleman.Response, map[s
 	return resp, decoded, nil
 }
 
+// XDeleteDbaasIntegration Delete a DBaaS Integration
+func XDeleteDbaasIntegration(paramIntegrationUuid string, params *viper.Viper) (*gentleman.Response, map[string]interface{}, error) {
+	handlerPath := "delete-dbaas-integration"
+	if xSubcommand {
+		handlerPath = "x " + handlerPath
+	}
+
+	server := viper.GetString("server")
+	if server == "" {
+		server = xServers()[viper.GetInt("server-index")]["url"]
+	}
+
+	url := server + "/dbaas-integration/{integration-uuid}"
+	url = strings.Replace(url, "{integration-uuid}", paramIntegrationUuid, 1)
+
+	req := cli.Client.Delete().URL(url)
+
+	cli.HandleBefore(handlerPath, params, req)
+
+	resp, err := req.Do()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "Request failed")
+	}
+
+	var decoded map[string]interface{}
+
+	if resp.StatusCode < 400 {
+		if err := cli.UnmarshalResponse(resp, &decoded); err != nil {
+			return nil, nil, errors.Wrap(err, "Unmarshalling response failed")
+		}
+	} else {
+		return nil, nil, errors.Errorf("HTTP %d: %s", resp.StatusCode, resp.String())
+	}
+
+	after := cli.HandleAfter(handlerPath, params, resp, decoded)
+	if after != nil {
+		decoded = after.(map[string]interface{})
+	}
+
+	return resp, decoded, nil
+}
+
 // XGetDbaasIntegration Get a DBaaS Integration
-func XGetDbaasIntegration(paramIntegrationId string, params *viper.Viper) (*gentleman.Response, map[string]interface{}, error) {
+func XGetDbaasIntegration(paramIntegrationUuid string, params *viper.Viper) (*gentleman.Response, map[string]interface{}, error) {
 	handlerPath := "get-dbaas-integration"
 	if xSubcommand {
 		handlerPath = "x " + handlerPath
@@ -632,10 +674,56 @@ func XGetDbaasIntegration(paramIntegrationId string, params *viper.Viper) (*gent
 		server = xServers()[viper.GetInt("server-index")]["url"]
 	}
 
-	url := server + "/dbaas-integration/{integration-id}"
-	url = strings.Replace(url, "{integration-id}", paramIntegrationId, 1)
+	url := server + "/dbaas-integration/{integration-uuid}"
+	url = strings.Replace(url, "{integration-uuid}", paramIntegrationUuid, 1)
 
 	req := cli.Client.Get().URL(url)
+
+	cli.HandleBefore(handlerPath, params, req)
+
+	resp, err := req.Do()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "Request failed")
+	}
+
+	var decoded map[string]interface{}
+
+	if resp.StatusCode < 400 {
+		if err := cli.UnmarshalResponse(resp, &decoded); err != nil {
+			return nil, nil, errors.Wrap(err, "Unmarshalling response failed")
+		}
+	} else {
+		return nil, nil, errors.Errorf("HTTP %d: %s", resp.StatusCode, resp.String())
+	}
+
+	after := cli.HandleAfter(handlerPath, params, resp, decoded)
+	if after != nil {
+		decoded = after.(map[string]interface{})
+	}
+
+	return resp, decoded, nil
+}
+
+// XUpdateDbaasIntegration Update a existing DBaaS integration
+func XUpdateDbaasIntegration(paramIntegrationUuid string, params *viper.Viper, body string) (*gentleman.Response, map[string]interface{}, error) {
+	handlerPath := "update-dbaas-integration"
+	if xSubcommand {
+		handlerPath = "x " + handlerPath
+	}
+
+	server := viper.GetString("server")
+	if server == "" {
+		server = xServers()[viper.GetInt("server-index")]["url"]
+	}
+
+	url := server + "/dbaas-integration/{integration-uuid}"
+	url = strings.Replace(url, "{integration-uuid}", paramIntegrationUuid, 1)
+
+	req := cli.Client.Put().URL(url)
+
+	if body != "" {
+		req = req.AddHeader("Content-Type", "application/json").BodyString(body)
+	}
 
 	cli.HandleBefore(handlerPath, params, req)
 
@@ -1258,6 +1346,98 @@ func XListDbaasServices(params *viper.Viper) (*gentleman.Response, map[string]in
 	url := server + "/dbaas-service"
 
 	req := cli.Client.Get().URL(url)
+
+	cli.HandleBefore(handlerPath, params, req)
+
+	resp, err := req.Do()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "Request failed")
+	}
+
+	var decoded map[string]interface{}
+
+	if resp.StatusCode < 400 {
+		if err := cli.UnmarshalResponse(resp, &decoded); err != nil {
+			return nil, nil, errors.Wrap(err, "Unmarshalling response failed")
+		}
+	} else {
+		return nil, nil, errors.Errorf("HTTP %d: %s", resp.StatusCode, resp.String())
+	}
+
+	after := cli.HandleAfter(handlerPath, params, resp, decoded)
+	if after != nil {
+		decoded = after.(map[string]interface{})
+	}
+
+	return resp, decoded, nil
+}
+
+// XGetDbaasServiceLogs Get logs of DBaaS service
+func XGetDbaasServiceLogs(paramServiceName string, params *viper.Viper, body string) (*gentleman.Response, map[string]interface{}, error) {
+	handlerPath := "get-dbaas-service-logs"
+	if xSubcommand {
+		handlerPath = "x " + handlerPath
+	}
+
+	server := viper.GetString("server")
+	if server == "" {
+		server = xServers()[viper.GetInt("server-index")]["url"]
+	}
+
+	url := server + "/dbaas-service-logs/{service-name}"
+	url = strings.Replace(url, "{service-name}", paramServiceName, 1)
+
+	req := cli.Client.Post().URL(url)
+
+	if body != "" {
+		req = req.AddHeader("Content-Type", "application/json").BodyString(body)
+	}
+
+	cli.HandleBefore(handlerPath, params, req)
+
+	resp, err := req.Do()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "Request failed")
+	}
+
+	var decoded map[string]interface{}
+
+	if resp.StatusCode < 400 {
+		if err := cli.UnmarshalResponse(resp, &decoded); err != nil {
+			return nil, nil, errors.Wrap(err, "Unmarshalling response failed")
+		}
+	} else {
+		return nil, nil, errors.Errorf("HTTP %d: %s", resp.StatusCode, resp.String())
+	}
+
+	after := cli.HandleAfter(handlerPath, params, resp, decoded)
+	if after != nil {
+		decoded = after.(map[string]interface{})
+	}
+
+	return resp, decoded, nil
+}
+
+// XGetDbaasServiceMetrics Get metrics of DBaaS service
+func XGetDbaasServiceMetrics(paramServiceName string, params *viper.Viper, body string) (*gentleman.Response, map[string]interface{}, error) {
+	handlerPath := "get-dbaas-service-metrics"
+	if xSubcommand {
+		handlerPath = "x " + handlerPath
+	}
+
+	server := viper.GetString("server")
+	if server == "" {
+		server = xServers()[viper.GetInt("server-index")]["url"]
+	}
+
+	url := server + "/dbaas-service-metrics/{service-name}"
+	url = strings.Replace(url, "{service-name}", paramServiceName, 1)
+
+	req := cli.Client.Post().URL(url)
+
+	if body != "" {
+		req = req.AddHeader("Content-Type", "application/json").BodyString(body)
+	}
 
 	cli.HandleBefore(handlerPath, params, req)
 
@@ -6948,7 +7128,42 @@ func xRegister(subcommand bool) {
 		var examples string
 
 		cmd := &cobra.Command{
-			Use:     "get-dbaas-integration integration-id",
+			Use:     "delete-dbaas-integration integration-uuid",
+			Short:   "Delete a DBaaS Integration",
+			Long:    cli.Markdown("Delete a DBaaS Integration"),
+			Example: examples,
+			Args:    cobra.MinimumNArgs(1),
+			Run: func(cmd *cobra.Command, args []string) {
+
+				_, decoded, err := XDeleteDbaasIntegration(args[0], params)
+				if err != nil {
+					log.Fatal().Err(err).Msg("Error calling operation")
+				}
+
+				if err := cli.Formatter.Format(decoded); err != nil {
+					log.Fatal().Err(err).Msg("Formatting failed")
+				}
+
+			},
+		}
+
+		root.AddCommand(cmd)
+
+		cli.SetCustomFlags(cmd)
+
+		if cmd.Flags().HasFlags() {
+			params.BindPFlags(cmd.Flags())
+		}
+
+	}()
+
+	func() {
+		params := viper.New()
+
+		var examples string
+
+		cmd := &cobra.Command{
+			Use:     "get-dbaas-integration integration-uuid",
 			Short:   "Get a DBaaS Integration",
 			Long:    cli.Markdown("Get a DBaaS Integration"),
 			Example: examples,
@@ -6956,6 +7171,45 @@ func xRegister(subcommand bool) {
 			Run: func(cmd *cobra.Command, args []string) {
 
 				_, decoded, err := XGetDbaasIntegration(args[0], params)
+				if err != nil {
+					log.Fatal().Err(err).Msg("Error calling operation")
+				}
+
+				if err := cli.Formatter.Format(decoded); err != nil {
+					log.Fatal().Err(err).Msg("Formatting failed")
+				}
+
+			},
+		}
+
+		root.AddCommand(cmd)
+
+		cli.SetCustomFlags(cmd)
+
+		if cmd.Flags().HasFlags() {
+			params.BindPFlags(cmd.Flags())
+		}
+
+	}()
+
+	func() {
+		params := viper.New()
+
+		var examples string
+
+		cmd := &cobra.Command{
+			Use:     "update-dbaas-integration integration-uuid",
+			Short:   "Update a existing DBaaS integration",
+			Long:    cli.Markdown("Update a existing DBaaS integration\n## Request Schema (application/json)\n\nproperties:\n  settings:\n    description: Integration settings\n    type: object\nrequired:\n- settings\ntype: object\n"),
+			Example: examples,
+			Args:    cobra.MinimumNArgs(1),
+			Run: func(cmd *cobra.Command, args []string) {
+				body, err := cli.GetBody("application/json", args[1:])
+				if err != nil {
+					log.Fatal().Err(err).Msg("Unable to get body")
+				}
+
+				_, decoded, err := XUpdateDbaasIntegration(args[0], params, body)
 				if err != nil {
 					log.Fatal().Err(err).Msg("Error calling operation")
 				}
@@ -7482,6 +7736,84 @@ func xRegister(subcommand bool) {
 			Run: func(cmd *cobra.Command, args []string) {
 
 				_, decoded, err := XListDbaasServices(params)
+				if err != nil {
+					log.Fatal().Err(err).Msg("Error calling operation")
+				}
+
+				if err := cli.Formatter.Format(decoded); err != nil {
+					log.Fatal().Err(err).Msg("Formatting failed")
+				}
+
+			},
+		}
+
+		root.AddCommand(cmd)
+
+		cli.SetCustomFlags(cmd)
+
+		if cmd.Flags().HasFlags() {
+			params.BindPFlags(cmd.Flags())
+		}
+
+	}()
+
+	func() {
+		params := viper.New()
+
+		var examples string
+
+		cmd := &cobra.Command{
+			Use:     "get-dbaas-service-logs service-name",
+			Short:   "Get logs of DBaaS service",
+			Long:    cli.Markdown("Get logs of DBaaS service\n## Request Schema (application/json)\n\nproperties:\n  limit:\n    description: 'How many log entries to receive at most, up to 500 (default: 100)'\n    format: int64\n    maximum: 500\n    minimum: 1\n    type: integer\n  offset:\n    description: Opaque offset identifier\n    type: string\n  sort-order:\n    $ref: '#/components/schemas/enum-sort-order'\ntype: object\n"),
+			Example: examples,
+			Args:    cobra.MinimumNArgs(1),
+			Run: func(cmd *cobra.Command, args []string) {
+				body, err := cli.GetBody("application/json", args[1:])
+				if err != nil {
+					log.Fatal().Err(err).Msg("Unable to get body")
+				}
+
+				_, decoded, err := XGetDbaasServiceLogs(args[0], params, body)
+				if err != nil {
+					log.Fatal().Err(err).Msg("Error calling operation")
+				}
+
+				if err := cli.Formatter.Format(decoded); err != nil {
+					log.Fatal().Err(err).Msg("Formatting failed")
+				}
+
+			},
+		}
+
+		root.AddCommand(cmd)
+
+		cli.SetCustomFlags(cmd)
+
+		if cmd.Flags().HasFlags() {
+			params.BindPFlags(cmd.Flags())
+		}
+
+	}()
+
+	func() {
+		params := viper.New()
+
+		var examples string
+
+		cmd := &cobra.Command{
+			Use:     "get-dbaas-service-metrics service-name",
+			Short:   "Get metrics of DBaaS service",
+			Long:    cli.Markdown("Get metrics of DBaaS service\n## Request Schema (application/json)\n\nproperties:\n  period:\n    description: 'Metrics time period (default: hour)'\n    enum:\n    - hour\n    - week\n    - year\n    - month\n    - day\n    type: string\ntype: object\n"),
+			Example: examples,
+			Args:    cobra.MinimumNArgs(1),
+			Run: func(cmd *cobra.Command, args []string) {
+				body, err := cli.GetBody("application/json", args[1:])
+				if err != nil {
+					log.Fatal().Err(err).Msg("Unable to get body")
+				}
+
+				_, decoded, err := XGetDbaasServiceMetrics(args[0], params, body)
 				if err != nil {
 					log.Fatal().Err(err).Msg("Error calling operation")
 				}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/exoscale/egoscale v0.83.0
+	github.com/exoscale/egoscale v0.83.2
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/exoscale/egoscale v0.83.0 h1:mo+eKegti0ALe6bHYfdeDb74w89tjcBPOTYn2rQ+Iss=
-github.com/exoscale/egoscale v0.83.0/go.mod h1:C1e4bJE8Ml1GylP14hOMGdCfgDDf9hMLsbny1QWsemw=
+github.com/exoscale/egoscale v0.83.2 h1:x1av63s5ayqWmVpKyTtu+KI7TK5DyCB8NgCz3g3zc40=
+github.com/exoscale/egoscale v0.83.2/go.mod h1:C1e4bJE8Ml1GylP14hOMGdCfgDDf9hMLsbny1QWsemw=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+0.83.2
+------
+
+- change: v2: refresh code generated from public API spec
+
+0.83.1
+------
+
+- change: v2: refresh code generated from public API spec
+
 0.83.0
 ------
 

--- a/vendor/github.com/exoscale/egoscale/v2/oapi/oapi.gen.go
+++ b/vendor/github.com/exoscale/egoscale/v2/oapi/oapi.gen.go
@@ -205,6 +205,13 @@ const (
 	EnumServiceStateRunning EnumServiceState = "running"
 )
 
+// Defines values for EnumSortOrder.
+const (
+	EnumSortOrderAsc EnumSortOrder = "asc"
+
+	EnumSortOrderDesc EnumSortOrder = "desc"
+)
+
 // Defines values for InstanceState.
 const (
 	InstanceStateDestroyed InstanceState = "destroyed"
@@ -629,6 +636,36 @@ type DbaasBackupConfig struct {
 
 // DbaasIntegration defines model for dbaas-integration.
 type DbaasIntegration struct {
+	// Description of the integration
+	Description *string `json:"description,omitempty"`
+
+	// Destination service name
+	Dest *string `json:"dest,omitempty"`
+
+	// Integration id
+	Id *string `json:"id,omitempty"`
+
+	// Whether the integration is active or not
+	IsActive *bool `json:"is-active,omitempty"`
+
+	// Whether the integration is enabled or not
+	IsEnabled *bool `json:"is-enabled,omitempty"`
+
+	// Integration settings
+	Settings *map[string]interface{} `json:"settings,omitempty"`
+
+	// Source service name
+	Source *string `json:"source,omitempty"`
+
+	// Integration status
+	Status *string `json:"status,omitempty"`
+
+	// Integration type
+	Type *string `json:"type,omitempty"`
+}
+
+// DbaasIntegrationType defines model for dbaas-integration-type.
+type DbaasIntegrationType struct {
 	// The description of the destination service types.
 	DestDescription *string `json:"dest-description,omitempty"`
 
@@ -744,8 +781,11 @@ type DbaasServiceCommon struct {
 	CreatedAt *time.Time `json:"created-at,omitempty"`
 
 	// TODO UNIT disk space for data storage
-	DiskSize *int64           `json:"disk-size,omitempty"`
-	Name     DbaasServiceName `json:"name"`
+	DiskSize *int64 `json:"disk-size,omitempty"`
+
+	// Service integrations
+	Integrations *[]DbaasIntegration `json:"integrations,omitempty"`
+	Name         DbaasServiceName    `json:"name"`
 
 	// Number of service nodes in the active plan
 	NodeCount *int64 `json:"node-count,omitempty"`
@@ -872,6 +912,9 @@ type DbaasServiceKafka struct {
 	// TODO UNIT disk space for data storage
 	DiskSize *int64 `json:"disk-size,omitempty"`
 
+	// Service integrations
+	Integrations *[]DbaasIntegration `json:"integrations,omitempty"`
+
 	// Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'
 	IpFilter *[]string `json:"ip-filter,omitempty"`
 
@@ -946,6 +989,18 @@ type DbaasServiceKafka struct {
 	Version *string `json:"version,omitempty"`
 }
 
+// DbaasServiceLogs defines model for dbaas-service-logs.
+type DbaasServiceLogs struct {
+	FirstLogOffset *string `json:"first-log-offset,omitempty"`
+	Logs           *[]struct {
+		Message *string `json:"message,omitempty"`
+		Node    *string `json:"node,omitempty"`
+		Time    *string `json:"time,omitempty"`
+		Unit    *string `json:"unit,omitempty"`
+	} `json:"logs,omitempty"`
+	Offset *string `json:"offset,omitempty"`
+}
+
 // Automatic maintenance settings
 type DbaasServiceMaintenance struct {
 	// Day of week for installing updates
@@ -1003,6 +1058,9 @@ type DbaasServiceMysql struct {
 
 	// TODO UNIT disk space for data storage
 	DiskSize *int64 `json:"disk-size,omitempty"`
+
+	// Service integrations
+	Integrations *[]DbaasIntegration `json:"integrations,omitempty"`
 
 	// Allowed CIDR address blocks for incoming connections
 	IpFilter *[]string `json:"ip-filter,omitempty"`
@@ -1145,6 +1203,9 @@ type DbaasServicePg struct {
 	// TODO UNIT disk space for data storage
 	DiskSize *int64 `json:"disk-size,omitempty"`
 
+	// Service integrations
+	Integrations *[]DbaasIntegration `json:"integrations,omitempty"`
+
 	// Allowed CIDR address blocks for incoming connections
 	IpFilter *[]string `json:"ip-filter,omitempty"`
 
@@ -1253,6 +1314,9 @@ type DbaasServiceRedis struct {
 
 	// TODO UNIT disk space for data storage
 	DiskSize *int64 `json:"disk-size,omitempty"`
+
+	// Service integrations
+	Integrations *[]DbaasIntegration `json:"integrations,omitempty"`
 
 	// Allowed CIDR address blocks for incoming connections
 	IpFilter *[]string `json:"ip-filter,omitempty"`
@@ -1478,6 +1542,9 @@ type EnumPgVariant string
 
 // EnumServiceState defines model for enum-service-state.
 type EnumServiceState string
+
+// EnumSortOrder defines model for enum-sort-order.
+type EnumSortOrder string
 
 // A notable event which happened on the infrastructure
 type Event struct {
@@ -2221,6 +2288,27 @@ type CreateAntiAffinityGroupJSONBody struct {
 	Name string `json:"name"`
 }
 
+// CreateDbaasIntegrationJSONBody defines parameters for CreateDbaasIntegration.
+type CreateDbaasIntegrationJSONBody struct {
+	// A destination service
+	DestService string `json:"dest-service"`
+
+	// Integration type
+	IntegrationType string `json:"integration-type"`
+
+	// Integration settings
+	Settings *map[string]interface{} `json:"settings,omitempty"`
+
+	// A source service
+	SourceService string `json:"source-service"`
+}
+
+// UpdateDbaasIntegrationJSONBody defines parameters for UpdateDbaasIntegration.
+type UpdateDbaasIntegrationJSONBody struct {
+	// Integration settings
+	Settings map[string]interface{} `json:"settings"`
+}
+
 // CreateDbaasServiceKafkaJSONBody defines parameters for CreateDbaasServiceKafka.
 type CreateDbaasServiceKafkaJSONBody struct {
 	// Kafka authentication methods
@@ -2648,6 +2736,25 @@ type CreateDbaasServiceJSONBody struct {
 
 // CreateDbaasServiceJSONBodyMaintenanceDow defines parameters for CreateDbaasService.
 type CreateDbaasServiceJSONBodyMaintenanceDow string
+
+// GetDbaasServiceLogsJSONBody defines parameters for GetDbaasServiceLogs.
+type GetDbaasServiceLogsJSONBody struct {
+	// How many log entries to receive at most, up to 500 (default: 100)
+	Limit *int64 `json:"limit,omitempty"`
+
+	// Opaque offset identifier
+	Offset    *string        `json:"offset,omitempty"`
+	SortOrder *EnumSortOrder `json:"sort-order,omitempty"`
+}
+
+// GetDbaasServiceMetricsJSONBody defines parameters for GetDbaasServiceMetrics.
+type GetDbaasServiceMetricsJSONBody struct {
+	// Metrics time period (default: hour)
+	Period *GetDbaasServiceMetricsJSONBodyPeriod `json:"period,omitempty"`
+}
+
+// GetDbaasServiceMetricsJSONBodyPeriod defines parameters for GetDbaasServiceMetrics.
+type GetDbaasServiceMetricsJSONBodyPeriod string
 
 // UpdateDbaasServiceJSONBody defines parameters for UpdateDbaasService.
 type UpdateDbaasServiceJSONBody struct {
@@ -3383,6 +3490,12 @@ type CreateAccessKeyJSONRequestBody CreateAccessKeyJSONBody
 // CreateAntiAffinityGroupJSONRequestBody defines body for CreateAntiAffinityGroup for application/json ContentType.
 type CreateAntiAffinityGroupJSONRequestBody CreateAntiAffinityGroupJSONBody
 
+// CreateDbaasIntegrationJSONRequestBody defines body for CreateDbaasIntegration for application/json ContentType.
+type CreateDbaasIntegrationJSONRequestBody CreateDbaasIntegrationJSONBody
+
+// UpdateDbaasIntegrationJSONRequestBody defines body for UpdateDbaasIntegration for application/json ContentType.
+type UpdateDbaasIntegrationJSONRequestBody UpdateDbaasIntegrationJSONBody
+
 // CreateDbaasServiceKafkaJSONRequestBody defines body for CreateDbaasServiceKafka for application/json ContentType.
 type CreateDbaasServiceKafkaJSONRequestBody CreateDbaasServiceKafkaJSONBody
 
@@ -3409,6 +3522,12 @@ type UpdateDbaasServiceRedisJSONRequestBody UpdateDbaasServiceRedisJSONBody
 
 // CreateDbaasServiceJSONRequestBody defines body for CreateDbaasService for application/json ContentType.
 type CreateDbaasServiceJSONRequestBody CreateDbaasServiceJSONBody
+
+// GetDbaasServiceLogsJSONRequestBody defines body for GetDbaasServiceLogs for application/json ContentType.
+type GetDbaasServiceLogsJSONRequestBody GetDbaasServiceLogsJSONBody
+
+// GetDbaasServiceMetricsJSONRequestBody defines body for GetDbaasServiceMetrics for application/json ContentType.
+type GetDbaasServiceMetricsJSONRequestBody GetDbaasServiceMetricsJSONBody
 
 // UpdateDbaasServiceJSONRequestBody defines body for UpdateDbaasService for application/json ContentType.
 type UpdateDbaasServiceJSONRequestBody UpdateDbaasServiceJSONBody
@@ -3758,11 +3877,27 @@ type ClientInterface interface {
 	// GetDbaasCaCertificate request
 	GetDbaasCaCertificate(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// CreateDbaasIntegration request with any body
+	CreateDbaasIntegrationWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateDbaasIntegration(ctx context.Context, body CreateDbaasIntegrationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListDbaasIntegrationSettings request
 	ListDbaasIntegrationSettings(ctx context.Context, integrationType string, sourceType string, destType string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListDbaasIntegrationTypes request
 	ListDbaasIntegrationTypes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteDbaasIntegration request
+	DeleteDbaasIntegration(ctx context.Context, integrationUuid string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetDbaasIntegration request
+	GetDbaasIntegration(ctx context.Context, integrationUuid string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateDbaasIntegration request with any body
+	UpdateDbaasIntegrationWithBody(ctx context.Context, integrationUuid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateDbaasIntegration(ctx context.Context, integrationUuid string, body UpdateDbaasIntegrationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetDbaasServiceKafka request
 	GetDbaasServiceKafka(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -3823,6 +3958,16 @@ type ClientInterface interface {
 	CreateDbaasServiceWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	CreateDbaasService(ctx context.Context, body CreateDbaasServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetDbaasServiceLogs request with any body
+	GetDbaasServiceLogsWithBody(ctx context.Context, serviceName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	GetDbaasServiceLogs(ctx context.Context, serviceName string, body GetDbaasServiceLogsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetDbaasServiceMetrics request with any body
+	GetDbaasServiceMetricsWithBody(ctx context.Context, serviceName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	GetDbaasServiceMetrics(ctx context.Context, serviceName string, body GetDbaasServiceMetricsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListDbaasServiceTypes request
 	ListDbaasServiceTypes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4420,6 +4565,30 @@ func (c *Client) GetDbaasCaCertificate(ctx context.Context, reqEditors ...Reques
 	return c.Client.Do(req)
 }
 
+func (c *Client) CreateDbaasIntegrationWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateDbaasIntegrationRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateDbaasIntegration(ctx context.Context, body CreateDbaasIntegrationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateDbaasIntegrationRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) ListDbaasIntegrationSettings(ctx context.Context, integrationType string, sourceType string, destType string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListDbaasIntegrationSettingsRequest(c.Server, integrationType, sourceType, destType)
 	if err != nil {
@@ -4434,6 +4603,54 @@ func (c *Client) ListDbaasIntegrationSettings(ctx context.Context, integrationTy
 
 func (c *Client) ListDbaasIntegrationTypes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListDbaasIntegrationTypesRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteDbaasIntegration(ctx context.Context, integrationUuid string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteDbaasIntegrationRequest(c.Server, integrationUuid)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetDbaasIntegration(ctx context.Context, integrationUuid string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetDbaasIntegrationRequest(c.Server, integrationUuid)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateDbaasIntegrationWithBody(ctx context.Context, integrationUuid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateDbaasIntegrationRequestWithBody(c.Server, integrationUuid, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateDbaasIntegration(ctx context.Context, integrationUuid string, body UpdateDbaasIntegrationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateDbaasIntegrationRequest(c.Server, integrationUuid, body)
 	if err != nil {
 		return nil, err
 	}
@@ -4710,6 +4927,54 @@ func (c *Client) CreateDbaasServiceWithBody(ctx context.Context, contentType str
 
 func (c *Client) CreateDbaasService(ctx context.Context, body CreateDbaasServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewCreateDbaasServiceRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetDbaasServiceLogsWithBody(ctx context.Context, serviceName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetDbaasServiceLogsRequestWithBody(c.Server, serviceName, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetDbaasServiceLogs(ctx context.Context, serviceName string, body GetDbaasServiceLogsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetDbaasServiceLogsRequest(c.Server, serviceName, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetDbaasServiceMetricsWithBody(ctx context.Context, serviceName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetDbaasServiceMetricsRequestWithBody(c.Server, serviceName, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetDbaasServiceMetrics(ctx context.Context, serviceName string, body GetDbaasServiceMetricsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetDbaasServiceMetricsRequest(c.Server, serviceName, body)
 	if err != nil {
 		return nil, err
 	}
@@ -7003,6 +7268,46 @@ func NewGetDbaasCaCertificateRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewCreateDbaasIntegrationRequest calls the generic CreateDbaasIntegration builder with application/json body
+func NewCreateDbaasIntegrationRequest(server string, body CreateDbaasIntegrationJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateDbaasIntegrationRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateDbaasIntegrationRequestWithBody generates requests for CreateDbaasIntegration with any type of body
+func NewCreateDbaasIntegrationRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-integration")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewListDbaasIntegrationSettingsRequest generates requests for ListDbaasIntegrationSettings
 func NewListDbaasIntegrationSettingsRequest(server string, integrationType string, sourceType string, destType string) (*http.Request, error) {
 	var err error
@@ -7074,6 +7379,121 @@ func NewListDbaasIntegrationTypesRequest(server string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewDeleteDbaasIntegrationRequest generates requests for DeleteDbaasIntegration
+func NewDeleteDbaasIntegrationRequest(server string, integrationUuid string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "integration-uuid", runtime.ParamLocationPath, integrationUuid)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-integration/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetDbaasIntegrationRequest generates requests for GetDbaasIntegration
+func NewGetDbaasIntegrationRequest(server string, integrationUuid string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "integration-uuid", runtime.ParamLocationPath, integrationUuid)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-integration/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateDbaasIntegrationRequest calls the generic UpdateDbaasIntegration builder with application/json body
+func NewUpdateDbaasIntegrationRequest(server string, integrationUuid string, body UpdateDbaasIntegrationJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateDbaasIntegrationRequestWithBody(server, integrationUuid, "application/json", bodyReader)
+}
+
+// NewUpdateDbaasIntegrationRequestWithBody generates requests for UpdateDbaasIntegration with any type of body
+func NewUpdateDbaasIntegrationRequestWithBody(server string, integrationUuid string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "integration-uuid", runtime.ParamLocationPath, integrationUuid)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-integration/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -7638,6 +8058,100 @@ func NewCreateDbaasServiceRequestWithBody(server string, contentType string, bod
 	}
 
 	operationPath := fmt.Sprintf("/dbaas-service")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetDbaasServiceLogsRequest calls the generic GetDbaasServiceLogs builder with application/json body
+func NewGetDbaasServiceLogsRequest(server string, serviceName string, body GetDbaasServiceLogsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewGetDbaasServiceLogsRequestWithBody(server, serviceName, "application/json", bodyReader)
+}
+
+// NewGetDbaasServiceLogsRequestWithBody generates requests for GetDbaasServiceLogs with any type of body
+func NewGetDbaasServiceLogsRequestWithBody(server string, serviceName string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "service-name", runtime.ParamLocationPath, serviceName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-service-logs/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetDbaasServiceMetricsRequest calls the generic GetDbaasServiceMetrics builder with application/json body
+func NewGetDbaasServiceMetricsRequest(server string, serviceName string, body GetDbaasServiceMetricsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewGetDbaasServiceMetricsRequestWithBody(server, serviceName, "application/json", bodyReader)
+}
+
+// NewGetDbaasServiceMetricsRequestWithBody generates requests for GetDbaasServiceMetrics with any type of body
+func NewGetDbaasServiceMetricsRequestWithBody(server string, serviceName string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "service-name", runtime.ParamLocationPath, serviceName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/dbaas-service-metrics/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -12365,11 +12879,27 @@ type ClientWithResponsesInterface interface {
 	// GetDbaasCaCertificate request
 	GetDbaasCaCertificateWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetDbaasCaCertificateResponse, error)
 
+	// CreateDbaasIntegration request with any body
+	CreateDbaasIntegrationWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDbaasIntegrationResponse, error)
+
+	CreateDbaasIntegrationWithResponse(ctx context.Context, body CreateDbaasIntegrationJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDbaasIntegrationResponse, error)
+
 	// ListDbaasIntegrationSettings request
 	ListDbaasIntegrationSettingsWithResponse(ctx context.Context, integrationType string, sourceType string, destType string, reqEditors ...RequestEditorFn) (*ListDbaasIntegrationSettingsResponse, error)
 
 	// ListDbaasIntegrationTypes request
 	ListDbaasIntegrationTypesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListDbaasIntegrationTypesResponse, error)
+
+	// DeleteDbaasIntegration request
+	DeleteDbaasIntegrationWithResponse(ctx context.Context, integrationUuid string, reqEditors ...RequestEditorFn) (*DeleteDbaasIntegrationResponse, error)
+
+	// GetDbaasIntegration request
+	GetDbaasIntegrationWithResponse(ctx context.Context, integrationUuid string, reqEditors ...RequestEditorFn) (*GetDbaasIntegrationResponse, error)
+
+	// UpdateDbaasIntegration request with any body
+	UpdateDbaasIntegrationWithBodyWithResponse(ctx context.Context, integrationUuid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateDbaasIntegrationResponse, error)
+
+	UpdateDbaasIntegrationWithResponse(ctx context.Context, integrationUuid string, body UpdateDbaasIntegrationJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateDbaasIntegrationResponse, error)
 
 	// GetDbaasServiceKafka request
 	GetDbaasServiceKafkaWithResponse(ctx context.Context, name DbaasServiceName, reqEditors ...RequestEditorFn) (*GetDbaasServiceKafkaResponse, error)
@@ -12430,6 +12960,16 @@ type ClientWithResponsesInterface interface {
 	CreateDbaasServiceWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDbaasServiceResponse, error)
 
 	CreateDbaasServiceWithResponse(ctx context.Context, body CreateDbaasServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDbaasServiceResponse, error)
+
+	// GetDbaasServiceLogs request with any body
+	GetDbaasServiceLogsWithBodyWithResponse(ctx context.Context, serviceName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GetDbaasServiceLogsResponse, error)
+
+	GetDbaasServiceLogsWithResponse(ctx context.Context, serviceName string, body GetDbaasServiceLogsJSONRequestBody, reqEditors ...RequestEditorFn) (*GetDbaasServiceLogsResponse, error)
+
+	// GetDbaasServiceMetrics request with any body
+	GetDbaasServiceMetricsWithBodyWithResponse(ctx context.Context, serviceName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GetDbaasServiceMetricsResponse, error)
+
+	GetDbaasServiceMetricsWithResponse(ctx context.Context, serviceName string, body GetDbaasServiceMetricsJSONRequestBody, reqEditors ...RequestEditorFn) (*GetDbaasServiceMetricsResponse, error)
 
 	// ListDbaasServiceTypes request
 	ListDbaasServiceTypesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListDbaasServiceTypesResponse, error)
@@ -13123,6 +13663,28 @@ func (r GetDbaasCaCertificateResponse) StatusCode() int {
 	return 0
 }
 
+type CreateDbaasIntegrationResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *DbaasIntegration
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateDbaasIntegrationResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateDbaasIntegrationResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type ListDbaasIntegrationSettingsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -13157,7 +13719,7 @@ type ListDbaasIntegrationTypesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
-		DbaasIntegrations *[]DbaasIntegration `json:"dbaas-integrations,omitempty"`
+		DbaasIntegrationTypes *[]DbaasIntegrationType `json:"dbaas-integration-types,omitempty"`
 	}
 }
 
@@ -13171,6 +13733,72 @@ func (r ListDbaasIntegrationTypesResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ListDbaasIntegrationTypesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteDbaasIntegrationResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *DbaasIntegration
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteDbaasIntegrationResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteDbaasIntegrationResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetDbaasIntegrationResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *DbaasIntegration
+}
+
+// Status returns HTTPResponse.Status
+func (r GetDbaasIntegrationResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetDbaasIntegrationResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateDbaasIntegrationResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *DbaasIntegration
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateDbaasIntegrationResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateDbaasIntegrationResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -13481,6 +14109,52 @@ func (r CreateDbaasServiceResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r CreateDbaasServiceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetDbaasServiceLogsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *DbaasServiceLogs
+}
+
+// Status returns HTTPResponse.Status
+func (r GetDbaasServiceLogsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetDbaasServiceLogsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetDbaasServiceMetricsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Metrics *map[string]interface{} `json:"metrics,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetDbaasServiceMetricsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetDbaasServiceMetricsResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -16306,6 +16980,23 @@ func (c *ClientWithResponses) GetDbaasCaCertificateWithResponse(ctx context.Cont
 	return ParseGetDbaasCaCertificateResponse(rsp)
 }
 
+// CreateDbaasIntegrationWithBodyWithResponse request with arbitrary body returning *CreateDbaasIntegrationResponse
+func (c *ClientWithResponses) CreateDbaasIntegrationWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDbaasIntegrationResponse, error) {
+	rsp, err := c.CreateDbaasIntegrationWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateDbaasIntegrationResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateDbaasIntegrationWithResponse(ctx context.Context, body CreateDbaasIntegrationJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDbaasIntegrationResponse, error) {
+	rsp, err := c.CreateDbaasIntegration(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateDbaasIntegrationResponse(rsp)
+}
+
 // ListDbaasIntegrationSettingsWithResponse request returning *ListDbaasIntegrationSettingsResponse
 func (c *ClientWithResponses) ListDbaasIntegrationSettingsWithResponse(ctx context.Context, integrationType string, sourceType string, destType string, reqEditors ...RequestEditorFn) (*ListDbaasIntegrationSettingsResponse, error) {
 	rsp, err := c.ListDbaasIntegrationSettings(ctx, integrationType, sourceType, destType, reqEditors...)
@@ -16322,6 +17013,41 @@ func (c *ClientWithResponses) ListDbaasIntegrationTypesWithResponse(ctx context.
 		return nil, err
 	}
 	return ParseListDbaasIntegrationTypesResponse(rsp)
+}
+
+// DeleteDbaasIntegrationWithResponse request returning *DeleteDbaasIntegrationResponse
+func (c *ClientWithResponses) DeleteDbaasIntegrationWithResponse(ctx context.Context, integrationUuid string, reqEditors ...RequestEditorFn) (*DeleteDbaasIntegrationResponse, error) {
+	rsp, err := c.DeleteDbaasIntegration(ctx, integrationUuid, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteDbaasIntegrationResponse(rsp)
+}
+
+// GetDbaasIntegrationWithResponse request returning *GetDbaasIntegrationResponse
+func (c *ClientWithResponses) GetDbaasIntegrationWithResponse(ctx context.Context, integrationUuid string, reqEditors ...RequestEditorFn) (*GetDbaasIntegrationResponse, error) {
+	rsp, err := c.GetDbaasIntegration(ctx, integrationUuid, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetDbaasIntegrationResponse(rsp)
+}
+
+// UpdateDbaasIntegrationWithBodyWithResponse request with arbitrary body returning *UpdateDbaasIntegrationResponse
+func (c *ClientWithResponses) UpdateDbaasIntegrationWithBodyWithResponse(ctx context.Context, integrationUuid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateDbaasIntegrationResponse, error) {
+	rsp, err := c.UpdateDbaasIntegrationWithBody(ctx, integrationUuid, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateDbaasIntegrationResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateDbaasIntegrationWithResponse(ctx context.Context, integrationUuid string, body UpdateDbaasIntegrationJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateDbaasIntegrationResponse, error) {
+	rsp, err := c.UpdateDbaasIntegration(ctx, integrationUuid, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateDbaasIntegrationResponse(rsp)
 }
 
 // GetDbaasServiceKafkaWithResponse request returning *GetDbaasServiceKafkaResponse
@@ -16520,6 +17246,40 @@ func (c *ClientWithResponses) CreateDbaasServiceWithResponse(ctx context.Context
 		return nil, err
 	}
 	return ParseCreateDbaasServiceResponse(rsp)
+}
+
+// GetDbaasServiceLogsWithBodyWithResponse request with arbitrary body returning *GetDbaasServiceLogsResponse
+func (c *ClientWithResponses) GetDbaasServiceLogsWithBodyWithResponse(ctx context.Context, serviceName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GetDbaasServiceLogsResponse, error) {
+	rsp, err := c.GetDbaasServiceLogsWithBody(ctx, serviceName, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetDbaasServiceLogsResponse(rsp)
+}
+
+func (c *ClientWithResponses) GetDbaasServiceLogsWithResponse(ctx context.Context, serviceName string, body GetDbaasServiceLogsJSONRequestBody, reqEditors ...RequestEditorFn) (*GetDbaasServiceLogsResponse, error) {
+	rsp, err := c.GetDbaasServiceLogs(ctx, serviceName, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetDbaasServiceLogsResponse(rsp)
+}
+
+// GetDbaasServiceMetricsWithBodyWithResponse request with arbitrary body returning *GetDbaasServiceMetricsResponse
+func (c *ClientWithResponses) GetDbaasServiceMetricsWithBodyWithResponse(ctx context.Context, serviceName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GetDbaasServiceMetricsResponse, error) {
+	rsp, err := c.GetDbaasServiceMetricsWithBody(ctx, serviceName, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetDbaasServiceMetricsResponse(rsp)
+}
+
+func (c *ClientWithResponses) GetDbaasServiceMetricsWithResponse(ctx context.Context, serviceName string, body GetDbaasServiceMetricsJSONRequestBody, reqEditors ...RequestEditorFn) (*GetDbaasServiceMetricsResponse, error) {
+	rsp, err := c.GetDbaasServiceMetrics(ctx, serviceName, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetDbaasServiceMetricsResponse(rsp)
 }
 
 // ListDbaasServiceTypesWithResponse request returning *ListDbaasServiceTypesResponse
@@ -18223,6 +18983,32 @@ func ParseGetDbaasCaCertificateResponse(rsp *http.Response) (*GetDbaasCaCertific
 	return response, nil
 }
 
+// ParseCreateDbaasIntegrationResponse parses an HTTP response from a CreateDbaasIntegrationWithResponse call
+func ParseCreateDbaasIntegrationResponse(rsp *http.Response) (*CreateDbaasIntegrationResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateDbaasIntegrationResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DbaasIntegration
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseListDbaasIntegrationSettingsResponse parses an HTTP response from a ListDbaasIntegrationSettingsWithResponse call
 func ParseListDbaasIntegrationSettingsResponse(rsp *http.Response) (*ListDbaasIntegrationSettingsResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -18273,8 +19059,86 @@ func ParseListDbaasIntegrationTypesResponse(rsp *http.Response) (*ListDbaasInteg
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
-			DbaasIntegrations *[]DbaasIntegration `json:"dbaas-integrations,omitempty"`
+			DbaasIntegrationTypes *[]DbaasIntegrationType `json:"dbaas-integration-types,omitempty"`
 		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteDbaasIntegrationResponse parses an HTTP response from a DeleteDbaasIntegrationWithResponse call
+func ParseDeleteDbaasIntegrationResponse(rsp *http.Response) (*DeleteDbaasIntegrationResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteDbaasIntegrationResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DbaasIntegration
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetDbaasIntegrationResponse parses an HTTP response from a GetDbaasIntegrationWithResponse call
+func ParseGetDbaasIntegrationResponse(rsp *http.Response) (*GetDbaasIntegrationResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetDbaasIntegrationResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DbaasIntegration
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateDbaasIntegrationResponse parses an HTTP response from a UpdateDbaasIntegrationWithResponse call
+func ParseUpdateDbaasIntegrationResponse(rsp *http.Response) (*UpdateDbaasIntegrationResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateDbaasIntegrationResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DbaasIntegration
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18641,6 +19505,60 @@ func ParseCreateDbaasServiceResponse(rsp *http.Response) (*CreateDbaasServiceRes
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest DbaasServiceCommon
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetDbaasServiceLogsResponse parses an HTTP response from a GetDbaasServiceLogsWithResponse call
+func ParseGetDbaasServiceLogsResponse(rsp *http.Response) (*GetDbaasServiceLogsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetDbaasServiceLogsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DbaasServiceLogs
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetDbaasServiceMetricsResponse parses an HTTP response from a GetDbaasServiceMetricsWithResponse call
+func ParseGetDbaasServiceMetricsResponse(rsp *http.Response) (*GetDbaasServiceMetricsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetDbaasServiceMetricsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Metrics *map[string]interface{} `json:"metrics,omitempty"`
+		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.83.0"
+const Version = "0.83.2"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.0
 ## explicit
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.83.0
+# github.com/exoscale/egoscale v0.83.2
 ## explicit
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/v2


### PR DESCRIPTION
## dbaas: add new "logs" command

This change adds a new `exo dbaas logs` command enabling Database
Service logs querying.

## dbaas: add new "metrics" command

This change adds a new `exo dbaas metrics` command enabling Database
Service metrics querying.
