### PR TITLE
Predrag/sc 45726/cli dbaas add update migration support

### DIFF
--- a/cmd/dbaas_create.go
+++ b/cmd/dbaas_create.go
@@ -48,6 +48,14 @@ type dbaasServiceCreateCmd struct {
 	MysqlRecoveryBackupTime string   `cli-flag:"mysql-recovery-backup-time" cli-usage:"the timestamp of the backup to restore when forking from a Database Service"`
 	MysqlSettings           string   `cli-flag:"mysql-settings" cli-usage:"MySQL configuration settings (JSON format)" cli-hidden:""`
 	MysqlVersion            string   `cli-flag:"mysql-version" cli-usage:"MySQL major version" cli-hidden:""`
+	MysqlMigrationHost      string   `cli-flag:"mysql-migration-host" cli-usage:"hostname or IP address of the source server where to migrate data from" cli-hidden:""`
+	MysqlMigrationPort      int64    `cli-flag:"mysql-migration-port" cli-usage:"port number of the source server where to migrate data from" cli-hidden:""`
+	MysqlMigrationPassword  string   `cli-flag:"mysql-migration-password" cli-usage:"password for authenticating to the source server" cli-hidden:""`
+	MysqlMigrationSSL       bool     `cli-flag:"mysql-migration-ssl" cli-usage:"connect to the source server using SSL" cli-hidden:""`
+	MysqlMigrationUsername  string   `cli-flag:"mysql-migration-username" cli-usage:"username for authenticating to the source server" cli-hidden:""`
+	MysqlMigrationDbName    string   `cli-flag:"mysql-migration-dbname" cli-usage:"database name for bootstrapping the initial connection" cli-hidden:""`
+	MysqlMigrationMethod    string   `cli-flag:"mysql-migration-method" cli-usage:"migration method to be used (\"dump\" or \"replication\")" cli-hidden:""`
+	MysqlMigrationIgnoreDbs []string `cli-flag:"mysql-migration-ignore-dbs" cli-usage:"list of databases which should be ignored during migration" cli-hidden:""`
 
 	// "pg" type specific flags
 	PGAdminPassword      string   `cli-flag:"pg-admin-password" cli-usage:"custom password for admin user" cli-hidden:""`

--- a/cmd/dbaas_create.go
+++ b/cmd/dbaas_create.go
@@ -68,12 +68,28 @@ type dbaasServiceCreateCmd struct {
 	PGRecoveryBackupTime string   `cli-flag:"pg-recovery-backup-time" cli-usage:"the timestamp of the backup to restore when forking from a Database Service"`
 	PGSettings           string   `cli-flag:"pg-settings" cli-usage:"PostgreSQL configuration settings (JSON format)" cli-hidden:""`
 	PGVersion            string   `cli-flag:"pg-version" cli-usage:"PostgreSQL major version" cli-hidden:""`
+	PGMigrationHost      string   `cli-flag:"pg-migration-host" cli-usage:"hostname or IP address of the source server where to migrate data from" cli-hidden:""`
+	PGMigrationPort      int64    `cli-flag:"pg-migration-port" cli-usage:"port number of the source server where to migrate data from" cli-hidden:""`
+	PGMigrationPassword  string   `cli-flag:"pg-migration-password" cli-usage:"password for authenticating to the source server" cli-hidden:""`
+	PGMigrationSSL       bool     `cli-flag:"pg-migration-ssl" cli-usage:"connect to the source server using SSL" cli-hidden:""`
+	PGMigrationUsername  string   `cli-flag:"pg-migration-username" cli-usage:"username for authenticating to the source server" cli-hidden:""`
+	PGMigrationDbName    string   `cli-flag:"pg-migration-dbname" cli-usage:"database name for bootstrapping the initial connection" cli-hidden:""`
+	PGMigrationMethod    string   `cli-flag:"pg-migration-method" cli-usage:"migration method to be used (\"dump\" or \"replication\")" cli-hidden:""`
+	PGMigrationIgnoreDbs []string `cli-flag:"pg-migration-ignore-dbs" cli-usage:"list of databases which should be ignored during migration" cli-hidden:""`
 
 	// "redis" type specific flags
 	RedisForkFrom           string   `cli-flag:"redis-fork-from" cli-usage:"name of a Database Service to fork from"`
 	RedisIPFilter           []string `cli-flag:"redis-ip-filter" cli-usage:"allow incoming connections from CIDR address block" cli-hidden:""`
 	RedisRecoveryBackupName string   `cli-flag:"redis-recovery-backup-name" cli-usage:"the name of the backup to restore when forking from a Database Service"`
 	RedisSettings           string   `cli-flag:"redis-settings" cli-usage:"Redis configuration settings (JSON format)" cli-hidden:""`
+	RedisMigrationHost      string   `cli-flag:"redis-migration-host" cli-usage:"hostname or IP address of the source server where to migrate data from" cli-hidden:""`
+	RedisMigrationPort      int64    `cli-flag:"redis-migration-port" cli-usage:"port number of the source server where to migrate data from" cli-hidden:""`
+	RedisMigrationPassword  string   `cli-flag:"redis-migration-password" cli-usage:"password for authenticating to the source server" cli-hidden:""`
+	RedisMigrationSSL       bool     `cli-flag:"redis-migration-ssl" cli-usage:"connect to the source server using SSL" cli-hidden:""`
+	RedisMigrationUsername  string   `cli-flag:"redis-migration-username" cli-usage:"username for authenticating to the source server" cli-hidden:""`
+	RedisMigrationDbName    string   `cli-flag:"redis-migration-dbname" cli-usage:"database name for bootstrapping the initial connection" cli-hidden:""`
+	RedisMigrationMethod    string   `cli-flag:"redis-migration-method" cli-usage:"migration method to be used (\"dump\" or \"replication\")" cli-hidden:""`
+	RedisMigrationIgnoreDbs []string `cli-flag:"redis-migration-ignore-dbs" cli-usage:"list of databases which should be ignored during migration" cli-hidden:""`
 }
 
 func (c *dbaasServiceCreateCmd) cmdAliases() []string { return gCreateAlias }

--- a/cmd/dbaas_create_kafka.go
+++ b/cmd/dbaas_create_kafka.go
@@ -46,8 +46,13 @@ func (c *dbaasServiceCreateCmd) createKafka(_ *cobra.Command, _ []string) error 
 	}
 
 	if c.MaintenanceDOW != "" && c.MaintenanceTime != "" {
-		databaseService.Maintenance.Dow = oapi.CreateDbaasServiceKafkaJSONBodyMaintenanceDow(c.MaintenanceDOW)
-		databaseService.Maintenance.Time = c.MaintenanceTime
+		databaseService.Maintenance = &struct {
+			Dow  oapi.CreateDbaasServiceKafkaJSONBodyMaintenanceDow `json:"dow"`
+			Time string                                             `json:"time"`
+		}{
+			Dow:  oapi.CreateDbaasServiceKafkaJSONBodyMaintenanceDow(c.MaintenanceDOW),
+			Time: c.MaintenanceTime,
+		}
 	}
 
 	if c.KafkaConnectSettings != "" {

--- a/cmd/dbaas_create_mysql.go
+++ b/cmd/dbaas_create_mysql.go
@@ -64,8 +64,13 @@ func (c *dbaasServiceCreateCmd) createMysql(_ *cobra.Command, _ []string) error 
 	}
 
 	if c.MaintenanceDOW != "" && c.MaintenanceTime != "" {
-		databaseService.Maintenance.Dow = oapi.CreateDbaasServiceMysqlJSONBodyMaintenanceDow(c.MaintenanceDOW)
-		databaseService.Maintenance.Time = c.MaintenanceTime
+		databaseService.Maintenance = &struct {
+			Dow  oapi.CreateDbaasServiceMysqlJSONBodyMaintenanceDow `json:"dow"`
+			Time string                                             `json:"time"`
+		}{
+			Dow:  oapi.CreateDbaasServiceMysqlJSONBodyMaintenanceDow(c.MaintenanceDOW),
+			Time: c.MaintenanceTime,
+		}
 	}
 
 	if c.MysqlSettings != "" {

--- a/cmd/dbaas_create_mysql.go
+++ b/cmd/dbaas_create_mysql.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
 	"github.com/exoscale/egoscale/v2/oapi"
@@ -73,6 +74,36 @@ func (c *dbaasServiceCreateCmd) createMysql(_ *cobra.Command, _ []string) error 
 			return fmt.Errorf("invalid settings: %w", err)
 		}
 		databaseService.MysqlSettings = &settings
+	}
+
+	if c.MysqlMigrationHost != "" {
+		databaseService.Migration = &struct {
+			Dbname    *string                     `json:"dbname,omitempty"`
+			Host      string                      `json:"host"`
+			IgnoreDbs *string                     `json:"ignore-dbs,omitempty"`
+			Method    *oapi.EnumPgMigrationMethod `json:"method,omitempty"`
+			Password  *string                     `json:"password,omitempty"`
+			Port      int64                       `json:"port"`
+			Ssl       *bool                       `json:"ssl,omitempty"`
+			Username  *string                     `json:"username,omitempty"`
+		}{
+			Host:     c.MysqlMigrationHost,
+			Port:     c.MysqlMigrationPort,
+			Password: nonEmptyStringPtr(c.MysqlMigrationPassword),
+			Username: nonEmptyStringPtr(c.MysqlMigrationUsername),
+			Dbname:   nonEmptyStringPtr(c.MysqlMigrationDbName),
+		}
+		if c.MysqlMigrationSSL {
+			databaseService.Migration.Ssl = &c.MysqlMigrationSSL
+		}
+		if c.MysqlMigrationMethod != "" {
+			method := oapi.EnumPgMigrationMethod(c.MysqlMigrationMethod)
+			databaseService.Migration.Method = &method
+		}
+		if len(c.MysqlMigrationIgnoreDbs) > 0 {
+			dbsJoin := strings.Join(c.MysqlMigrationIgnoreDbs, ",")
+			databaseService.Migration.IgnoreDbs = &dbsJoin
+		}
 	}
 
 	var res *oapi.CreateDbaasServiceMysqlResponse

--- a/cmd/dbaas_create_pg.go
+++ b/cmd/dbaas_create_pg.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
 	"github.com/exoscale/egoscale/v2/oapi"
@@ -63,8 +64,13 @@ func (c *dbaasServiceCreateCmd) createPG(_ *cobra.Command, _ []string) error {
 	}
 
 	if c.MaintenanceDOW != "" && c.MaintenanceTime != "" {
-		databaseService.Maintenance.Dow = oapi.CreateDbaasServicePgJSONBodyMaintenanceDow(c.MaintenanceDOW)
-		databaseService.Maintenance.Time = c.MaintenanceTime
+		databaseService.Maintenance = &struct {
+			Dow  oapi.CreateDbaasServicePgJSONBodyMaintenanceDow `json:"dow"`
+			Time string                                          `json:"time"`
+		}{
+			Dow:  oapi.CreateDbaasServicePgJSONBodyMaintenanceDow(c.MaintenanceDOW),
+			Time: c.MaintenanceTime,
+		}
 	}
 
 	if c.PGBouncerSettings != "" {
@@ -98,6 +104,36 @@ func (c *dbaasServiceCreateCmd) createPG(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("invalid settings: %w", err)
 		}
 		databaseService.PgSettings = &settings
+	}
+
+	if c.PGMigrationHost != "" {
+		databaseService.Migration = &struct {
+			Dbname    *string                     `json:"dbname,omitempty"`
+			Host      string                      `json:"host"`
+			IgnoreDbs *string                     `json:"ignore-dbs,omitempty"`
+			Method    *oapi.EnumPgMigrationMethod `json:"method,omitempty"`
+			Password  *string                     `json:"password,omitempty"`
+			Port      int64                       `json:"port"`
+			Ssl       *bool                       `json:"ssl,omitempty"`
+			Username  *string                     `json:"username,omitempty"`
+		}{
+			Host:     c.PGMigrationHost,
+			Port:     c.PGMigrationPort,
+			Password: nonEmptyStringPtr(c.PGMigrationPassword),
+			Username: nonEmptyStringPtr(c.PGMigrationUsername),
+			Dbname:   nonEmptyStringPtr(c.PGMigrationDbName),
+		}
+		if c.PGMigrationSSL {
+			databaseService.Migration.Ssl = &c.PGMigrationSSL
+		}
+		if c.PGMigrationMethod != "" {
+			method := oapi.EnumPgMigrationMethod(c.PGMigrationMethod)
+			databaseService.Migration.Method = &method
+		}
+		if len(c.PGMigrationIgnoreDbs) > 0 {
+			dbsJoin := strings.Join(c.PGMigrationIgnoreDbs, ",")
+			databaseService.Migration.IgnoreDbs = &dbsJoin
+		}
 	}
 
 	var res *oapi.CreateDbaasServicePgResponse

--- a/cmd/dbaas_create_redis.go
+++ b/cmd/dbaas_create_redis.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
 	"github.com/exoscale/egoscale/v2/oapi"
@@ -39,8 +40,13 @@ func (c *dbaasServiceCreateCmd) createRedis(_ *cobra.Command, _ []string) error 
 	}
 
 	if c.MaintenanceDOW != "" && c.MaintenanceTime != "" {
-		databaseService.Maintenance.Dow = oapi.CreateDbaasServiceRedisJSONBodyMaintenanceDow(c.MaintenanceDOW)
-		databaseService.Maintenance.Time = c.MaintenanceTime
+		databaseService.Maintenance = &struct {
+			Dow  oapi.CreateDbaasServiceRedisJSONBodyMaintenanceDow `json:"dow"`
+			Time string                                             `json:"time"`
+		}{
+			Dow:  oapi.CreateDbaasServiceRedisJSONBodyMaintenanceDow(c.MaintenanceDOW),
+			Time: c.MaintenanceTime,
+		}
 	}
 
 	if c.RedisSettings != "" {
@@ -49,6 +55,36 @@ func (c *dbaasServiceCreateCmd) createRedis(_ *cobra.Command, _ []string) error 
 			return fmt.Errorf("invalid settings: %w", err)
 		}
 		databaseService.RedisSettings = &settings
+	}
+
+	if c.RedisMigrationHost != "" {
+		databaseService.Migration = &struct {
+			Dbname    *string                     `json:"dbname,omitempty"`
+			Host      string                      `json:"host"`
+			IgnoreDbs *string                     `json:"ignore-dbs,omitempty"`
+			Method    *oapi.EnumPgMigrationMethod `json:"method,omitempty"`
+			Password  *string                     `json:"password,omitempty"`
+			Port      int64                       `json:"port"`
+			Ssl       *bool                       `json:"ssl,omitempty"`
+			Username  *string                     `json:"username,omitempty"`
+		}{
+			Host:     c.RedisMigrationHost,
+			Port:     c.RedisMigrationPort,
+			Password: nonEmptyStringPtr(c.RedisMigrationPassword),
+			Username: nonEmptyStringPtr(c.RedisMigrationUsername),
+			Dbname:   nonEmptyStringPtr(c.RedisMigrationDbName),
+		}
+		if c.RedisMigrationSSL {
+			databaseService.Migration.Ssl = &c.RedisMigrationSSL
+		}
+		if c.RedisMigrationMethod != "" {
+			method := oapi.EnumPgMigrationMethod(c.RedisMigrationMethod)
+			databaseService.Migration.Method = &method
+		}
+		if len(c.RedisMigrationIgnoreDbs) > 0 {
+			dbsJoin := strings.Join(c.RedisMigrationIgnoreDbs, ",")
+			databaseService.Migration.IgnoreDbs = &dbsJoin
+		}
 	}
 
 	var res *oapi.CreateDbaasServiceRedisResponse

--- a/cmd/dbaas_update.go
+++ b/cmd/dbaas_update.go
@@ -40,20 +40,44 @@ type dbaasServiceUpdateCmd struct {
 	KafkaSettings               string   `cli-flag:"kafka-settings" cli-usage:"Kafka configuration settings (JSON format)" cli-hidden:""`
 
 	// "mysql" type specific flags
-	MysqlBackupSchedule string   `cli-flag:"mysql-backup-schedule" cli-usage:"automated backup schedule (format: HH:MM)" cli-hidden:""`
-	MysqlIPFilter       []string `cli-flag:"mysql-ip-filter" cli-usage:"allow incoming connections from CIDR address block" cli-hidden:""`
-	MysqlSettings       string   `cli-flag:"mysql-settings" cli-usage:"MySQL configuration settings (JSON format)" cli-hidden:""`
+	MysqlBackupSchedule     string   `cli-flag:"mysql-backup-schedule" cli-usage:"automated backup schedule (format: HH:MM)" cli-hidden:""`
+	MysqlIPFilter           []string `cli-flag:"mysql-ip-filter" cli-usage:"allow incoming connections from CIDR address block" cli-hidden:""`
+	MysqlSettings           string   `cli-flag:"mysql-settings" cli-usage:"MySQL configuration settings (JSON format)" cli-hidden:""`
+	MysqlMigrationHost      string   `cli-flag:"mysql-migration-host" cli-usage:"hostname or IP address of the source server where to migrate data from" cli-hidden:""`
+	MysqlMigrationPort      int64    `cli-flag:"mysql-migration-port" cli-usage:"port number of the source server where to migrate data from" cli-hidden:""`
+	MysqlMigrationPassword  string   `cli-flag:"mysql-migration-password" cli-usage:"password for authenticating to the source server" cli-hidden:""`
+	MysqlMigrationSSL       bool     `cli-flag:"mysql-migration-ssl" cli-usage:"connect to the source server using SSL" cli-hidden:""`
+	MysqlMigrationUsername  string   `cli-flag:"mysql-migration-username" cli-usage:"username for authenticating to the source server" cli-hidden:""`
+	MysqlMigrationDbName    string   `cli-flag:"mysql-migration-dbname" cli-usage:"database name for bootstrapping the initial connection" cli-hidden:""`
+	MysqlMigrationMethod    string   `cli-flag:"mysql-migration-method" cli-usage:"migration method to be used (\"dump\" or \"replication\")" cli-hidden:""`
+	MysqlMigrationIgnoreDbs []string `cli-flag:"mysql-migration-ignore-dbs" cli-usage:"list of databases which should be ignored during migration" cli-hidden:""`
 
 	// "pg" type specific flags
-	PGBackupSchedule  string   `cli-flag:"pg-backup-schedule" cli-usage:"automated backup schedule (format: HH:MM)" cli-hidden:""`
-	PGBouncerSettings string   `cli-flag:"pg-bouncer-settings" cli-usage:"PgBouncer configuration settings (JSON format)" cli-hidden:""`
-	PGIPFilter        []string `cli-flag:"pg-ip-filter" cli-usage:"allow incoming connections from CIDR address block" cli-hidden:""`
-	PGLookoutSettings string   `cli-flag:"pg-lookout-settings" cli-usage:"pglookout configuration settings (JSON format)" cli-hidden:""`
-	PGSettings        string   `cli-flag:"pg-settings" cli-usage:"PostgreSQL configuration settings (JSON format)" cli-hidden:""`
+	PGBackupSchedule     string   `cli-flag:"pg-backup-schedule" cli-usage:"automated backup schedule (format: HH:MM)" cli-hidden:""`
+	PGBouncerSettings    string   `cli-flag:"pg-bouncer-settings" cli-usage:"PgBouncer configuration settings (JSON format)" cli-hidden:""`
+	PGIPFilter           []string `cli-flag:"pg-ip-filter" cli-usage:"allow incoming connections from CIDR address block" cli-hidden:""`
+	PGLookoutSettings    string   `cli-flag:"pg-lookout-settings" cli-usage:"pglookout configuration settings (JSON format)" cli-hidden:""`
+	PGSettings           string   `cli-flag:"pg-settings" cli-usage:"PostgreSQL configuration settings (JSON format)" cli-hidden:""`
+	PGMigrationHost      string   `cli-flag:"pg-migration-host" cli-usage:"hostname or IP address of the source server where to migrate data from" cli-hidden:""`
+	PGMigrationPort      int64    `cli-flag:"pg-migration-port" cli-usage:"port number of the source server where to migrate data from" cli-hidden:""`
+	PGMigrationPassword  string   `cli-flag:"pg-migration-password" cli-usage:"password for authenticating to the source server" cli-hidden:""`
+	PGMigrationSSL       bool     `cli-flag:"pg-migration-ssl" cli-usage:"connect to the source server using SSL" cli-hidden:""`
+	PGMigrationUsername  string   `cli-flag:"pg-migration-username" cli-usage:"username for authenticating to the source server" cli-hidden:""`
+	PGMigrationDbName    string   `cli-flag:"pg-migration-dbname" cli-usage:"database name for bootstrapping the initial connection" cli-hidden:""`
+	PGMigrationMethod    string   `cli-flag:"pg-migration-method" cli-usage:"migration method to be used (\"dump\" or \"replication\")" cli-hidden:""`
+	PGMigrationIgnoreDbs []string `cli-flag:"pg-migration-ignore-dbs" cli-usage:"list of databases which should be ignored during migration" cli-hidden:""`
 
 	// "redis" type specific flags
-	RedisIPFilter []string `cli-flag:"redis-ip-filter" cli-usage:"allow incoming connections from CIDR address block" cli-hidden:""`
-	RedisSettings string   `cli-flag:"redis-settings" cli-usage:"Redis configuration settings (JSON format)" cli-hidden:""`
+	RedisIPFilter           []string `cli-flag:"redis-ip-filter" cli-usage:"allow incoming connections from CIDR address block" cli-hidden:""`
+	RedisSettings           string   `cli-flag:"redis-settings" cli-usage:"Redis configuration settings (JSON format)" cli-hidden:""`
+	RedisMigrationHost      string   `cli-flag:"redis-migration-host" cli-usage:"hostname or IP address of the source server where to migrate data from" cli-hidden:""`
+	RedisMigrationPort      int64    `cli-flag:"redis-migration-port" cli-usage:"port number of the source server where to migrate data from" cli-hidden:""`
+	RedisMigrationPassword  string   `cli-flag:"redis-migration-password" cli-usage:"password for authenticating to the source server" cli-hidden:""`
+	RedisMigrationSSL       bool     `cli-flag:"redis-migration-ssl" cli-usage:"connect to the source server using SSL" cli-hidden:""`
+	RedisMigrationUsername  string   `cli-flag:"redis-migration-username" cli-usage:"username for authenticating to the source server" cli-hidden:""`
+	RedisMigrationDbName    string   `cli-flag:"redis-migration-dbname" cli-usage:"database name for bootstrapping the initial connection" cli-hidden:""`
+	RedisMigrationMethod    string   `cli-flag:"redis-migration-method" cli-usage:"migration method to be used (\"dump\" or \"replication\")" cli-hidden:""`
+	RedisMigrationIgnoreDbs []string `cli-flag:"redis-migration-ignore-dbs" cli-usage:"list of databases which should be ignored during migration" cli-hidden:""`
 }
 
 func (c *dbaasServiceUpdateCmd) cmdAliases() []string { return nil }


### PR DESCRIPTION
Adds support for running migration when creating/updating supported dbaas service. Services supporting migrations are mysql, pg and redis.
Also fixes a panic when using `--maintenance-dow` and `--maintenance-time` flags in `dbaas create` command.