### PR TITLE
Add configuration parameter to set API timeout

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -73,7 +73,7 @@ func buildClient() {
 		gCurrentAccount.Key,
 		gCurrentAccount.APISecret(),
 		exov2.ClientOptWithAPIEndpoint(gCurrentAccount.Endpoint),
-		exov2.ClientOptWithTimeout(5*time.Minute),
+		exov2.ClientOptWithTimeout(time.Minute*time.Duration(gCurrentAccount.ClientTimeout)),
 		exov2.ClientOptWithHTTPClient(func() *http.Client {
 			return &http.Client{
 				Transport: newCLIRoundTripper(http.DefaultTransport, gCurrentAccount.CustomHeaders),

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -37,6 +37,7 @@ type account struct {
 	DefaultTemplate      string
 	DefaultRunstatusPage string
 	DefaultOutputFormat  string
+	ClientTimeout        int
 	CustomHeaders        map[string]string
 }
 
@@ -87,6 +88,7 @@ const (
 	defaultRunstatusEndpoint  = "https://api.runstatus.com"
 	defaultZone               = "ch-dk-2"
 	defaultOutputFormat       = "table"
+	defaultClientTimeout      = 10
 )
 
 var configCmd = &cobra.Command{
@@ -174,6 +176,7 @@ func saveConfig(filePath string, newAccounts *config) error {
 		accounts[i]["key"] = acc.Key
 		accounts[i]["defaultZone"] = acc.DefaultZone
 		accounts[i]["defaultOutputFormat"] = acc.DefaultOutputFormat
+		accounts[i]["clientTimeout"] = acc.ClientTimeout
 		accounts[i]["environment"] = acc.Environment
 		if acc.DefaultSSHKey != "" {
 			accounts[i]["defaultSSHKey"] = acc.DefaultSSHKey

--- a/cmd/config_show.go
+++ b/cmd/config_show.go
@@ -17,6 +17,7 @@ type configShowOutput struct {
 	StorageAPIEndpoint string `json:"storage_api_endpoint,omitempty"`
 	DNSAPIEndpoint     string `json:"dns_api_endpoint,omitempty" outputLabel:"DNS API Endpoint"`
 	ConfigFile         string `json:"config_file" outputLabel:"Configuration File"`
+	ClientTimeout      int    `json:"client_timeout" outputLabel:"API Timeout (in minutes)"`
 }
 
 func (o *configShowOutput) Type() string { return "Account" }
@@ -69,6 +70,7 @@ func showConfig(name string) (outputter, error) {
 		ComputeAPIEndpoint: account.Endpoint,
 		StorageAPIEndpoint: account.SosEndpoint,
 		DNSAPIEndpoint:     account.DNSEndpoint,
+		ClientTimeout:      account.ClientTimeout,
 	}
 
 	return &out, nil

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -40,6 +40,7 @@ variables supported:
   * EXOSCALE_API_KEY: the Exoscale client API key
   * EXOSCALE_API_SECRET: the Exoscale client API secret
   * EXOSCALE_API_ENDPOINT: the Exoscale (Compute) API endpoint to use
+  * EXOSCALE_API_TIMEOUT: the Exoscale API timeout in minutes
 
 Note: to override the current profile API credentials, *both* EXOSCALE_API_KEY
 and EXOSCALE_API_SECRET variables have to be set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/exoscale/egoscale"
@@ -333,6 +334,16 @@ func initConfig() {
 
 	if gCurrentAccount.RunstatusEndpoint == "" {
 		gCurrentAccount.RunstatusEndpoint = defaultRunstatusEndpoint
+	}
+
+	if gCurrentAccount.ClientTimeout == 0 {
+		gCurrentAccount.ClientTimeout = defaultClientTimeout
+	}
+	clientTimeoutFromEnv := readFromEnv("EXOSCALE_API_TIMEOUT")
+	if clientTimeoutFromEnv != "" {
+		if t, err := strconv.Atoi(clientTimeoutFromEnv); err == nil {
+			gCurrentAccount.ClientTimeout = t
+		}
 	}
 
 	gCurrentAccount.Endpoint = strings.TrimRight(gCurrentAccount.Endpoint, "/")

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	github.com/vbauerster/mpb/v4 v4.12.2
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
-	golang.org/x/net v0.0.0-20210913180222-943fd674d43e // indirect
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c // indirect
 	gopkg.in/h2non/gentleman.v2 v2.0.4

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -338,7 +338,6 @@ golang.org/x/crypto/ssh/terminal
 # golang.org/x/lint v0.0.0-20190930215403-16217165b5de
 golang.org/x/lint
 # golang.org/x/net v0.0.0-20210913180222-943fd674d43e
-## explicit
 golang.org/x/net/http/httpguts
 golang.org/x/net/idna
 golang.org/x/net/publicsuffix


### PR DESCRIPTION
This PR adds `clientTimeout` configuration option (and `EXOSCALE_API_TIMEOUT` environment override) to set a egoscale API timeout. Extending API timeout is sometimes needed for async actions such as `instance_create`, `instance_pool_destroy`, etc.

Also extends default timeout from 5 minutes to 10 minutes.

```
$ go run . config show
┼──────────────────────────┼──────────────────────────────────────────────┼
│         ACCOUNT          │                                              │
┼──────────────────────────┼──────────────────────────────────────────────┼
│ Name                     │ my-account                                   │
│ API Key                  │ EXOxxxxxxxxxxxxxxxxxxxxxxxxx                 │
│ API Secret               │ ×××××××××××××××××××××××××××                  │
│ Default Zone             │ ch-gva-2                                     │
│ Default Template         │ Linux Ubuntu 22.04 LTS 64-bit                │
│ Compute API Endpoint     │ https://api.exoscale.com/v1                  │
│ Storage API Endpoint     │ https://sos-{zone}.exo.io                    │
│ DNS API Endpoint         │ https://api.exoscale.com/dns                 │
│ Configuration File       │ /home/<user>/.config/exoscale/exoscale.toml │
│ API Timeout (in minutes) │ 5                                            │
┼──────────────────────────┼──────────────────────────────────────────────┼
```

```
$ go run . environment
The exo CLI tool allows users to override some account configuration settings
by specifying shell environment variables. Here is the list of environment
variables supported:

  * EXOSCALE_API_KEY: the Exoscale client API key
  * EXOSCALE_API_SECRET: the Exoscale client API secret
  * EXOSCALE_API_ENDPOINT: the Exoscale (Compute) API endpoint to use
  * EXOSCALE_API_TIMEOUT: the Exoscale API timeout in minutes

Note: to override the current profile API credentials, *both* EXOSCALE_API_KEY
and EXOSCALE_API_SECRET variables have to be set.
```

