### PR TITLE
Dbaas logs: Improve help for --offset

### DIFF
--- a/cmd/dbaas_logs.go
+++ b/cmd/dbaas_logs.go
@@ -51,7 +51,7 @@ type dbaasServiceLogsCmd struct {
 	Name string `cli-arg:"#"`
 
 	Limit  int64  `cli-short:"l" cli-usage:"number of log messages to retrieve"`
-	Offset string `cli-short:"o" cli-usage:"log listing offset"`
+	Offset string `cli-short:"o" cli-usage:"opaque offset identifier (can be found in the JSON output of the command)"`
 	Sort   string `cli-usage:"log messages sorting order (asc|desc)"`
 	Zone   string `cli-short:"z" cli-usage:"Database Service zone"`
 }


### PR DESCRIPTION
fixes #443

The usage of the `--offset` parameter was unclear.
It takes an opaque offset identifier as parameter.

```
$ ./cli dbaas logs -h
This command outputs a Database Service logs.
|...]

Flags:
  -h, --help            help for logs
  -l, --limit int       number of log messages to retrieve (default 10)
  -o, --offset string   opaque offset identifier (can be found in the JSON output of the command)
      --sort string     log messages sorting order (asc|desc) (default "desc")
  -z, --zone string     Database Service zone

[...]
```