### PR TITLE
Fix panic in in dbaas type show when authorized is nil

### DIFF
--- a/cmd/dbaas_type_show.go
+++ b/cmd/dbaas_type_show.go
@@ -171,12 +171,12 @@ func (c *dbaasTypeShowCmd) cmdRun(_ *cobra.Command, _ []string) error { //nolint
 		out := make(dbaasTypePlanListOutput, len(dt.Plans))
 		for i := range dt.Plans {
 			out[i] = dbaasTypePlanListItemOutput{
-				Name:       *dt.Plans[i].Name,
-				Nodes:      *dt.Plans[i].Nodes,
-				NodeCPUs:   *dt.Plans[i].NodeCPUs,
-				NodeMemory: *dt.Plans[i].NodeMemory,
-				DiskSpace:  *dt.Plans[i].DiskSpace,
-				Authorized: *dt.Plans[i].Authorized,
+				Name:       utils.DefaultString(dt.Plans[i].Name, ""),
+				Nodes:      utils.DefaultInt64(dt.Plans[i].Nodes, 0),
+				NodeCPUs:   utils.DefaultInt64(dt.Plans[i].NodeCPUs, 0),
+				NodeMemory: utils.DefaultInt64(dt.Plans[i].NodeMemory, 0),
+				DiskSpace:  utils.DefaultInt64(dt.Plans[i].DiskSpace, 0),
+				Authorized: utils.DefaultBool(dt.Plans[i].Authorized, false),
 			}
 		}
 		return c.outputFunc(&out, nil)


### PR DESCRIPTION
This PR fixes unsafe handling of pointers in dbaas type show command.

```
$ go run . dbaas type show pg --plans
┼─────────────────┼─────────┼────────┼─────────────┼────────────┼────────────┼
│      NAME       │ # NODES │ # CPUS │ NODE MEMORY │ DISK SPACE │ AUTHORIZED │
┼─────────────────┼─────────┼────────┼─────────────┼────────────┼────────────┼
│ startup-8       │ 1       │ 4      │ 8.6 GB      │ 188 GB     │ false      │
│ startup-64      │ 1       │ 12     │ 69 GB       │ 805 GB     │ false      │
│ startup-4       │ 1       │ 2      │ 4.3 GB      │ 86 GB      │ true       │
│ startup-32      │ 1       │ 8      │ 34 GB       │ 537 GB     │ true       │
│ startup-225     │ 1       │ 24     │ 242 GB      │ 1.4 TB     │ false      │
│ startup-16      │ 1       │ 4      │ 17 GB       │ 376 GB     │ true       │
│ startup-128     │ 1       │ 16     │ 137 GB      │ 1.1 TB     │ false      │
│ so-startup-64   │ 1       │ 12     │ 69 GB       │ 2.1 TB     │ false      │
│ so-startup-32   │ 1       │ 8      │ 34 GB       │ 1.0 TB     │ false      │
│ so-startup-225  │ 1       │ 24     │ 242 GB      │ 7.2 TB     │ false      │
│ so-startup-128  │ 1       │ 16     │ 137 GB      │ 4.1 TB     │ false      │
│ so-premium-64   │ 3       │ 12     │ 69 GB       │ 2.1 TB     │ false      │
│ so-premium-32   │ 3       │ 8      │ 34 GB       │ 1.0 TB     │ false      │
│ so-premium-225  │ 3       │ 24     │ 242 GB      │ 7.2 TB     │ false      │
│ so-premium-128  │ 3       │ 16     │ 137 GB      │ 4.1 TB     │ false      │
│ so-business-64  │ 2       │ 12     │ 69 GB       │ 2.1 TB     │ false      │
│ so-business-32  │ 2       │ 8      │ 34 GB       │ 1.0 TB     │ false      │
│ so-business-225 │ 2       │ 24     │ 242 GB      │ 7.2 TB     │ false      │
│ so-business-128 │ 2       │ 16     │ 137 GB      │ 4.1 TB     │ false      │
│ premium-8       │ 3       │ 4      │ 8.6 GB      │ 188 GB     │ true       │
│ premium-64      │ 3       │ 12     │ 69 GB       │ 805 GB     │ false      │
│ premium-4       │ 3       │ 2      │ 4.3 GB      │ 86 GB      │ true       │
│ premium-32      │ 3       │ 8      │ 34 GB       │ 537 GB     │ true       │
│ premium-225     │ 3       │ 24     │ 242 GB      │ 1.4 TB     │ false      │
│ premium-16      │ 3       │ 4      │ 17 GB       │ 376 GB     │ true       │
│ premium-128     │ 3       │ 16     │ 137 GB      │ 1.1 TB     │ false      │
│ hobbyist-2      │ 1       │ 2      │ 2.1 GB      │ 8.6 GB     │ true       │
│ business-8      │ 2       │ 4      │ 8.6 GB      │ 188 GB     │ true       │
│ business-64     │ 2       │ 12     │ 69 GB       │ 805 GB     │ false      │
│ business-4      │ 2       │ 2      │ 4.3 GB      │ 86 GB      │ true       │
│ business-32     │ 2       │ 8      │ 34 GB       │ 537 GB     │ true       │
│ business-225    │ 2       │ 24     │ 242 GB      │ 1.4 TB     │ false      │
│ business-16     │ 2       │ 4      │ 17 GB       │ 376 GB     │ true       │
│ business-128    │ 2       │ 16     │ 137 GB      │ 1.1 TB     │ false      │
┼─────────────────┼─────────┼────────┼─────────────┼────────────┼────────────┼
```