### PR TITLE
root cmd: fix panic if inexistent config file is given

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -225,6 +225,15 @@ func initConfig() { //nolint:gocyclo
 	}
 
 	if gConfigFilePath != "" {
+		configFileStat, err := os.Stat(gConfigFilePath)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if configFileStat.IsDir() {
+			log.Fatalf("%q is a directory but but should be configuration file", gConfigFilePath)
+		}
+
 		// Use config file from the flag.
 		gConfig.SetConfigFile(gConfigFilePath)
 	} else {
@@ -372,9 +381,11 @@ func getCmdPosition(cmd string) int {
 
 	for _, arg := range os.Args[1:] {
 		if strings.HasPrefix(arg, "-") {
-			flag := RootCmd.Flags().Lookup(strings.Trim(arg, "-"))
-			if flag == nil {
-				flag = RootCmd.Flags().ShorthandLookup(strings.Trim(arg, "-"))
+			trimmedArg := strings.Trim(arg, "-")
+
+			flag := RootCmd.Flags().Lookup(trimmedArg)
+			if flag == nil && len(trimmedArg) < 2 {
+				flag = RootCmd.Flags().ShorthandLookup(trimmedArg)
 			}
 
 			if flag != nil && (flag.Value.Type() != "bool") {


### PR DESCRIPTION
If users specify an inexistent configuration file they will get a confusing error message.

panic: can not look up shorthand which is more than one ASCII character: "..."

goroutine 1 [running]:
github.com/spf13/pflag.(*FlagSet).ShorthandLookup(0xc0008bc400, {0x7ffd5e794c14?, 0x7ffd5e794c14?})
	/home/sauterp/src/github.com/exoscale/cli/vendor/github.com/spf13/pflag/flag.go:362 +0x106
github.com/exoscale/cli/cmd.getCmdPosition({0x137389e, 0x6})
	/home/sauterp/src/github.com/exoscale/cli/cmd/root.go:380 +0x188
github.com/exoscale/cli/cmd.isNonCredentialCmd(...)
	/home/sauterp/src/github.com/exoscale/cli/cmd/root.go:351
github.com/exoscale/cli/cmd.initConfig()
	/home/sauterp/src/github.com/exoscale/cli/cmd/root.go:244 +0x1053
github.com/spf13/cobra.(*Command).preRun(...)
	/home/sauterp/src/github.com/exoscale/cli/vendor/github.com/spf13/cobra/command.go:886
github.com/spf13/cobra.(*Command).execute(0xc000289180, {0xc000264070, 0x7, 0x7})
	/home/sauterp/src/github.com/exoscale/cli/vendor/github.com/spf13/cobra/command.go:822 +0x44e
github.com/spf13/cobra.(*Command).ExecuteC(0x2095b40)
	/home/sauterp/src/github.com/exoscale/cli/vendor/github.com/spf13/cobra/command.go:974 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/home/sauterp/src/github.com/exoscale/cli/vendor/github.com/spf13/cobra/command.go:902
github.com/exoscale/cli/cmd.Execute({0x18d24c4?, 0x0?}, {0x18d2ba0?, 0xc0000061a0?})
	/home/sauterp/src/github.com/exoscale/cli/cmd/root.go:86 +0x218
main.main()
	/home/sauterp/src/github.com/exoscale/cli/main.go:34 +0x46