### PR TITLE
Fix panic in nlb list if a NLB doesn't have an IP yet

### DIFF
--- a/cmd/instance_list.go
+++ b/cmd/instance_list.go
@@ -95,7 +95,7 @@ func (c *instanceListCmd) cmdRun(_ *cobra.Command, _ []string) error {
 				Name:      *i.Name,
 				Zone:      zone,
 				Type:      fmt.Sprintf("%s.%s", *instanceType.Family, *instanceType.Size),
-				IPAddress: defaultIp(i.PublicIPAddress, "-"),
+				IPAddress: defaultIP(i.PublicIPAddress, "-"),
 				State:     *i.State,
 			}
 		}

--- a/cmd/instance_show.go
+++ b/cmd/instance_show.go
@@ -87,8 +87,8 @@ func (c *instanceShowCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 		DiskSize:           humanize.IBytes(uint64(*instance.DiskSize << 30)),
 		ElasticIPs:         make([]string, 0),
 		ID:                 *instance.ID,
-		IPAddress:          defaultIp(instance.PublicIPAddress, "-"),
-		IPv6Address:        defaultIp(instance.IPv6Address, "-"),
+		IPAddress:          defaultIP(instance.PublicIPAddress, "-"),
+		IPv6Address:        defaultIP(instance.IPv6Address, "-"),
 		Labels: func() (v map[string]string) {
 			if instance.Labels != nil {
 				v = *instance.Labels

--- a/cmd/nlb_list.go
+++ b/cmd/nlb_list.go
@@ -73,11 +73,16 @@ func (c *nlbListCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		}
 
 		for _, nlb := range list {
+			ip := ""
+			if nlb.IPAddress != nil {
+				ip = nlb.IPAddress.String()
+			}
+
 			res <- nlbListItemOutput{
 				ID:        *nlb.ID,
 				Name:      *nlb.Name,
 				Zone:      zone,
-				IPAddress: nlb.IPAddress.String(),
+				IPAddress: ip,
 			}
 		}
 

--- a/cmd/nlb_list.go
+++ b/cmd/nlb_list.go
@@ -73,16 +73,11 @@ func (c *nlbListCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		}
 
 		for _, nlb := range list {
-			ip := ""
-			if nlb.IPAddress != nil {
-				ip = nlb.IPAddress.String()
-			}
-
 			res <- nlbListItemOutput{
 				ID:        *nlb.ID,
 				Name:      *nlb.Name,
 				Zone:      zone,
-				IPAddress: ip,
+				IPAddress: defaultIP(nlb.IPAddress, ""),
 			}
 		}
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -49,7 +49,7 @@ func defaultBool(b *bool, def bool) bool {
 }
 
 // defaultIP returns the IP as string if not nil, otherwise the default value specified.
-func defaultIp(i *net.IP, def string) string {
+func defaultIP(i *net.IP, def string) string {
 	if i != nil {
 		return i.String()
 	}


### PR DESCRIPTION
fixes #464

```
$ go run . compute nlb list

┼──────────────────────────────────────┼──────┼──────────┼────────────┼
│                  ID                  │ NAME │   ZONE   │ IP ADDRESS │
┼──────────────────────────────────────┼──────┼──────────┼────────────┼
│ 8148907c-7826-4957-8dfb-5f09beffb7a9 │ toto │ at-vie-1 │            │
│ 8148907c-7826-4957-8dfb-5f09beffb7a9 │ toto │ ch-gva-2 │            │
│ 8148907c-7826-4957-8dfb-5f09beffb7a9 │ toto │ ch-dk-2  │            │
│ 8148907c-7826-4957-8dfb-5f09beffb7a9 │ toto │ de-fra-1 │            │
┼──────────────────────────────────────┼──────┼──────────┼────────────┼

vs

$ exo compute nlb list
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xfc315d]

goroutine 53 [running]:
github.com/exoscale/cli/cmd.(*nlbListCmd).cmdRun.func2({0x1284fd8, 0x8})
	github.com/exoscale/cli/cmd/nlb_list.go:80 +0x1fd
github.com/exoscale/cli/cmd.forEachZone.func1()
	github.com/exoscale/cli/cmd/request.go:225 +0x25
github.com/hashicorp/go-multierror.(*Group).Go.func1()
	github.com/hashicorp/go-multierror@v1.1.0/group.go:23 +0x67
created by github.com/hashicorp/go-multierror.(*Group).Go
	github.com/hashicorp/go-multierror@v1.1.0/group.go:20 +0x8d
```