### PR TITLE
sks nodepool show: add addons

### DIFF
--- a/cmd/sks_nodepool_show.go
+++ b/cmd/sks_nodepool_show.go
@@ -28,6 +28,7 @@ type sksNodepoolShowOutput struct {
 	State              string            `json:"state"`
 	Taints             []string          `json:"taints"`
 	Labels             map[string]string `json:"labels"`
+	AddOns             []string          `json:"addons"`
 }
 
 func (o *sksNodepoolShowOutput) Type() string { return "SKS Nodepool" }
@@ -86,6 +87,12 @@ func (c *sksNodepoolShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	}
 
 	out := sksNodepoolShowOutput{
+		AddOns: func() (v []string) {
+			if nodepool.AddOns != nil {
+				v = *nodepool.AddOns
+			}
+			return
+		}(),
 		AntiAffinityGroups: make([]string, 0),
 		CreationDate:       nodepool.CreatedAt.String(),
 		Description:        defaultString(nodepool.Description, ""),


### PR DESCRIPTION
```
┼──────────────────────┼──────────────────────────────────────┼
│     SKS NODEPOOL     │                                      │
┼──────────────────────┼──────────────────────────────────────┼
......
│ Version              │ 1.24.8                               │
│ Size                 │ 2                                    │
│ State                │ running                              │
│ Taints               │ n/a                                  │
│ Labels               │ n/a                                  │
│ Add Ons              │ storage-lvm                          │
┼──────────────────────┼──────────────────────────────────────┼
```