### PR TITLE
chore: add setup github action

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ When using [Fig](https://fig.io) you can run this command to output Fig completi
 exo integrations generate-fig-spec
 ```
 
+### GitHub Actions
+
+You can easily set up the `exo` CLI in your GitHub Actions workflow by using
+the [setup-exoscale](https://github.com/marketplace/actions/setup-exoscale) action.
 
 [releases]: https://github.com/exoscale/cli/releases
 [communitydoc]: https://community.exoscale.com/documentation/tools/exoscale-command-line-interface/


### PR DESCRIPTION
Hey 👋,

I've recently created the [setup-exoscale](https://github.com/marketplace/actions/setup-exoscale) GitHub Action that streamlines the process of setting up the `exo` CLI on a GitHub Actions runner. I saw the [Integrations](https://github.com/exoscale/cli#integrations) section in your README, and I thought we could add it there.

Let me know what you think.

Cheers.