### PR TITLE
[compute] ssh: no support for private instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.70.0 (UNRELEASED)
+
+### Features
+
+- compute instance show: display deploy-target (#512)
+
+### Bug Fixes
+
+- compute instance ssh: don't try to connect to private instances (#514)
+
 ## 1.69.0
 
 ### Features

--- a/cmd/instance_ssh.go
+++ b/cmd/instance_ssh.go
@@ -91,6 +91,11 @@ func (c *instanceSSHCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// No ssh possible for Private Instances
+	if *instance.PublicIPAssignment == "none" {
+		return fmt.Errorf("instance %q is a Private Instance (`exo compute instance ssh` is not supported)", c.Instance)
+	}
+
 	if c.Login == "" {
 		instanceTemplate, err := globalstate.EgoscaleClient.GetTemplate(ctx, c.Zone, *instance.TemplateID)
 		if err != nil {


### PR DESCRIPTION
Fix exception when trying to connect to a private instance
```
exo c i ssh  private
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1085e3d]

goroutine 1 [running]:
github.com/exoscale/cli/cmd.(*instanceSSHCmd).cmdRun(0xc000274300, 0xc0008a9ce8?, {0xc0008a9cc0?, 0x0?, 0x0?})
        github.com/exoscale/cli/cmd/instance_ssh.go:105 +0x31d
github.com/spf13/cobra.(*Command).execute(0xc00031a280, {0xc00011f2f0, 0x1, 0x1})
        github.com/spf13/cobra@v1.3.0/command.go:856 +0x67c
github.com/spf13/cobra.(*Command).ExecuteC(0x203a180)
        github.com/spf13/cobra@v1.3.0/command.go:974 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.3.0/command.go:902
github.com/exoscale/cli/cmd.Execute({0x18a5c20?, 0x0?}, {0x18a6268?, 0xc0000061a0?})
        github.com/exoscale/cli/cmd/root.go:87 +0x218
main.main()
        github.com/exoscale/cli/main.go:34 +0x46

```

With the fix
```
$ go run . c i ssh private
error: instance "private" is a Private Instance (`exo compute instance ssh` is not supported)
exit status 1
```