### PR TITLE
Deprecates template-filter, improve search template by name

### DIFF
--- a/cmd/instance_create.go
+++ b/cmd/instance_create.go
@@ -172,23 +172,16 @@ func (c *instanceCreateCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		instance.SSHKey = sshKey.Name
 	}
 
-	templates, err := cs.ListTemplates(
-		ctx,
-		c.Zone,
-		egoscale.ListTemplatesWithVisibility(c.TemplateVisibility),
-	)
+	template, err := cs.FindTemplate(ctx, c.Zone, c.Template, c.TemplateVisibility)
 	if err != nil {
-		return fmt.Errorf("error retrieving templates: %w", err)
+		return fmt.Errorf(
+			"no template %q found with visibility %s in zone %s",
+			c.Template,
+			c.TemplateVisibility,
+			c.Zone,
+		)
 	}
-	for _, template := range templates {
-		if *template.ID == c.Template || *template.Name == c.Template {
-			instance.TemplateID = template.ID
-			break
-		}
-	}
-	if instance.TemplateID == nil {
-		return fmt.Errorf("no template %q found with visibility %s", c.Template, c.TemplateVisibility)
-	}
+	instance.TemplateID = template.ID
 
 	if c.CloudInitFile != "" {
 		userData, err := getUserDataFromFile(c.CloudInitFile, c.CloudInitCompress)

--- a/cmd/instance_reset.go
+++ b/cmd/instance_reset.go
@@ -67,24 +67,15 @@ func (c *instanceResetCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	var template *egoscale.Template
 	if c.Template != "" {
-		templates, err := cs.ListTemplates(
-			ctx,
-			c.Zone,
-			egoscale.ListTemplatesWithVisibility(c.TemplateVisibility),
-		)
+		template, err = cs.FindTemplate(ctx, c.Zone, c.Template, c.TemplateVisibility)
 		if err != nil {
-			return fmt.Errorf("error retrieving templates: %w", err)
+			return fmt.Errorf(
+				"no template %q found with visibility %s in zone %s",
+				c.Template,
+				c.TemplateVisibility,
+				c.Zone,
+			)
 		}
-		for _, t := range templates {
-			if *t.ID == c.Template || *t.Name == c.Template {
-				template = t
-				break
-			}
-		}
-		if template == nil {
-			return fmt.Errorf("no template %q found with visibility %s", c.Template, c.TemplateVisibility)
-		}
-
 		opts = append(opts, egoscale.ResetInstanceWithTemplate(template))
 	}
 

--- a/cmd/instance_template_list.go
+++ b/cmd/instance_template_list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	egoscale "github.com/exoscale/egoscale/v2"
@@ -65,6 +66,12 @@ func (c *instanceTemplateListCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	)
 	if err != nil {
 		return err
+	}
+
+	// Sort private templates by name for better visibility
+	// Public templates are sorted by Family
+	if c.Visibility == "private" {
+		sort.Sort(egoscale.ByName{Templates: templates})
 	}
 
 	out := make(instanceTemplateListOutput, 0)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/exoscale/egoscale v0.93.0
+	github.com/exoscale/egoscale v0.95.0
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/exoscale/egoscale v0.93.0 h1:QHxHrM8UULwgQbTdAUkZb6bnA7GmOodFR1MP5Upgjrg=
-github.com/exoscale/egoscale v0.93.0/go.mod h1:BAb9p4rmyU+Wl400CJZO5270H2sXtdsZjLcm5xMKkz4=
+github.com/exoscale/egoscale v0.95.0 h1:4X5ns2wDQjQ61HA347Z/HdtjRcHclgXzK1qeFzFudTk=
+github.com/exoscale/egoscale v0.95.0/go.mod h1:BAb9p4rmyU+Wl400CJZO5270H2sXtdsZjLcm5xMKkz4=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+0.95.0
+------
+
+- feature: v2: add `Client.FindTemplate()` method
+- fix: v2: error for `Client.GetTemplateByName()`
+
+0.94.0
+------
+
+- feature: v2: add `Client.GetTemplateByName()` method
+- feature: v2: implement sort.Interface for []*Template by CreatedAt or by Name
+
 0.93.0
 ------
 

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.93.0"
+const Version = "0.95.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.0
 ## explicit
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.93.0
+# github.com/exoscale/egoscale v0.95.0
 ## explicit
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/v2


### PR DESCRIPTION
- sort by name the list of private templates
-  deprecates ` template-filter` in instancepool create|update commands: replaced by `template-visibility`
- Use `FindTemplate` to search template by ID or by Name 

<details>
  <summary>Tests</summary>

```
 exo c template list  --visibility private
┼──────────────────────────────────────┼────────────────────────────┼────────────────┼───────────────────────────────┼
│                  ID                  │            NAME            │     FAMILY     │         CREATION DATE         │
┼──────────────────────────────────────┼────────────────────────────┼────────────────┼───────────────────────────────┼
│ _____________REDACTED_______________ │ tpl_D                      │ other (64-bit) │ 2021-11-18 12:50:06 +0000 UTC │
│ _____________REDACTED_______________ │ tpl_C                      │ other (64-bit) │ 2022-04-05 12:57:39 +0000 UTC │
│ _____________REDACTED_______________ │ tpl_A                      │ other (64-bit) │ 2022-11-16 08:52:29 +0000 UTC │
│ _____________REDACTED_______________ │ tpl_B                      │ other (64-bit) │ 2022-11-16 08:54:23 +0000 UTC │
│ _____________REDACTED_______________ │ tpl_B                      │ other (64-bit) │ 2022-12-13 09:59:22 +0000 UTC │
┼──────────────────────────────────────┼────────────────────────────┼────────────────┼───────────────────────────────┼


$ go run . c template list --visibility private
┼──────────────────────────────────────┼────────────────────────────┼────────────────┼───────────────────────────────┼
│                  ID                  │            NAME            │     FAMILY     │         CREATION DATE         │
┼──────────────────────────────────────┼────────────────────────────┼────────────────┼───────────────────────────────┼
│ _____________REDACTED_______________ │ tpl_A                      │ other (64-bit) │ 2022-11-16 08:52:29 +0000 UTC │
│ _____________REDACTED_______________ │ tpl_B                      │ other (64-bit) │ 2022-12-13 09:59:22 +0000 UTC │
│ _____________REDACTED_______________ │ tpl_B                      │ other (64-bit) │ 2022-11-16 08:54:23 +0000 UTC │
│ _____________REDACTED_______________ │ tpl_C                      │ other (64-bit) │ 2022-04-05 12:57:39 +0000 UTC │
│ _____________REDACTED_______________ │ tpl_D                      │ other (64-bit) │ 2021-11-18 12:50:06 +0000 UTC │
┼──────────────────────────────────────┼────────────────────────────┼────────────────┼───────────────────────────────┼

$ go run . c template show tpl_A --visibility private
┼──────────────────┼──────────────────────────────────────┼
│     TEMPLATE     │                                      │
┼──────────────────┼──────────────────────────────────────┼
│ ID               │ _____________REDACTED_______________ │
│ Zone             │ ch-gva-2                             │
│ Name             │ tpl_A                                │
│ Description      │ Generic tpl_A Template               │
│ Family           │ other (64-bit)                       │
│ Creation Date    │ 2022-12-13 09:59:22 +0000 UTC        │
│ Visibility       │ private                              │
│ Size             │ 10 GiB                               │
│ Version          │ 22.04                                │
│ Build            │ 2022-12-13-c6030d                    │
│ Maintainer       │ Exoscale                             │
│ Default User     │ ubuntu                               │
│ SSH key enabled  │ true                                 │
│ Password enabled │ true                                 │
│ Boot Mode        │ uefi                                 │
│ Checksum         │ 5ca8131db1f6c694354d6b18feb620b1     │
┼──────────────────┼──────────────────────────────────────┼

$ go run . c instance-pool create --template-filter private  --template tpl_A test
**********************************************************************
WARNING: flag "--template-filter" has been deprecated and will be removed in
a future release, please use "--template-visibility" instead.
**********************************************************************
 ✔ Creating Instance Pool "test"... 24s
┼──────────────────────┼──────────────────────────────────────┼
│    INSTANCE POOL     │                                      │
┼──────────────────────┼──────────────────────────────────────┼
│ ID                   │ _____________REDACTED_______________ │
│ Name                 │ test                                 │
│ Description          │                                      │
│ Instance Type        │ standard.medium                      │
│ Template             │ tpl_A                                │
│ Zone                 │ ch-gva-2                             │
│ Anti-Affinity Groups │ n/a                                  │
│ Security Groups      │ n/a                                  │
│ Private Networks     │ n/a                                  │
│ Elastic IPs          │ n/a                                  │
│ IPv6                 │ false                                │
│ SSH Key              │ -                                    │
│ Size                 │ 1                                    │
│ Disk Size            │ 50 GiB                               │
│ Instance Prefix      │ pool                                 │
│ State                │ scaling-up                           │
│ Labels               │ n/a                                  │
│ Instances            │ pool-2ca72-krpnf                     │
┼──────────────────────┼──────────────────────────────────────┼
$ go run . c instance-pool update --template-visibility private  --template tpl_B test
 ✔ Updating Instance Pool "test"... 9s
┼──────────────────────┼──────────────────────────────────────┼
│    INSTANCE POOL     │                                      │
┼──────────────────────┼──────────────────────────────────────┼
│ ID                   │ _____________REDACTED_______________ │
│ Name                 │ test                                 │
│ Description          │                                      │
│ Instance Type        │ standard.medium                      │
│ Template             │ tpl_B                                │
│ Zone                 │ ch-gva-2                             │
│ Anti-Affinity Groups │ n/a                                  │
│ Security Groups      │ n/a                                  │
│ Private Networks     │ n/a                                  │
│ Elastic IPs          │ n/a                                  │
│ IPv6                 │ false                                │
│ SSH Key              │ -                                    │
│ Size                 │ 1                                    │
│ Disk Size            │ 50 GiB                               │
│ Instance Prefix      │ pool                                 │
│ State                │ running                              │
│ Labels               │ n/a                                  │
│ Instances            │ pool-2ca72-krpnf                     │
┼──────────────────────┼──────────────────────────────────────┼

  ```
</details>