### PR TITLE
fix: instance reset wrong default template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- fixed: instance reset default template now falling back to current instance template
+
 ## 1.72.0
 
 ### Changes

--- a/cmd/instance_reset.go
+++ b/cmd/instance_reset.go
@@ -45,7 +45,6 @@ Supported output template annotations: %s`,
 
 func (c *instanceResetCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
 	cmdSetZoneFlagFromDefault(cmd)
-	cmdSetTemplateFlagFromDefault(cmd)
 	return cliCommandDefaultPreRun(c, cmd, args)
 }
 


### PR DESCRIPTION
Instance reset was setting the instance base template to account default instead of the current instance template.

Before the fix, if I reset a debian instance with my local settings, it was using ubuntu after reset.
Now it sticks to debian, as expected.
```
❯ go run main.go compute instance reset -z de-fra-1 VM-b4235265-75e5-4c04-8d03-86dc35914c9f
[+] Are you sure you want to reset instance "VM-b4235265-75e5-4c04-8d03-86dc35914c9f"? [yN]: y
 ✔ Resetting instance "VM-b4235265-75e5-4c04-8d03-86dc35914c9f"... 15s
┼──────────────────────┼─────────────────────────────────────────┼
│   COMPUTE INSTANCE   │                                         │
┼──────────────────────┼─────────────────────────────────────────┼
│ ID                   │ b4235265-75e5-4c04-8d03-86dc35914c9f    │
│ Name                 │ VM-b4235265-75e5-4c04-8d03-86dc35914c9f │
│ Creation Date        │ 2023-08-09 07:53:59 +0000 UTC           │
│ Instance Type        │ standard.micro                          │
│ Template             │ Linux Debian 12 (Bookworm) 64-bit       │
│ Zone                 │ de-fra-1                                │
│ Anti-Affinity Groups │ n/a                                     │
│ Deploy Target        │ -                                       │
│ Security Groups      │ default                                 │
│ Private Instance     │ No                                      │
│ Private Networks     │ n/a                                     │
│ Elastic IPs          │ n/a                                     │
│ IP Address           │ 194.182.168.81                          │
│ IPv6 Address         │ -                                       │
│ SSH Key              │ core-management                         │
│ Disk Size            │ 50 GiB                                  │
│ State                │ running                                 │
│ Labels               │ n/a                                     │
│ Reverse DNS          │                                         │
┼──────────────────────┼─────────────────────────────────────────┼

```