### PR TITLE
compute sks create: change --oidc-required-claim flag type

### DIFF
--- a/cmd/sks_create.go
+++ b/cmd/sks_create.go
@@ -47,7 +47,7 @@ type sksCreateCmd struct {
 	OIDCGroupsClaim            string            `cli-flag:"oidc-groups-claim" cli-usage:"OpenID JWT claim to use as the user's group"`
 	OIDCGroupsPrefix           string            `cli-flag:"oidc-groups-prefix" cli-usage:"OpenID prefix prepended to group claims"`
 	OIDCIssuerURL              string            `cli-flag:"oidc-issuer-url" cli-usage:"OpenID provider URL"`
-	OIDCRequiredClaim          string            `cli-flag:"oidc-required-claim" cli-usage:"a key=value pair that describes a required claim in the OpenID Token"`
+	OIDCRequiredClaim          map[string]string `cli-flag:"oidc-required-claim" cli-usage:"OpenID token required claim (format: key=value)"`
 	OIDCUsernameClaim          string            `cli-flag:"oidc-username-claim" cli-usage:"OpenID JWT claim to use as the user name"`
 	OIDCUsernamePrefix         string            `cli-flag:"oidc-username-prefix" cli-usage:"OpenID prefix prepended to username claims"`
 	ServiceLevel               string            `cli-usage:"SKS cluster control plane service level (starter|pro)"`
@@ -140,11 +140,16 @@ func (c *sksCreateCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	var opts []egoscale.CreateSKSClusterOpt
 	if c.OIDCClientID != "" {
 		opts = append(opts, egoscale.CreateSKSClusterWithOIDC(&egoscale.SKSClusterOIDCConfig{
-			ClientID:       &c.OIDCClientID,
-			GroupsClaim:    nonEmptyStringPtr(c.OIDCGroupsClaim),
-			GroupsPrefix:   nonEmptyStringPtr(c.OIDCGroupsPrefix),
-			IssuerURL:      &c.OIDCIssuerURL,
-			RequiredClaim:  nonEmptyStringPtr(c.OIDCRequiredClaim),
+			ClientID:     &c.OIDCClientID,
+			GroupsClaim:  nonEmptyStringPtr(c.OIDCGroupsClaim),
+			GroupsPrefix: nonEmptyStringPtr(c.OIDCGroupsPrefix),
+			IssuerURL:    &c.OIDCIssuerURL,
+			RequiredClaim: func() (v *map[string]string) {
+				if len(c.OIDCRequiredClaim) > 0 {
+					v = &c.OIDCRequiredClaim
+				}
+				return
+			}(),
 			UsernameClaim:  nonEmptyStringPtr(c.OIDCUsernameClaim),
 			UsernamePrefix: nonEmptyStringPtr(c.OIDCUsernamePrefix),
 		}))

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/exoscale/egoscale v0.83.2
+	github.com/exoscale/egoscale v0.84.0
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/exoscale/egoscale v0.83.2 h1:x1av63s5ayqWmVpKyTtu+KI7TK5DyCB8NgCz3g3zc40=
-github.com/exoscale/egoscale v0.83.2/go.mod h1:C1e4bJE8Ml1GylP14hOMGdCfgDDf9hMLsbny1QWsemw=
+github.com/exoscale/egoscale v0.84.0 h1:Belx+jVUXwhf11SBB5hZY6t27Aghi7vWf85kdMwiL84=
+github.com/exoscale/egoscale v0.84.0/go.mod h1:C1e4bJE8Ml1GylP14hOMGdCfgDDf9hMLsbny1QWsemw=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.84.0
+------
+
+- change: v2: `SKSClusterOIDCConfig` struct field `RequiredClaim` now is a `map[string]string` type instead of a string
+
 0.83.2
 ------
 

--- a/vendor/github.com/exoscale/egoscale/v2/oapi/oapi.gen.go
+++ b/vendor/github.com/exoscale/egoscale/v2/oapi/oapi.gen.go
@@ -2147,14 +2147,19 @@ type SksOidc struct {
 	// OpenID provider URL
 	IssuerUrl string `json:"issuer-url"`
 
-	// A key=value pair that describes a required claim in the ID Token
-	RequiredClaim *string `json:"required-claim,omitempty"`
+	// A key value map that describes a required claim in the ID Token
+	RequiredClaim *SksOidc_RequiredClaim `json:"required-claim,omitempty"`
 
 	// JWT claim to use as the user name
 	UsernameClaim *string `json:"username-claim,omitempty"`
 
 	// Prefix prepended to username claims
 	UsernamePrefix *string `json:"username-prefix,omitempty"`
+}
+
+// A key value map that describes a required claim in the ID Token
+type SksOidc_RequiredClaim struct {
+	AdditionalProperties map[string]string `json:"-"`
 }
 
 // Snapshot
@@ -3755,6 +3760,59 @@ func (a *SksNodepoolTaints) UnmarshalJSON(b []byte) error {
 
 // Override default JSON handling for SksNodepoolTaints to handle AdditionalProperties
 func (a SksNodepoolTaints) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
+
+// Getter for additional properties for SksOidc_RequiredClaim. Returns the specified
+// element and whether it was found
+func (a SksOidc_RequiredClaim) Get(fieldName string) (value string, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for SksOidc_RequiredClaim
+func (a *SksOidc_RequiredClaim) Set(fieldName string, value string) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]string)
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for SksOidc_RequiredClaim to handle AdditionalProperties
+func (a *SksOidc_RequiredClaim) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]string)
+		for fieldName, fieldBuf := range object {
+			var fieldVal string
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for SksOidc_RequiredClaim to handle AdditionalProperties
+func (a SksOidc_RequiredClaim) MarshalJSON() ([]byte, error) {
 	var err error
 	object := make(map[string]json.RawMessage)
 

--- a/vendor/github.com/exoscale/egoscale/v2/sks_cluster.go
+++ b/vendor/github.com/exoscale/egoscale/v2/sks_cluster.go
@@ -15,7 +15,7 @@ type SKSClusterOIDCConfig struct {
 	GroupsClaim    *string
 	GroupsPrefix   *string
 	IssuerURL      *string `req-for:"create"`
-	RequiredClaim  *string
+	RequiredClaim  *map[string]string
 	UsernameClaim  *string
 	UsernamePrefix *string
 }
@@ -32,11 +32,16 @@ func CreateSKSClusterWithOIDC(v *SKSClusterOIDCConfig) CreateSKSClusterOpt {
 
 		if v != nil {
 			b.Oidc = &oapi.SksOidc{
-				ClientId:       *v.ClientID,
-				GroupsClaim:    v.GroupsClaim,
-				GroupsPrefix:   v.GroupsPrefix,
-				IssuerUrl:      *v.IssuerURL,
-				RequiredClaim:  v.RequiredClaim,
+				ClientId:     *v.ClientID,
+				GroupsClaim:  v.GroupsClaim,
+				GroupsPrefix: v.GroupsPrefix,
+				IssuerUrl:    *v.IssuerURL,
+				RequiredClaim: func() *oapi.SksOidc_RequiredClaim {
+					if v.RequiredClaim != nil {
+						return &oapi.SksOidc_RequiredClaim{AdditionalProperties: *v.RequiredClaim}
+					}
+					return nil
+				}(),
 				UsernameClaim:  v.UsernameClaim,
 				UsernamePrefix: v.UsernamePrefix,
 			}

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.83.2"
+const Version = "0.84.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.0
 ## explicit
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.83.2
+# github.com/exoscale/egoscale v0.84.0
 ## explicit
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/v2


### PR DESCRIPTION
This change switches the `exo compute sks create --oidc-required-claim`
flag type from `string` to `map[string]string` following an API change.