### PR TITLE
Set default API timeout when env credentials are used

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -192,6 +192,10 @@ func initConfig() {
 		}
 		gCurrentAccount.DNSEndpoint = buildDNSAPIEndpoint(gCurrentAccount.Endpoint)
 
+		if gCurrentAccount.ClientTimeout == 0 {
+			gCurrentAccount.ClientTimeout = defaultClientTimeout
+		}
+
 		gAllAccount = &config{
 			DefaultAccount: gCurrentAccount.Name,
 			Accounts:       []account{*gCurrentAccount},


### PR DESCRIPTION
Fixes panic in the new feature ( #478 ) when credentials are set using environment variables.