### PR TITLE
Compute: Do not compress user-data by default

### DIFF
--- a/cmd/instance_create.go
+++ b/cmd/instance_create.go
@@ -26,6 +26,7 @@ type instanceCreateCmd struct {
 
 	AntiAffinityGroups []string          `cli-flag:"anti-affinity-group" cli-usage:"instance Anti-Affinity Group NAME|ID (can be specified multiple times)"`
 	CloudInitFile      string            `cli-flag:"cloud-init" cli-usage:"instance cloud-init user data configuration file path"`
+	CloudInitCompress  bool              `cli-flag:"cloud-init-compress" cli-usage:"compress instance cloud-init user data"`
 	DeployTarget       string            `cli-usage:"instance Deploy Target NAME|ID"`
 	DiskSize           int64             `cli-usage:"instance disk size"`
 	IPv6               bool              `cli-flag:"ipv6" cli-usage:"enable IPv6 on instance"`
@@ -184,7 +185,7 @@ func (c *instanceCreateCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	}
 
 	if c.CloudInitFile != "" {
-		userData, err := getUserDataFromFile(c.CloudInitFile)
+		userData, err := getUserDataFromFile(c.CloudInitFile, c.CloudInitCompress)
 		if err != nil {
 			return fmt.Errorf("error parsing cloud-init user data: %w", err)
 		}

--- a/cmd/instance_pool_create.go
+++ b/cmd/instance_pool_create.go
@@ -18,6 +18,7 @@ type instancePoolCreateCmd struct {
 
 	AntiAffinityGroups []string          `cli-flag:"anti-affinity-group" cli-short:"a" cli-usage:"managed Compute instances Anti-Affinity Group NAME|ID (can be specified multiple times)"`
 	CloudInitFile      string            `cli-flag:"cloud-init" cli-short:"c" cli-usage:"cloud-init user data configuration file path"`
+	CloudInitCompress  bool              `cli-flag:"cloud-init-compress" cli-usage:"compress instance cloud-init user data"`
 	DeployTarget       string            `cli-usage:"managed Compute instances Deploy Target NAME|ID"`
 	Description        string            `cli-usage:"Instance Pool description"`
 	Disk               int64             `cli-flag:"disk" cli-short:"d" cli-usage:"[DEPRECATED] use --disk-size"`
@@ -222,7 +223,7 @@ func (c *instancePoolCreateCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	instancePool.TemplateID = &templateID
 
 	if c.CloudInitFile != "" {
-		userData, err := getUserDataFromFile(c.CloudInitFile)
+		userData, err := getUserDataFromFile(c.CloudInitFile, c.CloudInitCompress)
 		if err != nil {
 			return fmt.Errorf("error parsing cloud-init user data: %w", err)
 		}

--- a/cmd/instance_pool_update.go
+++ b/cmd/instance_pool_update.go
@@ -18,6 +18,7 @@ type instancePoolUpdateCmd struct {
 
 	AntiAffinityGroups []string          `cli-flag:"anti-affinity-group" cli-short:"a" cli-usage:"managed Compute instances Anti-Affinity Group NAME|ID (can be specified multiple times)"`
 	CloudInitFile      string            `cli-flag:"cloud-init" cli-short:"c" cli-usage:"cloud-init user data configuration file path"`
+	CloudInitCompress  bool              `cli-flag:"cloud-init-compress" cli-usage:"compress instance cloud-init user data"`
 	DeployTarget       string            `cli-usage:"managed Compute instances Deploy Target NAME|ID"`
 	Description        string            `cli-usage:"Instance Pool description"`
 	Disk               int64             `cli-flag:"disk" cli-short:"d" cli-usage:"[DEPRECATED] use --disk-size"`
@@ -260,7 +261,7 @@ func (c *instancePoolUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 	}
 
 	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.CloudInitFile)) {
-		userData, err := getUserDataFromFile(c.CloudInitFile)
+		userData, err := getUserDataFromFile(c.CloudInitFile, c.CloudInitCompress)
 		if err != nil {
 			return fmt.Errorf("error parsing cloud-init user data: %w", err)
 		}

--- a/cmd/instance_update.go
+++ b/cmd/instance_update.go
@@ -15,10 +15,11 @@ type instanceUpdateCmd struct {
 
 	Instance string `cli-arg:"#" cli-usage:"NAME|ID"`
 
-	CloudInitFile string            `cli-flag:"cloud-init" cli-short:"c" cli-usage:"instance cloud-init user data configuration file path"`
-	Labels        map[string]string `cli-flag:"label" cli-usage:"instance label (format: key=value)"`
-	Name          string            `cli-short:"n" cli-usage:"instance name"`
-	Zone          string            `cli-short:"z" cli-usage:"instance zone"`
+	CloudInitFile     string            `cli-flag:"cloud-init" cli-short:"c" cli-usage:"instance cloud-init user data configuration file path"`
+	CloudInitCompress bool              `cli-flag:"cloud-init-compress" cli-usage:"compress instance cloud-init user data"`
+	Labels            map[string]string `cli-flag:"label" cli-usage:"instance label (format: key=value)"`
+	Name              string            `cli-short:"n" cli-usage:"instance name"`
+	Zone              string            `cli-short:"z" cli-usage:"instance zone"`
 }
 
 func (c *instanceUpdateCmd) cmdAliases() []string { return nil }
@@ -59,7 +60,7 @@ func (c *instanceUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 	}
 
 	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.CloudInitFile)) {
-		userData, err := getUserDataFromFile(c.CloudInitFile)
+		userData, err := getUserDataFromFile(c.CloudInitFile, c.CloudInitCompress)
 		if err != nil {
 			return fmt.Errorf("error parsing cloud-init user data: %w", err)
 		}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -124,4 +126,14 @@ func versionIsNewer(old, new string) bool {
 // versionsAreEquivalent returns true if new and old versions both have same major and minor numbers
 func versionsAreEquivalent(a, b string) bool {
 	return (versionMajor(b) == versionMajor(a) && versionMinor(b) == versionMinor(a))
+}
+
+func isGzipContentType(out io.Reader) (bool, error) {
+	buffer := make([]byte, 512)
+	_, err := out.Read(buffer)
+	if err != nil {
+		return false, err
+	}
+
+	return http.DetectContentType(buffer) == "application/x-gzip", nil
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
-	"net/http"
 	"strconv"
 	"strings"
 )
@@ -126,14 +124,4 @@ func versionIsNewer(old, new string) bool {
 // versionsAreEquivalent returns true if new and old versions both have same major and minor numbers
 func versionsAreEquivalent(a, b string) bool {
 	return (versionMajor(b) == versionMajor(a) && versionMinor(b) == versionMinor(a))
-}
-
-func isGzipContentType(out io.Reader) (bool, error) {
-	buffer := make([]byte, 512)
-	_, err := out.Read(buffer)
-	if err != nil {
-		return false, err
-	}
-
-	return http.DetectContentType(buffer) == "application/x-gzip", nil
 }

--- a/cmd/vm_create.go
+++ b/cmd/vm_create.go
@@ -35,9 +35,13 @@ Supported output template annotations: %s`,
 		if err != nil {
 			return err
 		}
+		userDataCompress, err := cmd.Flags().GetBool("cloud-init-compress")
+		if err != nil {
+			return err
+		}
 		userData := ""
 		if userDataPath != "" {
-			userData, err = getUserDataFromFile(userDataPath)
+			userData, err = getUserDataFromFile(userDataPath, userDataCompress)
 			if err != nil {
 				return err
 			}
@@ -207,7 +211,8 @@ func init() {
 	vmCreateCmd.Flags().StringSliceP("security-group", "s", nil, "Security Group NAME|ID. Can be specified multiple times.")
 	vmCreateCmd.Flags().StringSliceP("privnet", "p", nil, "Private Network NAME|ID. Can be specified multiple times.")
 	vmCreateCmd.Flags().StringSliceP("anti-affinity-group", "a", nil, "Anti-Affinity Group NAME|ID. Can be specified multiple times.")
-	vmCreateCmd.Flags().StringP("cloud-init-file", "f", "", "cloud-init userdata")
+	vmCreateCmd.Flags().StringP("cloud-init-file", "f", "", "instance cloud-init userdata")
+	vmCreateCmd.Flags().BoolP("cloud-init-compress", "", false, "compress instance cloud-init user data")
 	vmCreateCmd.Flags().BoolP("ipv6", "6", false, "enable IPv6")
 	vmCmd.AddCommand(vmCreateCmd)
 }

--- a/cmd/vm_show.go
+++ b/cmd/vm_show.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/base64"
 	"fmt"
 	"os"
 	"strings"
@@ -161,12 +160,12 @@ func showVMUserData(name string) error {
 		return err
 	}
 
-	userData, err := base64.StdEncoding.DecodeString(resp.(*egoscale.VirtualMachineUserData).UserData)
+	userData, err := decodeUserData(resp.(*egoscale.VirtualMachineUserData).UserData)
 	if err != nil {
 		return err
 	}
 
-	fmt.Println(string(userData))
+	fmt.Println(userData)
 
 	return nil
 }

--- a/cmd/vm_update.go
+++ b/cmd/vm_update.go
@@ -41,8 +41,12 @@ var vmUpdateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		userDataCompress, err := cmd.Flags().GetBool("cloud-init-compress")
+		if err != nil {
+			return err
+		}
 		if userDataPath != "" {
-			vmEdit.UserData, err = getUserDataFromFile(userDataPath)
+			vmEdit.UserData, err = getUserDataFromFile(userDataPath, userDataCompress)
 			if err != nil {
 				return err
 			}
@@ -80,6 +84,7 @@ var vmUpdateCmd = &cobra.Command{
 func init() {
 	vmUpdateCmd.Flags().String("name", "", "instance display name")
 	vmUpdateCmd.Flags().String("cloud-init-file", "", "path to a cloud-init user data file")
+	vmUpdateCmd.Flags().BoolP("cloud-init-compress", "", false, "compress instance cloud-init user data")
 	vmUpdateCmd.Flags().String("reverse-dns", "", "instance reverse DNS record")
 	vmCmd.AddCommand(vmUpdateCmd)
 }


### PR DESCRIPTION
For some consistency with the Web portal, we should not compress the user-data by default.

In the context of the Fedora CoreOS template, Ignition accept only not compressed user-data:
https://github.com/coreos/ignition/pull/1345