### PR TITLE
Don't panic on nil pointer in dbaas opensearch commands

### DIFF
--- a/cmd/dbaas_show_opensearch.go
+++ b/cmd/dbaas_show_opensearch.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/exoscale/cli/table"
 	exoapi "github.com/exoscale/egoscale/v2/api"
@@ -221,9 +222,14 @@ func opensearchShowDatabase(db *oapi.DbaasServiceOpensearch, zone string) (outpu
 	if db.IndexPatterns != nil {
 		for _, i := range *db.IndexPatterns {
 			indexPatterns = append(indexPatterns, dbServiceOpensearchIndexPatternShowOutput{
-				MaxIndexCount:    *i.MaxIndexCount,
-				Pattern:          *i.Pattern,
-				SortingAlgorithm: string(*i.SortingAlgorithm),
+				MaxIndexCount: defaultInt64(i.MaxIndexCount, 0),
+				Pattern:       defaultString(i.Pattern, ""),
+				SortingAlgorithm: func() string {
+					if i.SortingAlgorithm != nil {
+						return string(*i.SortingAlgorithm)
+					}
+					return ""
+				}(),
 			})
 		}
 	}
@@ -231,18 +237,18 @@ func opensearchShowDatabase(db *oapi.DbaasServiceOpensearch, zone string) (outpu
 	var indexTemplate *dbServiceOpensearchIndexTemplateShowOutput
 	if db.IndexTemplate != nil {
 		indexTemplate = &dbServiceOpensearchIndexTemplateShowOutput{
-			MappingNestedObjectsLimit: *db.IndexTemplate.MappingNestedObjectsLimit,
-			NumberOfReplicas:          *db.IndexTemplate.NumberOfReplicas,
-			NumberOfShards:            *db.IndexTemplate.NumberOfShards,
+			MappingNestedObjectsLimit: defaultInt64(db.IndexTemplate.MappingNestedObjectsLimit, 0),
+			NumberOfReplicas:          defaultInt64(db.IndexTemplate.NumberOfReplicas, 0),
+			NumberOfShards:            defaultInt64(db.IndexTemplate.NumberOfShards, 0),
 		}
 	}
 
 	var dashboard *dbServiceOpensearchDashboardShowOutput
 	if db.OpensearchDashboards != nil {
 		dashboard = &dbServiceOpensearchDashboardShowOutput{
-			Enabled:                  *db.OpensearchDashboards.Enabled,
-			MaxOldSpaceSize:          *db.OpensearchDashboards.MaxOldSpaceSize,
-			OpensearchRequestTimeout: *db.OpensearchDashboards.OpensearchRequestTimeout,
+			Enabled:                  defaultBool(db.OpensearchDashboards.Enabled, false),
+			MaxOldSpaceSize:          defaultInt64(db.OpensearchDashboards.MaxOldSpaceSize, 0),
+			OpensearchRequestTimeout: defaultInt64(db.OpensearchDashboards.OpensearchRequestTimeout, 0),
 		}
 	}
 
@@ -250,26 +256,41 @@ func opensearchShowDatabase(db *oapi.DbaasServiceOpensearch, zone string) (outpu
 	if db.Users != nil {
 		for _, u := range *db.Users {
 			users = append(users, dbServiceOpensearchUserShowOutput{
-				Password: *u.Password,
-				Type:     *u.Type,
-				Username: *u.Username,
+				Password: defaultString(u.Password, ""),
+				Type:     defaultString(u.Type, ""),
+				Username: defaultString(u.Username, ""),
 			})
 		}
 	}
 
 	return &dbServiceShowOutput{
-		Zone:                  zone,
-		Name:                  string(db.Name),
-		Type:                  string(db.Type),
-		Plan:                  db.Plan,
-		CreationDate:          *db.CreatedAt,
-		Nodes:                 *db.NodeCount,
-		NodeCPUs:              *db.NodeCpuCount,
-		NodeMemory:            *db.NodeMemory,
-		UpdateDate:            *db.UpdatedAt,
-		DiskSize:              *db.DiskSize,
-		State:                 string(*db.State),
-		TerminationProtection: *db.TerminationProtection,
+		Zone: zone,
+		Name: string(db.Name),
+		Type: string(db.Type),
+		Plan: db.Plan,
+		CreationDate: func() time.Time {
+			if db.CreatedAt != nil {
+				return *db.CreatedAt
+			}
+			return time.Time{}
+		}(),
+		Nodes:      defaultInt64(db.NodeCount, 0),
+		NodeCPUs:   defaultInt64(db.NodeCpuCount, 0),
+		NodeMemory: defaultInt64(db.NodeMemory, 0),
+		UpdateDate: func() time.Time {
+			if db.UpdatedAt != nil {
+				return *db.UpdatedAt
+			}
+			return time.Time{}
+		}(),
+		DiskSize: defaultInt64(db.DiskSize, 0),
+		State: func() string {
+			if db.State != nil {
+				return string(*db.State)
+			}
+			return ""
+		}(),
+		TerminationProtection: defaultBool(db.TerminationProtection, false),
 
 		Maintenance: func() (v *dbServiceMaintenanceShowOutput) {
 			if db.Maintenance != nil {
@@ -288,15 +309,25 @@ func opensearchShowDatabase(db *oapi.DbaasServiceOpensearch, zone string) (outpu
 				}
 				return
 			}(),
-			URI:        *db.Uri,
-			URIParams:  *db.UriParams,
+			URI: defaultString(db.Uri, ""),
+			URIParams: func() map[string]interface{} {
+				if db.UriParams != nil {
+					return *db.UriParams
+				}
+				return map[string]interface{}{}
+			}(),
 			Version:    defaultString(db.Version, ""),
 			Components: components,
 			ConnectionInfo: dbServiceOpensearchConnectionInfoShowOutput{
 				DashboardURI: defaultString(db.ConnectionInfo.DashboardUri, ""),
 				Password:     defaultString(db.ConnectionInfo.Password, ""),
-				URI:          *db.ConnectionInfo.Uri,
-				Username:     defaultString(db.ConnectionInfo.Username, ""),
+				URI: func() []string {
+					if db.ConnectionInfo.Uri != nil {
+						return *db.ConnectionInfo.Uri
+					}
+					return []string{}
+				}(),
+				Username: defaultString(db.ConnectionInfo.Username, ""),
 			},
 			Description:              defaultString(db.Description, ""),
 			IndexPatterns:            indexPatterns,


### PR DESCRIPTION
This PR adds proper pointer handling (prevents panic on nil pointer) in `dbaas opensearch` commands.