### PR TITLE
Update 'Not Found' error message to include search zone where relevant

### DIFF
--- a/cmd/elastic_ip_delete.go
+++ b/cmd/elastic_ip_delete.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
@@ -36,6 +37,9 @@ func (c *elasticIPDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	elasticIP, err := cs.FindElasticIP(ctx, c.Zone, c.ElasticIP)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/elastic_ip_show.go
+++ b/cmd/elastic_ip_show.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -95,6 +96,10 @@ func (c *elasticIPShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	elasticIP, err := cs.FindElasticIP(ctx, c.Zone, c.ElasticIP)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
+
 		return err
 	}
 

--- a/cmd/elastic_ip_update.go
+++ b/cmd/elastic_ip_update.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -55,6 +56,9 @@ func (c *elasticIPUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 
 	elasticIP, err := cs.FindElasticIP(ctx, c.Zone, c.ElasticIP)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_delete.go
+++ b/cmd/instance_delete.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -36,6 +37,9 @@ func (c *instanceDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_elastic_ip_attach.go
+++ b/cmd/instance_elastic_ip_attach.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -43,6 +44,9 @@ func (c *instanceEIPAttachCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_elastic_ip_detach.go
+++ b/cmd/instance_elastic_ip_detach.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -43,6 +44,9 @@ func (c *instanceEIPDetachCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_pool_delete.go
+++ b/cmd/instance_pool_delete.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
@@ -34,6 +35,9 @@ func (c *instancePoolDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	instancePool, err := cs.FindInstancePool(ctx, c.Zone, c.InstancePool)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_pool_evict.go
+++ b/cmd/instance_pool_evict.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
@@ -53,6 +54,9 @@ func (c *instancePoolEvictCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 
 	instancePool, err := cs.FindInstancePool(ctx, c.Zone, c.InstancePool)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_pool_scale.go
+++ b/cmd/instance_pool_scale.go
@@ -58,6 +58,9 @@ func (c *instancePoolScaleCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	instancePool, err := cs.FindInstancePool(ctx, c.Zone, c.InstancePool)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_pool_show.go
+++ b/cmd/instance_pool_show.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -67,6 +68,10 @@ func (c *instancePoolShowCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 
 	instancePool, err := cs.FindInstancePool(ctx, c.Zone, c.InstancePool)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
+
 		return err
 	}
 

--- a/cmd/instance_pool_update.go
+++ b/cmd/instance_pool_update.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -133,6 +134,9 @@ func (c *instancePoolUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 
 	instancePool, err := cs.FindInstancePool(ctx, c.Zone, c.InstancePool)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_private_network_attach.go
+++ b/cmd/instance_private_network_attach.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -46,6 +47,9 @@ func (c *instancePrivnetAttachCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_private_network_detach.go
+++ b/cmd/instance_private_network_detach.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -43,6 +44,9 @@ func (c *instancePrivnetDetachCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_private_network_updateip.go
+++ b/cmd/instance_private_network_updateip.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -46,6 +47,9 @@ func (c *instancePrivnetUpdateIPCmd) cmdRun(_ *cobra.Command, _ []string) error 
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_reboot.go
+++ b/cmd/instance_reboot.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
@@ -34,6 +35,9 @@ func (c *instanceRebootCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_resizedisk.go
+++ b/cmd/instance_resizedisk.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -41,6 +42,9 @@ func (c *instanceResizeDiskCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_scale.go
+++ b/cmd/instance_scale.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -44,6 +45,9 @@ func (c *instanceScaleCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_scp.go
+++ b/cmd/instance_scp.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -95,6 +96,9 @@ func (c *instanceSCPCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_security_group_add.go
+++ b/cmd/instance_security_group_add.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -46,6 +47,9 @@ func (c *instanceSGAddCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_security_group_remove.go
+++ b/cmd/instance_security_group_remove.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -48,6 +49,9 @@ func (c *instanceSGRemoveCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_show.go
+++ b/cmd/instance_show.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -65,6 +66,9 @@ func (c *instanceShowCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_snapshot_delete.go
+++ b/cmd/instance_snapshot_delete.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
@@ -36,6 +37,9 @@ func (c *instanceSnapshotDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	snapshot, err := cs.GetSnapshot(ctx, c.Zone, c.ID)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_snapshot_export.go
+++ b/cmd/instance_snapshot_export.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -51,6 +52,9 @@ func (c *instanceSnapshotExportCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	snapshot, err := cs.GetSnapshot(ctx, c.Zone, c.ID)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_snapshot_revert.go
+++ b/cmd/instance_snapshot_revert.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -49,6 +50,9 @@ func (c *instanceSnapshotRevertCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_snapshot_show.go
+++ b/cmd/instance_snapshot_show.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -56,6 +57,9 @@ func (c *instanceSnapshotShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	snapshot, err := cs.GetSnapshot(ctx, c.Zone, c.ID)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return fmt.Errorf("error retrieving Compute instance snapshot: %w", err)
 	}
 

--- a/cmd/instance_ssh.go
+++ b/cmd/instance_ssh.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -81,6 +82,9 @@ func (c *instanceSSHCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_start.go
+++ b/cmd/instance_start.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	egoscale "github.com/exoscale/egoscale/v2"
@@ -36,6 +37,9 @@ func (c *instanceStartCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_stop.go
+++ b/cmd/instance_stop.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
@@ -34,6 +35,9 @@ func (c *instanceStopCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/instance_update.go
+++ b/cmd/instance_update.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -46,6 +47,9 @@ func (c *instanceUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/private_network_delete.go
+++ b/cmd/private_network_delete.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
@@ -36,6 +37,9 @@ func (c *privateNetworkDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	privateNetwork, err := cs.FindPrivateNetwork(ctx, c.Zone, c.PrivateNetwork)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/private_network_show.go
+++ b/cmd/private_network_show.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -103,6 +104,9 @@ func (c *privateNetworkShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	privateNetwork, err := cs.FindPrivateNetwork(ctx, c.Zone, c.PrivateNetwork)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/private_network_update.go
+++ b/cmd/private_network_update.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -48,6 +49,9 @@ func (c *privateNetworkUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 
 	privateNetwork, err := cs.FindPrivateNetwork(ctx, c.Zone, c.PrivateNetwork)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/sks_authority_cert.go
+++ b/cmd/sks_authority_cert.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -60,6 +61,9 @@ func (c *sksAuthorityCertCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
 	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/sks_delete.go
+++ b/cmd/sks_delete.go
@@ -36,6 +36,9 @@ func (c *sksDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/sks_deprecated_resources.go
+++ b/cmd/sks_deprecated_resources.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -62,6 +63,9 @@ func (c *sksDeprecatedResourcesCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/sks_kubeconfig.go
+++ b/cmd/sks_kubeconfig.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -118,6 +119,9 @@ func (c *sksKubeconfigCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/sks_nodepool_add.go
+++ b/cmd/sks_nodepool_add.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -61,6 +62,9 @@ func (c *sksNodepoolAddCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return fmt.Errorf("error retrieving cluster: %w", err)
 	}
 

--- a/cmd/sks_nodepool_delete.go
+++ b/cmd/sks_nodepool_delete.go
@@ -42,6 +42,9 @@ func (c *sksNodepoolDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/sks_nodepool_evict.go
+++ b/cmd/sks_nodepool_evict.go
@@ -63,6 +63,9 @@ func (c *sksNodepoolEvictCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 
 	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/sks_nodepool_scale.go
+++ b/cmd/sks_nodepool_scale.go
@@ -60,6 +60,9 @@ func (c *sksNodepoolScaleCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/sks_nodepool_show.go
+++ b/cmd/sks_nodepool_show.go
@@ -69,6 +69,9 @@ func (c *sksNodepoolShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/sks_nodepool_update.go
+++ b/cmd/sks_nodepool_update.go
@@ -59,6 +59,9 @@ func (c *sksNodepoolUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 
 	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/sks_rotate_ccm_credentials.go
+++ b/cmd/sks_rotate_ccm_credentials.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
@@ -39,6 +40,9 @@ func (c *sksRotateCCMCredentialsCmd) cmdRun(_ *cobra.Command, _ []string) error 
 
 	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/sks_show.go
+++ b/cmd/sks_show.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -107,6 +108,9 @@ func (c *sksShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/sks_update.go
+++ b/cmd/sks_update.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -46,6 +47,9 @@ func (c *sksUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 
 	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/sks_upgrade.go
+++ b/cmd/sks_upgrade.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -37,6 +38,9 @@ func (c *sksUpgradeCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 

--- a/cmd/sks_upgrade_service_level.go
+++ b/cmd/sks_upgrade_service_level.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	exoapi "github.com/exoscale/egoscale/v2/api"
@@ -50,6 +51,9 @@ func (c *sksUpgradeServiceLevelCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	cluster, err := cs.FindSKSCluster(ctx, c.Zone, c.Cluster)
 	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
 		return err
 	}
 


### PR DESCRIPTION
This PR adds zone information to relevant error messages.

It is a common mistake to forget zone flag (`-z <zone>`) for resources not in default zone. Updated error message should help with debugging.