### PR TITLE
Fix brace expansion in Makefile and concurency issue in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,9 @@
 project_name: exoscale-cli
 
+before:
+  hooks:
+    - make manpages completions sos-certificates
+
 builds:
   - binary: exo
     env:
@@ -26,8 +30,6 @@ builds:
         goarch: arm
       - goos: openbsd
         goarch: arm64
-    hooks:
-      pre: make manpages completions sos-certificates
 
 # macOS Universal Binaries
 universal_binaries:

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,9 @@ manpages: manpage
 
 .PHONY: completions
 completions:
-	mkdir -p contrib/completion/{bash,powershell,zsh}
+	mkdir -p contrib/completion/bash \
+		contrib/completion/powershell \
+		contrib/completion/zsh
 	$(GO) run -mod vendor completion/main.go bash ; mv bash_completion contrib/completion/bash/exo
 	$(GO) run -mod vendor completion/main.go powershell ; mv powershell_completion contrib/completion/powershell/exo
 	$(GO) run -mod vendor completion/main.go zsh ; mv zsh_completion contrib/completion/zsh/_exo


### PR DESCRIPTION
- Default make shell might not be bash so we should avoid expansion.
- The builds are running in parallel, including the build hook, this caused concurency issues for me so I moved the hook before the build

testing: 1.50.0 released from this branch