### PR TITLE
config: allow specifying a default output format

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -36,6 +36,7 @@ type account struct {
 	DefaultSSHKey        string
 	DefaultTemplate      string
 	DefaultRunstatusPage string
+	DefaultOutputFormat  string
 	CustomHeaders        map[string]string
 }
 
@@ -172,6 +173,7 @@ func saveConfig(filePath string, newAccounts *config) error {
 		accounts[i]["endpoint"] = acc.Endpoint
 		accounts[i]["key"] = acc.Key
 		accounts[i]["defaultZone"] = acc.DefaultZone
+		accounts[i]["defaultOutputFormat"] = acc.DefaultOutputFormat
 		accounts[i]["environment"] = acc.Environment
 		if acc.DefaultSSHKey != "" {
 			accounts[i]["defaultSSHKey"] = acc.DefaultSSHKey

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -275,12 +275,6 @@ func initConfig() {
 		log.Fatalf("default account not defined")
 	}
 
-	if gOutputFormat == "" {
-		if gOutputFormat = config.DefaultOutputFormat; gOutputFormat == "" {
-			gOutputFormat = defaultOutputFormat
-		}
-	}
-
 	if gAccountName == "" {
 		gAccountName = config.DefaultAccount
 	}
@@ -313,6 +307,16 @@ func initConfig() {
 
 	if gCurrentAccount.DefaultZone == "" {
 		gCurrentAccount.DefaultZone = defaultZone
+	}
+
+	// if an output format isn't specified via cli argument, use
+	// the current account default format
+	if gOutputFormat == "" {
+		if gCurrentAccount.DefaultOutputFormat != "" {
+			gOutputFormat = gCurrentAccount.DefaultOutputFormat
+		} else {
+			gOutputFormat = defaultOutputFormat
+		}
 	}
 
 	if gCurrentAccount.DNSEndpoint == "" {


### PR DESCRIPTION
Allow providing a "defaultOutputFormat" in the config file.  The command line argument still takes precedence.

Tested-by: Aaron Groom <aarongroom@users.noreply.github.com>