### PR TITLE
Set bash as Make SHELL to fix brace expansion

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,8 @@ builds:
       - goos: openbsd
         goarch: arm64
     hooks:
-      pre: make manpages completions sos-certificates
+      # we need bash for brace expansion
+      pre: make SHELL=/bin/bash manpages completions sos-certificates
 
 # macOS Universal Binaries
 universal_binaries:


### PR DESCRIPTION
On Ubuntu make might use sh by default, we need bash to use brace expansion/

```
antoine@antoine-exo:~/repos/src/github.com/exoscale/cli$ make completions
mkdir -p contrib/completion/{bash,powershell,zsh}
/usr/local/go/bin/go run -mod vendor completion/main.go bash ; mv bash_completion contrib/completion/bash/exo
/usr/local/go/bin/go run -mod vendor completion/main.go powershell ; mv powershell_completion contrib/completion/powershell/exo
/usr/local/go/bin/go run -mod vendor completion/main.go zsh ; mv zsh_completion contrib/completion/zsh/_exo
mv: cannot move 'bash_completion' to 'contrib/completion/bash/exo': No such file or directory
mv: cannot move 'powershell_completion' to 'contrib/completion/powershell/exo': No such file or directory
mv: cannot move 'zsh_completion' to 'contrib/completion/zsh/_exo': No such file or directory
make: *** [Makefile:48: completions] Error 1

antoine@antoine-exo:~/repos/src/github.com/exoscale/cli$ ls contrib/completion/
{bash,powershell,zsh}
```