### PR TITLE
Remove legacy example usage

### DIFF
--- a/cmd/sks_kubeconfig.go
+++ b/cmd/sks_kubeconfig.go
@@ -44,7 +44,8 @@ certificates.
 Example usage:
 
     # Obtain "cluster-admin" credentials
-    $ exo sks kubeconfig my-cluster admin \
+    $ exo compute sks kubeconfig my-cluster admin \
+     	--zone de-fra-1 \
         -g system:masters \
         -t $((86400 * 7)) > $HOME/.kube/my-cluster.config
     $ kubeconfig --kubeconfig=$HOME/.kube/my-cluster.config get pods


### PR DESCRIPTION
The exo sks command seems to be deprecated, replace example usage with current API
Add zone to example usage because it is not obvious to specify a zone if a cluster is not in the default zone