### PR TITLE
compute instance: Use defaultTemplate from current account (fix #428)

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -73,6 +73,16 @@ func cmdSetZoneFlagFromDefault(cmd *cobra.Command) {
 	}
 }
 
+// cmdSetTemplateFlagFromDefault  attempts to set the "--template" flag value based on the current active account's
+// default template setting if set. This is a convenience helper, there is no guarantee that the flag will be
+// set once this function returns.
+func cmdSetTemplateFlagFromDefault(cmd *cobra.Command) {
+	fmt.Print(cmd.Flag("template").Value.String())
+	if cmd.Flag("template").Value.String() == "" {
+		cmd.Flag("template").Value.Set(gCurrentAccount.DefaultTemplate) // nolint:errcheck
+	}
+}
+
 func cmdExitOnUsageError(cmd *cobra.Command, reason string) {
 	cmd.PrintErrln(fmt.Sprintf("error: %s", reason))
 	cmd.Usage() // nolint:errcheck

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -77,7 +77,6 @@ func cmdSetZoneFlagFromDefault(cmd *cobra.Command) {
 // default template setting if set. This is a convenience helper, there is no guarantee that the flag will be
 // set once this function returns.
 func cmdSetTemplateFlagFromDefault(cmd *cobra.Command) {
-	fmt.Print(cmd.Flag("template").Value.String())
 	if cmd.Flag("template").Value.String() == "" {
 		cmd.Flag("template").Value.Set(gCurrentAccount.DefaultTemplate) // nolint:errcheck
 	}

--- a/cmd/instance_create.go
+++ b/cmd/instance_create.go
@@ -58,6 +58,7 @@ Supported output template annotations: %s`,
 
 func (c *instanceCreateCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
 	cmdSetZoneFlagFromDefault(cmd)
+	cmdSetTemplateFlagFromDefault(cmd)
 	return cliCommandDefaultPreRun(c, cmd, args)
 }
 
@@ -246,7 +247,6 @@ func init() {
 
 		DiskSize:           50,
 		InstanceType:       fmt.Sprintf("%s.%s", defaultInstanceTypeFamily, defaultInstanceType),
-		Template:           defaultTemplate,
 		TemplateVisibility: defaultTemplateVisibility,
 	}))
 }

--- a/cmd/instance_pool_create.go
+++ b/cmd/instance_pool_create.go
@@ -115,6 +115,7 @@ in a future release, please use "--instance-type" instead.
 	}
 
 	cmdSetZoneFlagFromDefault(cmd)
+	cmdSetTemplateFlagFromDefault(cmd)
 	return cliCommandDefaultPreRun(c, cmd, args)
 }
 
@@ -253,7 +254,6 @@ func init() {
 		DiskSize:       50,
 		InstanceType:   fmt.Sprintf("%s.%s", defaultInstanceTypeFamily, defaultInstanceType),
 		Size:           1,
-		Template:       defaultTemplate,
 		TemplateFilter: defaultTemplateFilter,
 	}))
 
@@ -264,7 +264,6 @@ func init() {
 		DiskSize:       50,
 		InstanceType:   fmt.Sprintf("%s.%s", defaultInstanceTypeFamily, defaultInstanceType),
 		Size:           1,
-		Template:       defaultTemplate,
 		TemplateFilter: defaultTemplateFilter,
 	}))
 }

--- a/cmd/instance_reset.go
+++ b/cmd/instance_reset.go
@@ -41,6 +41,7 @@ Supported output template annotations: %s`,
 
 func (c *instanceResetCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
 	cmdSetZoneFlagFromDefault(cmd)
+	cmdSetTemplateFlagFromDefault(cmd)
 	return cliCommandDefaultPreRun(c, cmd, args)
 }
 


### PR DESCRIPTION
In `exo compute instance create` and `exo compute instance-pool create`, the current active account's default template will be used instead of the CLI one (if `--template` flag is absent). 