### PR TITLE
Add command to stop database migration

### DIFF
--- a/cmd/dbaas_migration.go
+++ b/cmd/dbaas_migration.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var dbaasMigrationCmd = &cobra.Command{
 	Use:     "migration",
-	Short:   "control database migration",
+	Short:   "database migration management",
 	Aliases: []string{"c"},
 }
 

--- a/cmd/dbaas_migration.go
+++ b/cmd/dbaas_migration.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var dbaasMigrationCmd = &cobra.Command{
 	Use:     "migration",
-	Short:   "migration status/check",
+	Short:   "control database migration",
 	Aliases: []string{"c"},
 }
 

--- a/cmd/dbaas_migration_stop.go
+++ b/cmd/dbaas_migration_stop.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type dbaasMigrationStopCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"stop"`
+
+	Name string `cli-arg:"#"`
+	Zone string `cli-short:"z" cli-usage:"Database Service zone"`
+}
+
+func (c *dbaasMigrationStopCmd) cmdAliases() []string { return []string{} }
+
+func (c *dbaasMigrationStopCmd) cmdShort() string {
+	return "Stop running migration of a Database"
+}
+
+func (c *dbaasMigrationStopCmd) cmdLong() string {
+	return "This command stops the currently running migration of a Database."
+}
+
+func (c *dbaasMigrationStopCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	cmdSetZoneFlagFromDefault(cmd)
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *dbaasMigrationStopCmd) cmdRun(cmd *cobra.Command, args []string) error {
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
+
+	dbType, err := dbaasGetType(ctx, c.Name, c.Zone)
+	if err != nil {
+		return err
+	}
+
+	decorateAsyncOperation("Stopping Database Migration...", func() {
+		switch dbType {
+		case "mysql":
+			err = cs.StopMysqlDatabaseMigration(ctx, c.Zone, c.Name)
+		case "pg":
+			err = cs.StopPgDatabaseMigration(ctx, c.Zone, c.Name)
+		case "redis":
+			err = cs.StopRedisDatabaseMigration(ctx, c.Zone, c.Name)
+		default:
+			err = fmt.Errorf("migrations not supported for database type %q", dbType)
+		}
+	})
+
+	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("migration not running in zone %q", c.Zone)
+		}
+		return fmt.Errorf("failed to stop migration: %s", err)
+	}
+
+	return nil
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(dbaasMigrationCmd, &dbaasMigrationStopCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/exoscale/egoscale v0.96.0
+	github.com/exoscale/egoscale v0.97.0
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,10 +103,8 @@ github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/exoscale/egoscale v0.95.0 h1:4X5ns2wDQjQ61HA347Z/HdtjRcHclgXzK1qeFzFudTk=
-github.com/exoscale/egoscale v0.95.0/go.mod h1:BAb9p4rmyU+Wl400CJZO5270H2sXtdsZjLcm5xMKkz4=
-github.com/exoscale/egoscale v0.96.0 h1:vTPVjDc2g2axWH6iP8FedJxJwQIINjXthRfvETZEINU=
-github.com/exoscale/egoscale v0.96.0/go.mod h1:BAb9p4rmyU+Wl400CJZO5270H2sXtdsZjLcm5xMKkz4=
+github.com/exoscale/egoscale v0.97.0 h1:9DRSdFxepQrm/BOX/tvMXmfeN7d1row9N/+D9wrFp8E=
+github.com/exoscale/egoscale v0.97.0/go.mod h1:BAb9p4rmyU+Wl400CJZO5270H2sXtdsZjLcm5xMKkz4=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.97.0
+------
+
+- v2: database migration stop methods for databases supporting it: Redis, PostgreSQL, MySQL
+
 0.96.0
 ------
 

--- a/vendor/github.com/exoscale/egoscale/v2/client_mock.go
+++ b/vendor/github.com/exoscale/egoscale/v2/client_mock.go
@@ -1157,3 +1157,30 @@ func (m *oapiClientMock) UpdateReverseDnsElasticIpWithResponse(
 	args := m.Called(ctx, id, body, reqEditors)
 	return args.Get(0).(*oapi.UpdateReverseDnsElasticIpResponse), args.Error(1)
 }
+
+func (m *oapiClientMock) StopDbaasRedisMigrationWithResponse(
+	ctx context.Context,
+	name oapi.DbaasServiceName,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.StopDbaasRedisMigrationResponse, error) {
+	args := m.Called(ctx, name, reqEditors)
+	return args.Get(0).(*oapi.StopDbaasRedisMigrationResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) StopDbaasPgMigrationWithResponse(
+	ctx context.Context,
+	name oapi.DbaasServiceName,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.StopDbaasPgMigrationResponse, error) {
+	args := m.Called(ctx, name, reqEditors)
+	return args.Get(0).(*oapi.StopDbaasPgMigrationResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) StopDbaasMysqlMigrationWithResponse(
+	ctx context.Context,
+	name oapi.DbaasServiceName,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.StopDbaasMysqlMigrationResponse, error) {
+	args := m.Called(ctx, name, reqEditors)
+	return args.Get(0).(*oapi.StopDbaasMysqlMigrationResponse), args.Error(1)
+}

--- a/vendor/github.com/exoscale/egoscale/v2/database_mysql.go
+++ b/vendor/github.com/exoscale/egoscale/v2/database_mysql.go
@@ -1,0 +1,26 @@
+package v2
+
+import (
+	"context"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	"github.com/exoscale/egoscale/v2/oapi"
+)
+
+// StopMysqlDatabaseMigration stops running Database migration.
+func (c *Client) StopMysqlDatabaseMigration(ctx context.Context, zone string, name string) error {
+	resp, err := c.StopDbaasMysqlMigrationWithResponse(apiv2.WithZone(ctx, zone), oapi.DbaasServiceName(name))
+	if err != nil {
+		return err
+	}
+
+	_, err = oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/exoscale/egoscale/v2/database_pg.go
+++ b/vendor/github.com/exoscale/egoscale/v2/database_pg.go
@@ -1,0 +1,26 @@
+package v2
+
+import (
+	"context"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	"github.com/exoscale/egoscale/v2/oapi"
+)
+
+// StopPgDatabaseMigration stops running Database migration.
+func (c *Client) StopPgDatabaseMigration(ctx context.Context, zone string, name string) error {
+	resp, err := c.StopDbaasPgMigrationWithResponse(apiv2.WithZone(ctx, zone), oapi.DbaasServiceName(name))
+	if err != nil {
+		return err
+	}
+
+	_, err = oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/exoscale/egoscale/v2/database_redis.go
+++ b/vendor/github.com/exoscale/egoscale/v2/database_redis.go
@@ -1,0 +1,26 @@
+package v2
+
+import (
+	"context"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	"github.com/exoscale/egoscale/v2/oapi"
+)
+
+// StopRedisDatabaseMigration stops running Database migration.
+func (c *Client) StopRedisDatabaseMigration(ctx context.Context, zone string, name string) error {
+	resp, err := c.StopDbaasRedisMigrationWithResponse(apiv2.WithZone(ctx, zone), oapi.DbaasServiceName(name))
+	if err != nil {
+		return err
+	}
+
+	_, err = oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.96.0"
+const Version = "0.97.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.0
 ## explicit
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.96.0
+# github.com/exoscale/egoscale v0.97.0
 ## explicit
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/v2


### PR DESCRIPTION
This PR adds a new command: `exo dbaas migration stop`.
New command will stop migration if it is running.

**Note**: due to internal implementation of Aiven API, time window to stop a migration begins couple of minutes after database creation.