### PR TITLE
compute instance-template register: fix --from-snapshot

### DIFF
--- a/cmd/instance_template_register.go
+++ b/cmd/instance_template_register.go
@@ -100,8 +100,8 @@ func (c *instanceTemplateRegisterCmd) cmdRun(cmd *cobra.Command, _ []string) err
 			return fmt.Errorf("error retrieving snapshot export information: %w", err)
 		}
 
-		c.URL = *snapshotExport.PresignedURL
-		c.Checksum = *snapshotExport.MD5sum
+		template.URL = snapshotExport.PresignedURL
+		template.Checksum = snapshotExport.MD5sum
 
 		// Pre-setting the new template properties from the source template.
 		instance, err := cs.GetInstance(ctx, c.Zone, *snapshot.InstanceID)


### PR DESCRIPTION
This change fixes a bug in the `exo compute instance-template register`
command, preventing to use the `--from-snapshot` flag.