### PR TITLE
CI & build plan improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,14 +10,33 @@ on:
     - 'v*' # Don't run CI tests on release tags
 
 jobs:
-  build:
+  run:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: true
+      matrix:
+        go: ['stable', 'oldstable']
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
-      with:
-        go-version: '^1.17'
-    - name: Run tests and attempt building
-      run: |
-        git submodule update --init --recursive go.mk
-        PATH=$(go env GOPATH)/bin:$PATH make test build
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go }}
+          check-latest: true
+
+      # Pre-check
+      - name: Go Format
+        run: gofmt -s -w . && git diff --exit-code
+      - name: Go Vet
+        run: go vet ./...
+      - name: Go Tidy
+        run: go mod tidy && go vendor && git diff --exit-code
+      - name: Go Mod
+        run: go mod download
+      - name: Go Mod Verify
+        run: go mod verify
+
+      - name: Run tests and attempt building
+        run: |
+          git submodule update --init --recursive go.mk
+          PATH=$(go env GOPATH)/bin:$PATH make test build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         go: ['stable', 'oldstable']
     steps:
+      # Setup
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
@@ -29,13 +30,10 @@ jobs:
         run: go fmt ./... && git diff --exit-code
       - name: Go Vet
         run: go vet ./...
-      - name: Go Tidy
-        run: go mod tidy && go vendor && git diff --exit-code
-      - name: Go Mod
-        run: go mod download
-      - name: Go Mod Verify
-        run: go mod verify
+      - name: Check Go modules and vendor folder
+        run: go mod tidy && go mod vendor && git diff --exit-code
 
+      # Test & build
       - name: Run tests and attempt building
         run: |
           git submodule update --init --recursive go.mk

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # Setup
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
           check-latest: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
 
       # Pre-check
       - name: Go Format
-        run: gofmt -s -w . && git diff --exit-code
+        run: go fmt ./... && git diff --exit-code
       - name: Go Vet
         run: go vet ./...
       - name: Go Tidy

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -1,0 +1,29 @@
+Vname: vuln
+
+permissions: {}
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+  - cron: '0 7 * * 1' # 07:00 on Monday
+
+jobs:
+  run:
+    name: Vuln
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    timeout-minutes: 5
+    steps:
+        uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 'stable'
+          check-latest: true
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run govulncheck
+        run: govulncheck -test ./...

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches: [master]
   schedule:
-  - cron: '0 7 * * 1' # 07:00 on Monday
+    - cron: '0 7 * * 1' # 07:00 on Monday
 
 jobs:
   run:
@@ -18,7 +18,7 @@ jobs:
       fail-fast: true
     timeout-minutes: 5
     steps:
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: 'stable'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,6 +34,7 @@ builds:
 # macOS Universal Binaries
 universal_binaries:
   - replace: true
+    name_template: 'exo'
 
 archives:
   - id: windows
@@ -78,7 +79,7 @@ brews:
     homepage: "https://exoscale.github.io/cli/"
     description: Manage easily your Exoscale infrastructure from the command-line.
     install: |
-      bin.install "exoscale-cli" => "exo"
+      bin.install "exo"
       man1.install Dir["manpage/exo*.1"]
       bash_completion.install "contrib/completion/bash/exo"
       zsh_completion.install "contrib/completion/zsh/_exo"

--- a/Makefile
+++ b/Makefile
@@ -41,16 +41,16 @@ manpage:
 
 .PHONY: manpages
 manpages: manpage
-	$(GO) run -mod vendor docs/main.go --man-page
+	$(GO) run docs/main.go --man-page
 
 .PHONY: completions
 completions:
 	mkdir -p contrib/completion/bash \
 		contrib/completion/powershell \
 		contrib/completion/zsh
-	$(GO) run -mod vendor completion/main.go bash ; mv bash_completion contrib/completion/bash/exo
-	$(GO) run -mod vendor completion/main.go powershell ; mv powershell_completion contrib/completion/powershell/exo
-	$(GO) run -mod vendor completion/main.go zsh ; mv zsh_completion contrib/completion/zsh/_exo
+	$(GO) run completion/main.go bash ; mv bash_completion contrib/completion/bash/exo
+	$(GO) run completion/main.go powershell ; mv powershell_completion contrib/completion/powershell/exo
+	$(GO) run completion/main.go zsh ; mv zsh_completion contrib/completion/zsh/_exo
 
 .PHONY: clean
 clean::


### PR DESCRIPTION
Minor improvements:

### Makefile

- removes explicit `-mod vendor` (it is default anyway).

### goreleaser

- rename MacOS `unified_binary` to be inline with other packages.

### github action

- Run against 2 latest (supported) Go versions;
- Check the code with `go fmt` and `go vet`;
- Validate dependencies;
- Add `govulncheck` job;
- minor QOL improvements.