### PR TITLE
Implements v2 Reverse DNS options

### DIFF
--- a/cmd/elastic_ip_show.go
+++ b/cmd/elastic_ip_show.go
@@ -20,6 +20,7 @@ type elasticIPShowOutput struct {
 	Description              string         `json:"description"`
 	Zone                     string         `json:"zone"`
 	Type                     string         `json:"type"`
+	ReverseDNS               string         `json:"reverse_dns"`
 	HealthcheckMode          *string        `json:"healthcheck_mode,omitempty"`
 	HealthcheckPort          *uint16        `json:"healthcheck_port,omitempty"`
 	HealthcheckURI           *string        `json:"healthcheck_uri,omitempty"`
@@ -45,6 +46,7 @@ func (o *elasticIPShowOutput) toTable() {
 	t.Append([]string{"Description", o.Description})
 	t.Append([]string{"Zone", o.Zone})
 	t.Append([]string{"Type", o.Type})
+	t.Append([]string{"Reverse DNS", o.ReverseDNS})
 
 	if o.Type == "managed" {
 		t.Append([]string{"Healthcheck Mode", *o.HealthcheckMode})
@@ -112,6 +114,17 @@ func (c *elasticIPShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		Zone:          c.Zone,
 		Type:          "manual",
 	}
+
+	rdns, err := cs.GetElasticIPReverseDNS(ctx, c.Zone, *elasticIP.ID)
+	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			out.ReverseDNS = ""
+		} else {
+			return err
+		}
+	}
+
+	out.ReverseDNS = rdns
 
 	if elasticIP.Healthcheck != nil {
 		out.Type = "managed"

--- a/cmd/instance_show.go
+++ b/cmd/instance_show.go
@@ -27,6 +27,7 @@ type instanceShowOutput struct {
 	DiskSize           string            `json:"disk_size"`
 	State              string            `json:"state"`
 	Labels             map[string]string `json:"labels"`
+	ReverseDNS         string            `json:"reverse_dns" outputLabel:"Reverse DNS"`
 }
 
 func (o *instanceShowOutput) Type() string { return "Compute instance" }
@@ -158,6 +159,17 @@ func (c *instanceShowCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	out.Template = *template.Name
+
+	rdns, err := cs.GetInstanceReverseDNS(ctx, c.Zone, *instance.ID)
+	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			out.ReverseDNS = ""
+		} else {
+			return err
+		}
+	}
+
+	out.ReverseDNS = rdns
 
 	return c.outputFunc(&out, nil)
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/exoscale/egoscale v0.91.0
+	github.com/exoscale/egoscale v0.92.0
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/exoscale/egoscale v0.91.0 h1:paq7Eap+SzuI+ml/CwwgEPq5mFmOA9fVF/YUParo6Bs=
-github.com/exoscale/egoscale v0.91.0/go.mod h1:BAb9p4rmyU+Wl400CJZO5270H2sXtdsZjLcm5xMKkz4=
+github.com/exoscale/egoscale v0.92.0 h1:Cy/oZxuiKfFhIaatkG7KBLaoG/jtoCXAgYPMT97iX/k=
+github.com/exoscale/egoscale v0.92.0/go.mod h1:BAb9p4rmyU+Wl400CJZO5270H2sXtdsZjLcm5xMKkz4=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.92.0
+------
+
+- feature: v2: implement reverse DNS management
+
 0.91.0
 ------
 

--- a/vendor/github.com/exoscale/egoscale/v2/client_mock.go
+++ b/vendor/github.com/exoscale/egoscale/v2/client_mock.go
@@ -1101,3 +1101,59 @@ func (m *oapiClientMock) UpdateDnsDomainRecordWithResponse(
 	args := m.Called(ctx, domainId, recordId, body, reqEditors)
 	return args.Get(0).(*oapi.UpdateDnsDomainRecordResponse), args.Error(1)
 }
+
+func (m *oapiClientMock) GetReverseDnsInstanceWithResponse(
+	ctx context.Context,
+	id string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.GetReverseDnsInstanceResponse, error) {
+	args := m.Called(ctx, id, reqEditors)
+	return args.Get(0).(*oapi.GetReverseDnsInstanceResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) DeleteReverseDnsInstanceWithResponse(
+	ctx context.Context,
+	id string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.DeleteReverseDnsInstanceResponse, error) {
+	args := m.Called(ctx, id, reqEditors)
+	return args.Get(0).(*oapi.DeleteReverseDnsInstanceResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) UpdateReverseDnsInstanceWithResponse(
+	ctx context.Context,
+	id string,
+	body oapi.UpdateReverseDnsInstanceJSONRequestBody,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.UpdateReverseDnsInstanceResponse, error) {
+	args := m.Called(ctx, id, body, reqEditors)
+	return args.Get(0).(*oapi.UpdateReverseDnsInstanceResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) GetReverseDnsElasticIpWithResponse(
+	ctx context.Context,
+	id string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.GetReverseDnsElasticIpResponse, error) {
+	args := m.Called(ctx, id, reqEditors)
+	return args.Get(0).(*oapi.GetReverseDnsElasticIpResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) DeleteReverseDnsElasticIpWithResponse(
+	ctx context.Context,
+	id string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.DeleteReverseDnsElasticIpResponse, error) {
+	args := m.Called(ctx, id, reqEditors)
+	return args.Get(0).(*oapi.DeleteReverseDnsElasticIpResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) UpdateReverseDnsElasticIpWithResponse(
+	ctx context.Context,
+	id string,
+	body oapi.UpdateReverseDnsElasticIpJSONRequestBody,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.UpdateReverseDnsElasticIpResponse, error) {
+	args := m.Called(ctx, id, body, reqEditors)
+	return args.Get(0).(*oapi.UpdateReverseDnsElasticIpResponse), args.Error(1)
+}

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.90.2"
+const Version = "0.92.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.0
 ## explicit
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.91.0
+# github.com/exoscale/egoscale v0.92.0
 ## explicit
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/v2


### PR DESCRIPTION
This PR implements a `--reverse-dns` flag to `compute instance` and `compute elastic-ip` commands.
Note: to delete a Reverse DNS entry, run update command with `--reverse-dns ""`.

```
$ go run . c i show update my-instance --reverse-dns example.net
 ✔ Updating instance "my-instance"... 3s
┼──────────────────────┼──────────────────────────────────────┼
│   COMPUTE INSTANCE   │                                      │
┼──────────────────────┼──────────────────────────────────────┼
│ ID                   │ 27923f37-0b18-473e-a693-a10f907baf8d │
│ Name                 │ my-instance                          │
│ Creation Date        │ 2022-12-06 21:41:09 +0000 UTC        │
│ Instance Type        │ standard.micro                       │
│ Template             │ Linux Ubuntu 22.04 LTS 64-bit        │
│ Zone                 │ ch-gva-2                             │
│ Anti-Affinity Groups │ n/a                                  │
│ Security Groups      │ default                              │
│ Private Networks     │ n/a                                  │
│ Elastic IPs          │ n/a                                  │
│ IP Address           │ x.x.x.x                       │
│ IPv6 Address         │ -                                    │
│ SSH Key              │ work-laptop                          │
│ Disk Size            │ 10 GiB                               │
│ State                │ running                              │
│ Labels               │ n/a                                  │
│ Reverse DNS          │ example.net.                         │
┼──────────────────────┼──────────────────────────────────────┼

```

```
$ go run . c elastic-ip update 41380aec-4b96-4a8d-ad81-e98be0e73372 --reverse-dns example.net
 ✔ Updating Elastic IP 41380aec-4b96-4a8d-ad81-e98be0e73372... 3s
┼────────────────┼──────────────────────────────────────┼
│   ELASTIC IP   │                                      │
┼────────────────┼──────────────────────────────────────┼
│ ID             │ 41380aec-4b96-4a8d-ad81-e98be0e73372 │
│ IP Address     │ x.x.x.x                       │
│ Address Family │ inet4                                │
│ CIDR           │ x.x.x.x/32                     │
│ Description    │                                      │
│ Zone           │ ch-gva-2                             │
│ Type           │ manual                               │
│ Reverse DNS    │ example.net.                         │
┼────────────────┼──────────────────────────────────────┼
```