### PR TITLE
Implement SKS deprecated resources listing

### DIFF
--- a/cmd/sks_deprecated_resources.go
+++ b/cmd/sks_deprecated_resources.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type sksListDeprecatedResourcesItemOutput struct {
+	Group          string `json:"group"`
+	Version        string `json:"version"`
+	Resource       string `json:"resource"`
+	SubResource    string `json:"subresource"`
+	RemovedRelease string `json:"removed_release"`
+}
+
+type sksListDeprecatedResourcesOutput []sksListDeprecatedResourcesItemOutput
+
+func (o *sksListDeprecatedResourcesOutput) toJSON()  { outputJSON(o) }
+func (o *sksListDeprecatedResourcesOutput) toText()  { outputText(o) }
+func (o *sksListDeprecatedResourcesOutput) toTable() { outputTable(o) }
+
+type sksDeprecatedResourcesCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"deprecated-resources"`
+
+	Cluster string `cli-arg:"#" cli-usage:"CLUSTER-NAME|ID"`
+	Zone    string `cli-short:"z" cli-usage:"SKS cluster zone"`
+}
+
+func (c *sksDeprecatedResourcesCmd) cmdAliases() []string { return []string{"dr"} }
+
+func (c *sksDeprecatedResourcesCmd) cmdShort() string {
+	return "List resources that will be deprecated in a futur release of Kubernetes for an SKS cluster"
+}
+
+func (c *sksDeprecatedResourcesCmd) cmdLong() string {
+	return fmt.Sprintf(`This command lists SKS cluster Nodepools.
+
+Supported output template annotations: %s`,
+		strings.Join(outputterTemplateAnnotations(&sksListDeprecatedResourcesItemOutput{}), ", "))
+}
+
+func emptyIfNil(inp *string) string {
+	if inp == nil {
+		return ""
+	}
+
+	return *inp
+}
+
+func (c *sksDeprecatedResourcesCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	cmdSetZoneFlagFromDefault(cmd)
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *sksDeprecatedResourcesCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
+
+	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
+	if err != nil {
+		return err
+	}
+
+	deprecatedResources, err := cs.ListSKSClusterDeprecatedResources(
+		ctx,
+		c.Zone,
+		cluster,
+	)
+	if err != nil {
+		return fmt.Errorf("error retrieving deprecated resources: %w", err)
+	}
+
+	out := make(sksListDeprecatedResourcesOutput, 0)
+
+	for _, t := range deprecatedResources {
+		out = append(out, sksListDeprecatedResourcesItemOutput{
+			Group:          emptyIfNil(t.Group),
+			RemovedRelease: emptyIfNil(t.RemovedRelease),
+			Resource:       emptyIfNil(t.Resource),
+			SubResource:    emptyIfNil(t.SubResource),
+			Version:        emptyIfNil(t.Version),
+		})
+	}
+
+	return c.outputFunc(&out, nil)
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(sksCmd, &sksDeprecatedResourcesCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/sks_upgrade.go
+++ b/cmd/sks_upgrade.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
+	v2 "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
 	"github.com/spf13/cobra"
 )
@@ -31,7 +33,31 @@ func (c *sksUpgradeCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
 }
 
 func (c *sksUpgradeCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
+
+	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
+	if err != nil {
+		return err
+	}
+
 	if !c.Force {
+		deprecatedResources, err := cs.ListSKSClusterDeprecatedResources(
+			ctx,
+			c.Zone,
+			cluster,
+		)
+		if err != nil {
+			return fmt.Errorf("error retrieving deprecated resources: %w", err)
+		}
+
+		if len(deprecatedResources) > 0 {
+			fmt.Println("Some resources in your cluster are using deprecated APIs:")
+
+			for _, t := range deprecatedResources {
+				fmt.Println("- " + formatDeprecatedResource(t))
+			}
+		}
+
 		if !askQuestion(fmt.Sprintf(
 			"Are you sure you want to upgrade the cluster %q to version %s?",
 			c.Cluster,
@@ -39,13 +65,6 @@ func (c *sksUpgradeCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		)) {
 			return nil
 		}
-	}
-
-	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
-
-	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
-	if err != nil {
-		return err
 	}
 
 	decorateAsyncOperation(fmt.Sprintf("Upgrading SKS cluster %q...", c.Cluster), func() {
@@ -64,6 +83,31 @@ func (c *sksUpgradeCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+func formatDeprecatedResource(deprecatedResource *v2.SKSClusterDeprecatedResource) string {
+	var version string
+	var resource string
+
+	if !isEmptyStringPtr(deprecatedResource.Group) && !isEmptyStringPtr(deprecatedResource.Version) {
+		version = *deprecatedResource.Group + "/" + *deprecatedResource.Version
+	}
+
+	if !isEmptyStringPtr(deprecatedResource.Resource) {
+		resource = *deprecatedResource.Resource
+
+		if !isEmptyStringPtr(deprecatedResource.SubResource) {
+			resource += " (" + *deprecatedResource.SubResource + " subresource)"
+		}
+	}
+
+	deprecationNotice := strings.Join([]string{version, resource}, " ")
+
+	if !isEmptyStringPtr(deprecatedResource.RemovedRelease) {
+		return "Removed in Kubernetes v" + *deprecatedResource.RemovedRelease + ": " + deprecationNotice
+	}
+
+	return deprecationNotice
 }
 
 func init() {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -78,4 +79,49 @@ func sliceToMap(v []string) (map[string]string, error) {
 	}
 
 	return m, nil
+}
+
+// versionMajor returns major part of a version number (given "x.y(.z)", returns "x").
+// If the input version is not in semver format, returns 0.
+func versionMajor(version string) uint32 {
+	parts := strings.Split(version, ".")
+
+	if len(parts) > 0 {
+		v, e := strconv.ParseUint(parts[0], 10, 32)
+		if e != nil {
+			return 0
+		}
+
+		return uint32(v)
+	}
+
+	return 0
+}
+
+// versionMinor returns minor part of a version number (given "x.y(.z)", returns "y").
+// If the input version is not in semver format, returns 0.
+func versionMinor(version string) uint32 {
+	parts := strings.Split(version, ".")
+
+	if len(parts) > 1 {
+		v, e := strconv.ParseUint(parts[1], 10, 32)
+		if e != nil {
+			return 0
+		}
+
+		return uint32(v)
+	}
+
+	return 0
+}
+
+// versionIsNewer returns true if new version has potential deprecation
+func versionIsNewer(old, new string) bool {
+	return (versionMajor(new) >= versionMajor(old)) ||
+		(versionMajor(new) == versionMajor(old) && versionMinor(new) >= versionMinor(old))
+}
+
+// versionsAreEquivalent returns true if new and old versions both have same major and minor numbers
+func versionsAreEquivalent(a, b string) bool {
+	return (versionMajor(b) == versionMajor(a) && versionMinor(b) == versionMinor(a))
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -55,6 +55,10 @@ func nonEmptyStringPtr(s string) *string {
 	return nil
 }
 
+func isEmptyStringPtr(s *string) bool {
+	return s == nil || *s == ""
+}
+
 // sliceToMap returns a map[string]string from a slice of KEY=VALUE formatted
 // strings.
 // This function is used to obtain a map[string]string from CLI flags, as the


### PR DESCRIPTION
Requires https://github.com/exoscale/egoscale/pull/551

Features (with Kubernetes 1.22):

Cluster deprecated resources listing:

```
➜ go run main.go compute sks deprecated-resources -z de-fra-1 test-upgrade
┼────────┼─────────┼──────────────────────┼──────────────┼─────────────────┼
│ GROUP  │ VERSION │       RESOURCE       │ SUB RESOURCE │ REMOVED RELEASE │
┼────────┼─────────┼──────────────────────┼──────────────┼─────────────────┼
│ policy │ v1beta1 │ poddisruptionbudgets │              │ 1.25            │
│ policy │ v1beta1 │ podsecuritypolicies  │              │ 1.25            │
┼────────┼─────────┼──────────────────────┼──────────────┼─────────────────┼
```

Cluster upgrade warning:
```
➜ go run main.go compute sks upgrade -z de-fra-1 test-upgrade 1.23        
Some resources in your cluster are using deprecated APIs:
- Removed in Kubernetes v1.25: policy/v1beta1 poddisruptionbudgets
- Removed in Kubernetes v1.25: policy/v1beta1 podsecuritypolicies
[+] Are you sure you want to upgrade the cluster "test-upgrade" to version 1.23? [yN]: n
```

EDIT: No deprecation notices anymore on SKS upgrades if target version != deprecated resource removal version. e.g. the output above should happen only if we were upgrading `test-upgrade` to 1.25.