### PR TITLE
compute sks: fix a crash in the "create" command

### DIFF
--- a/cmd/sks_create.go
+++ b/cmd/sks_create.go
@@ -169,7 +169,12 @@ func (c *sksCreateCmd) cmdRun(_ *cobra.Command, _ []string) error {
 				}
 				return
 			}(),
-			Name: nonEmptyStringPtr(c.NodepoolName),
+			Name: nonEmptyStringPtr(func() string {
+				if c.NodepoolName != "" {
+					return c.NodepoolName
+				}
+				return c.Name
+			}()),
 			Size: &c.NodepoolSize,
 		}
 


### PR DESCRIPTION
This change fixes a crashing bug occurring when creating an SKS cluster
with a default Nodepool without specifying a name using the
--nodepool-name` flag.