### PR TITLE
compute: add support for public security groups and password reveal

### DIFF
--- a/cmd/instance_reveal_password.go
+++ b/cmd/instance_reveal_password.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	exoapi "github.com/exoscale/egoscale/v2/api"
+	"github.com/spf13/cobra"
+)
+
+type instanceRevealCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"reveal-password"`
+
+	Instance string `cli-arg:"#" cli-usage:"NAME|ID"`
+	Zone     string `cli-short:"z" cli-usage:"instance zone"`
+}
+
+type instanceRevealOutput struct {
+	ID       string `json:"id"`
+	Password string `json:"password"`
+}
+
+func (o *instanceRevealOutput) Type() string { return "Compute instance" }
+func (o *instanceRevealOutput) toJSON()      { outputJSON(o) }
+func (o *instanceRevealOutput) toText()      { outputText(o) }
+func (o *instanceRevealOutput) toTable()     { outputTable(o) }
+
+func (c *instanceRevealCmd) cmdAliases() []string { return nil }
+
+func (c *instanceRevealCmd) cmdShort() string { return "Reveal the password of a Compute instance" }
+
+func (c *instanceRevealCmd) cmdLong() string { return "" }
+
+func (c *instanceRevealCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	cmdSetZoneFlagFromDefault(cmd)
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *instanceRevealCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(gCurrentAccount.Environment, c.Zone))
+
+	instance, err := cs.FindInstance(ctx, c.Zone, c.Instance)
+	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
+		return err
+	}
+
+	pwd, err := cs.RevealInstancePassword(ctx, c.Zone, instance)
+	if err != nil {
+		return nil
+	}
+
+	out := instanceRevealOutput{
+		ID:       *instance.ID,
+		Password: pwd,
+	}
+	return c.outputFunc(&out, nil)
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(instanceCmd, &instanceRevealCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/instance_reveal_password.go
+++ b/cmd/instance_reveal_password.go
@@ -51,7 +51,7 @@ func (c *instanceRevealCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	pwd, err := cs.RevealInstancePassword(ctx, c.Zone, instance)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	out := instanceRevealOutput{

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/exoscale/egoscale v0.98.0
+	github.com/exoscale/egoscale v0.99.0
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,12 +103,8 @@ github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/exoscale/egoscale v0.97.0 h1:9DRSdFxepQrm/BOX/tvMXmfeN7d1row9N/+D9wrFp8E=
-github.com/exoscale/egoscale v0.97.0/go.mod h1:BAb9p4rmyU+Wl400CJZO5270H2sXtdsZjLcm5xMKkz4=
-github.com/exoscale/egoscale v0.97.1-0.20230306134401-d4c9cc9c4a41 h1:zCjiXiBG/MZWtIk7T34HI4lOqop5Ig+SJDkgLK7lRAw=
-github.com/exoscale/egoscale v0.97.1-0.20230306134401-d4c9cc9c4a41/go.mod h1:BAb9p4rmyU+Wl400CJZO5270H2sXtdsZjLcm5xMKkz4=
-github.com/exoscale/egoscale v0.98.0 h1:XCmY0mRYUJMR4tmf9CHxocGRP+g4IhLUv9KUf4M/o00=
-github.com/exoscale/egoscale v0.98.0/go.mod h1:BAb9p4rmyU+Wl400CJZO5270H2sXtdsZjLcm5xMKkz4=
+github.com/exoscale/egoscale v0.99.0 h1:I4EHe0LEMBy1XJDwHU0zxKR16aHxbn5M0N44xD77AZE=
+github.com/exoscale/egoscale v0.99.0/go.mod h1:BAb9p4rmyU+Wl400CJZO5270H2sXtdsZjLcm5xMKkz4=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/CHANGELOG.md
+++ b/vendor/github.com/exoscale/egoscale/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+0.99.0
+------
+
+- feature: v2: add RevealInstancePassword
+
+0.98.1
+------
+
+- feature: v2: add FindSecurityGroups with parameter support
+
 0.98.0
 ------
 

--- a/vendor/github.com/exoscale/egoscale/v2/instance.go
+++ b/vendor/github.com/exoscale/egoscale/v2/instance.go
@@ -808,6 +808,19 @@ func (c *Client) StopInstance(ctx context.Context, zone string, instance *Instan
 	return nil
 }
 
+// RevealInstancePassword retrieves a recently started instance's root password if possible.
+func (c *Client) RevealInstancePassword(ctx context.Context, zone string, instance *Instance) (string, error) {
+	resp, err := c.RevealInstancePasswordWithResponse(apiv2.WithZone(ctx, zone), *instance.ID)
+	if err != nil {
+		return "", err
+	}
+	// If the password is unavailable, return an empty string
+	if resp.JSON200.Password == nil {
+		return "", nil
+	}
+	return *resp.JSON200.Password, nil
+}
+
 // UpdateInstance updates a Compute instance.
 func (c *Client) UpdateInstance(ctx context.Context, zone string, instance *Instance) error {
 	if err := validateOperationParams(instance, "update"); err != nil {

--- a/vendor/github.com/exoscale/egoscale/v2/security_group.go
+++ b/vendor/github.com/exoscale/egoscale/v2/security_group.go
@@ -167,6 +167,25 @@ func (c *Client) ListSecurityGroups(ctx context.Context, zone string) ([]*Securi
 	return list, nil
 }
 
+// FindSecurityGroups returns the list of existing Security Groups.
+// The `params` allows specifying standard filters.
+func (c *Client) FindSecurityGroups(ctx context.Context, zone string, params *oapi.ListSecurityGroupsParams) ([]*SecurityGroup, error) {
+	list := make([]*SecurityGroup, 0)
+
+	resp, err := c.ListSecurityGroupsWithResponse(apiv2.WithZone(ctx, zone), params)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.SecurityGroups != nil {
+		for i := range *resp.JSON200.SecurityGroups {
+			list = append(list, securityGroupFromAPI(&(*resp.JSON200.SecurityGroups)[i]))
+		}
+	}
+
+	return list, nil
+}
+
 // RemoveExternalSourceFromSecurityGroup removes an external source from
 // a Security Group. This operation is idempotent.
 func (c *Client) RemoveExternalSourceFromSecurityGroup(

--- a/vendor/github.com/exoscale/egoscale/version/version.go
+++ b/vendor/github.com/exoscale/egoscale/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version represents the current egoscale version.
-const Version = "0.98.0"
+const Version = "0.99.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.0
 ## explicit
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.98.0
+# github.com/exoscale/egoscale v0.99.0
 ## explicit
 github.com/exoscale/egoscale
 github.com/exoscale/egoscale/v2


### PR DESCRIPTION
New behavior

- `exo compute security-group list --visibility (public|private)`
- `exo compute instance reveal-password ${ID|NAME}`

With guidance from @kobajagi, thanks!