### PR TITLE
instance list: fix panic when no ip

### DIFF
--- a/cmd/instance_list.go
+++ b/cmd/instance_list.go
@@ -95,7 +95,7 @@ func (c *instanceListCmd) cmdRun(_ *cobra.Command, _ []string) error {
 				Name:      *i.Name,
 				Zone:      zone,
 				Type:      fmt.Sprintf("%s.%s", *instanceType.Family, *instanceType.Size),
-				IPAddress: i.PublicIPAddress.String(),
+				IPAddress: defaultIp(i.PublicIPAddress, "-"),
 				State:     *i.State,
 			}
 		}

--- a/cmd/instance_show.go
+++ b/cmd/instance_show.go
@@ -87,13 +87,8 @@ func (c *instanceShowCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 		DiskSize:           humanize.IBytes(uint64(*instance.DiskSize << 30)),
 		ElasticIPs:         make([]string, 0),
 		ID:                 *instance.ID,
-		IPAddress:          instance.PublicIPAddress.String(),
-		IPv6Address: func() string {
-			if instance.IPv6Address != nil {
-				return instance.IPv6Address.String()
-			}
-			return "-"
-		}(),
+		IPAddress:          defaultIp(instance.PublicIPAddress, "-"),
+		IPv6Address:        defaultIp(instance.IPv6Address, "-"),
 		Labels: func() (v map[string]string) {
 			if instance.Labels != nil {
 				v = *instance.Labels

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 )
@@ -42,6 +43,15 @@ func defaultString(s *string, def string) string {
 func defaultBool(b *bool, def bool) bool {
 	if b != nil {
 		return *b
+	}
+
+	return def
+}
+
+// defaultIP returns the IP as string if not nil, otherwise the default value specified.
+func defaultIp(i *net.IP, def string) string {
+	if i != nil {
+		return i.String()
 	}
 
 	return def


### PR DESCRIPTION
This change prevents the `exo compute instance list` command from panicking if an instance has no IP address (when an instance is created, during a short time, instance has no IP address).

```
┼──────────────────────────────────────┼──────────────────┼──────────┼─────────────────┼─────────────────┼─────────┼
│                  ID                  │       NAME       │   ZONE   │      TYPE       │   IP ADDRESS    │  STATE  │
┼──────────────────────────────────────┼──────────────────┼──────────┼─────────────────┼─────────────────┼─────────┼
│ a1d55bee-66fe-4847-bdce-fc7c50ce4411 │ test             │ ch-gva-2 │ standard.medium │ -               │ stopped │
┼──────────────────────────────────────┼──────────────────┼──────────┼─────────────────┼─────────────────┼─────────┼
```