### PR TITLE
dbaas type show: add --backup-config flag

### DIFF
--- a/cmd/output.go
+++ b/cmd/output.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -430,4 +431,12 @@ For the complete Go templating reference, see https://godoc.org/text/template
 `,
 	},
 	)
+}
+
+func Int64PtrFormatOutput(n *int64) string {
+	if n != nil {
+		return strconv.FormatInt(*n, 10)
+	}
+
+	return "n/a"
 }


### PR DESCRIPTION
New flag `--backup-config` prints backup configuration for service type and plan.

```
$ exo dbaas type show redis --help

....

Flags:
      --backup-config string   show backup configuration for the Database Service type and Plan
  -h, --help                   help for show
      --plans                  list plans offered for the Database Service type
      --settings string        show settings supported by the Database Service type

$ exo dbaas type show pg --backup-config startup-8 
┼────────────────────────────┼──────┼
│ Backup interval (hours)    │ 24   │
│ Max backups                │ 3    │
│ Recovery mode              │ pitr │
│ Frequent backup interval   │ n/a  │
│ Frequent backup max age    │ n/a  │
│ Infrequent backup interval │ n/a  │
│ Infrequent backup max age  │ n/a  │
┼────────────────────────────┼──────┼
```