### PR TITLE
golangci-lint: use revive instead of golint & update go.mk

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,8 @@
-linters-settings:
-  golint:
-    min-confidence: 0.3
-
 linters:
   enable:
     - exportloopref
     - gofmt
-    - golint
+    - revive
     - megacheck
     - misspell
     - prealloc


### PR DESCRIPTION
This change replaces deprecated linter with recommended alternative (`revive`). Also updates `go.mk` submodule.