### PR TITLE
elastic_ip: add support for IPv6

### DIFF
--- a/cmd/elastic_ip_create.go
+++ b/cmd/elastic_ip_create.go
@@ -16,6 +16,7 @@ type elasticIPCreateCmd struct {
 	_ bool `cli-cmd:"create"`
 
 	Description               string `cli-usage:"Elastic IP description"`
+	IPv6                      bool   `cli-flag:"ipv6" cli-usage:"create IPv6 Elastic IP address instead of IPv4"`
 	HealthcheckInterval       int64  `cli-usage:"managed Elastic IP health checking interval in seconds"`
 	HealthcheckMode           string `cli-usage:"managed Elastic IP health checking mode (tcp|http|https)"`
 	HealthcheckPort           int64  `cli-usage:"managed Elastic IP health checking port"`
@@ -79,6 +80,10 @@ func (c *elasticIPCreateCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	elasticIP := &egoscale.ElasticIP{
 		Description: nonEmptyStringPtr(c.Description),
 		Healthcheck: healthcheck,
+	}
+
+	if c.IPv6 {
+		elasticIP.AddressFamily = nonEmptyStringPtr("inet6")
 	}
 
 	var err error

--- a/cmd/elastic_ip_show.go
+++ b/cmd/elastic_ip_show.go
@@ -14,6 +14,8 @@ import (
 type elasticIPShowOutput struct {
 	ID                       string         `json:"id"`
 	IPAddress                string         `json:"ip_address"`
+	AddressFamily            string         `json:"address_family"`
+	CIDR                     string         `json:"cidr"`
 	Description              string         `json:"description"`
 	Zone                     string         `json:"zone"`
 	Type                     string         `json:"type"`
@@ -37,6 +39,8 @@ func (o *elasticIPShowOutput) toTable() {
 
 	t.Append([]string{"ID", o.ID})
 	t.Append([]string{"IP Address", o.IPAddress})
+	t.Append([]string{"Address Family", o.AddressFamily})
+	t.Append([]string{"CIDR", o.CIDR})
 	t.Append([]string{"Description", o.Description})
 	t.Append([]string{"Zone", o.Zone})
 	t.Append([]string{"Type", o.Type})
@@ -95,11 +99,13 @@ func (c *elasticIPShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	}
 
 	out := elasticIPShowOutput{
-		ID:          *elasticIP.ID,
-		IPAddress:   elasticIP.IPAddress.String(),
-		Description: defaultString(elasticIP.Description, ""),
-		Zone:        c.Zone,
-		Type:        "manual",
+		ID:            *elasticIP.ID,
+		IPAddress:     elasticIP.IPAddress.String(),
+		AddressFamily: defaultString(elasticIP.AddressFamily, ""),
+		CIDR:          defaultString(elasticIP.CIDR, ""),
+		Description:   defaultString(elasticIP.Description, ""),
+		Zone:          c.Zone,
+		Type:          "manual",
 	}
 
 	if elasticIP.Healthcheck != nil {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/exoscale/egoscale v0.89.0
+	github.com/exoscale/egoscale v0.90.0
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,10 +103,8 @@ github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/exoscale/egoscale v0.88.2 h1:ak/uNYr0H7xEGYRNj9FKg9oleVi/891+BIqD2yB4/S8=
-github.com/exoscale/egoscale v0.88.2/go.mod h1:wyXE5zrnFynMXA0jMhwQqSe24CfUhmBk2WI5wFZcq6Y=
-github.com/exoscale/egoscale v0.89.0 h1:YEA3pG97j14diC6okttXMOH9mLwlMuv/184uZyUGxhk=
-github.com/exoscale/egoscale v0.89.0/go.mod h1:wyXE5zrnFynMXA0jMhwQqSe24CfUhmBk2WI5wFZcq6Y=
+github.com/exoscale/egoscale v0.90.0 h1:DZBXVU3iHqu5Ju5lQ5jWVlPo0IpI98SUo8Aa1UQVrmo=
+github.com/exoscale/egoscale v0.90.0/go.mod h1:wyXE5zrnFynMXA0jMhwQqSe24CfUhmBk2WI5wFZcq6Y=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
@@ -117,7 +115,6 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/getkin/kin-openapi v0.22.0/go.mod h1:WGRs2ZMM1Q8LR1QBEwUxC6RJEfaBcD0s+pcEVXFuAjw=
 github.com/getkin/kin-openapi v0.87.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
-github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.7.4/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjXkfUtY=

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,13 +1,18 @@
 Changelog
 =========
 
+0.90.0
+------
+
+- feature: v2: add support for Elastic IPv6
+
 0.89.0
-----
+------
 
 - feature: v2: add support for DNS management
 
 0.88.2
-----
+------
 
 - feature: v2: add support for Build, Maintainer and Version attributes to RegisterTemplate
 

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.89.0"
+const Version = "0.90.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.0
 ## explicit
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.89.0
+# github.com/exoscale/egoscale v0.90.0
 ## explicit
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/v2


### PR DESCRIPTION
This PR adds supports for Elastic IPv6.

New flag `--ipv6` added to `compute elastic-ip create` command.
New fields in `compute elastic-ip show`: `Address Family` (inet4 or inet6) and `CIDR`.
Output of `compute elastic-ip list` unchanged.

```
$ go run . c elastic-ip create --ipv6 --description myip
 ✔ Creating Elastic IP... 3s
┼────────────────┼──────────────────────────────────────┼
│   ELASTIC IP   │                                      │
┼────────────────┼──────────────────────────────────────┼
│ ID             │ 429aca0f-9a30-4cb3-88da-808ff91bdd97 │
│ IP Address     │ 2a04:c43:e00:a127:500:1:0:1          │
│ Address Family │ inet6                                │
│ CIDR           │ 2a04:c43:e00:a127:500:1::/96         │
│ Description    │ myip                                 │
│ Zone           │ ch-gva-2                             │
│ Type           │ manual                               │
┼────────────────┼──────────────────────────────────────┼
``` 