### PR TITLE
Fix panic in nlb show if a NLB doesn't have an IP yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.59.2
+
+### Bug Fixes
+
+- Fix panic in nlb show if a NLB doesn't have an IP yet (#473)
+- Remove SOS certs that were shipped as a workaround with Windows releases (#470)
+
 ## 1.59.1
 
 ### Bug Fixes

--- a/cmd/nlb_show.go
+++ b/cmd/nlb_show.go
@@ -126,7 +126,7 @@ func (c *nlbShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		Description:  defaultString(nlb.Description, ""),
 		CreationDate: nlb.CreatedAt.String(),
 		Zone:         c.Zone,
-		IPAddress:    nlb.IPAddress.String(),
+		IPAddress:    defaultIP(nlb.IPAddress, ""),
 		State:        *nlb.State,
 		Services:     svcOut,
 		Labels: func() (v map[string]string) {


### PR DESCRIPTION
fixes #471 and CHANGELOG for 1.59.2