### PR TITLE
Remove hardcoded instance snapshot timeout

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -88,7 +88,7 @@ const (
 	defaultRunstatusEndpoint  = "https://api.runstatus.com"
 	defaultZone               = "ch-dk-2"
 	defaultOutputFormat       = "table"
-	defaultClientTimeout      = 10
+	defaultClientTimeout      = 20
 )
 
 var configCmd = &cobra.Command{

--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"time"
-
 	"github.com/spf13/cobra"
 )
 
@@ -32,11 +30,6 @@ var instanceCmd = &cobra.Command{
 	Use:     "instance",
 	Short:   "Compute instances management",
 	Aliases: []string{"i"},
-	PersistentPreRun: func(_ *cobra.Command, _ []string) {
-		// Some instance operations can take a long time, raising
-		// the Exoscale API client timeout as a precaution.
-		cs.Client.SetTimeout(10 * time.Minute)
-	},
 }
 
 func init() {

--- a/cmd/instance_snapshot_create.go
+++ b/cmd/instance_snapshot_create.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
@@ -37,10 +36,6 @@ func (c *instanceSnapshotCreateCmd) cmdPreRun(cmd *cobra.Command, args []string)
 }
 
 func (c *instanceSnapshotCreateCmd) cmdRun(_ *cobra.Command, _ []string) error {
-	// Snapshot creation can take a _long time_, raising
-	// the Exoscale API client timeout as a precaution.
-	cs.Client.SetTimeout(time.Hour)
-
 	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
 
 	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)

--- a/cmd/instance_snapshot_create.go
+++ b/cmd/instance_snapshot_create.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -47,6 +49,9 @@ func (c *instanceSnapshotCreateCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	decorateAsyncOperation(fmt.Sprintf("Creating snapshot of instance %q...", c.Instance), func() {
 		snapshot, err = cs.CreateInstanceSnapshot(ctx, c.Zone, instance)
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				err = fmt.Errorf("Request timeout reached. Snapshot creation is not canceled and might still be running, check the status with: exo c i snapshot list")
+			}
 			return
 		}
 	})


### PR DESCRIPTION
Instance snapshot command had a hardcoded timeout of 60 minutes without a way to extend it. This PR removes the hardcoded value. Default value is now 10 minutes (fairly small for snapshot), however timeout override is applied and can easily extend value (env `EXOSCALE_API_TIMEOUT` or config `clientTimeout`).

**edit:** Default Timeout bumped to 20 minutes. Also added descriptive error when timeout is hit on create snapshot command:

```
$ EXOSCALE_API_TIMEOUT=1 go run . c i snapshot create myinstance
 ✔ Creating snapshot of instance "myinstance"... 1m0s
error: Request timeout reached. Snapshot creation is not canceled and might still be running, check the status with : exo c i snapshot list
exit status 1
``` 