### PR TITLE
dbaas: fix a crash in the "logs" command

### DIFF
--- a/cmd/dbaas_logs.go
+++ b/cmd/dbaas_logs.go
@@ -102,8 +102,8 @@ func (c *dbaasServiceLogsCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	}
 
 	out := dbServiceLogsOutput{
-		FirstLogOffset: *res.JSON200.FirstLogOffset,
-		Offset:         *res.JSON200.Offset,
+		FirstLogOffset: defaultString(res.JSON200.FirstLogOffset, "-"),
+		Offset:         defaultString(res.JSON200.Offset, "-"),
 		Logs:           make([]dbServiceLogsItemOutput, len(*res.JSON200.Logs)),
 	}
 


### PR DESCRIPTION
This changes fixes a bug causing the `exo dbaas logs` command to crash
if the Database Service is too recent to have logs.