### PR TITLE
nlb: remove uri and tlssni from nlb service healthcheck mode is tcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## UNRELEASED
 
-- fixed: instance reset default template now falling back to current instance template
+## Bug fixes
+
+- compute: instance reset default template now falling back to current instance template
+- compute: remmove uri and tlssni fields when nlb service healthcheck is "tcp"
 
 ## 1.72.0
 

--- a/cmd/nlb_service_update.go
+++ b/cmd/nlb_service_update.go
@@ -11,6 +11,7 @@ import (
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
+	"github.com/exoscale/cli/utils"
 	egoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
 )
@@ -118,6 +119,18 @@ func (c *nlbServiceUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 
 	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.HealthcheckURI)) {
 		service.Healthcheck.URI = &c.HealthcheckURI
+		updated = true
+	}
+
+	// If mode is is tcp, ensure URI and TLSSNI are not set
+	if *service.Healthcheck.Mode == "tcp" && (utils.DefaultString(service.Healthcheck.TLSSNI, "") != "" || utils.DefaultString(service.Healthcheck.URI, "") != "") {
+		service.Healthcheck = &egoscale.NetworkLoadBalancerServiceHealthcheck{
+			Interval: service.Healthcheck.Interval,
+			Mode:     service.Healthcheck.Mode,
+			Port:     service.Healthcheck.Port,
+			Retries:  service.Healthcheck.Retries,
+			Timeout:  service.Healthcheck.Timeout,
+		}
 		updated = true
 	}
 


### PR DESCRIPTION
After an update of the mode of a NLB service heathcheck from http to tcp, URI and tslsni were still set

HTTP Healtcheck
```
exo c nlb service show  d03dde14-0436-43e3-8017-0faa958be35a bc2fdb55-0ba8-4f12-a836-b4a9b1cba2f9  -z ch-gva-2
┼──────────────────────┼──────────────────────────────────────┼
│     NLB SERVICE      │                                      │
┼──────────────────────┼──────────────────────────────────────┼
│ ID                   │ bc2fdb55-0ba8-4f12-a836-b4a9b1cba2f9 │
│ Name                 │ my-nlb-service                       │
│ Description          │                                      │
│ Instance Pool ID     │ 23bd21b9-f8cb-45e1-bb18-e495f457bfb1 │
│ Protocol             │ tcp                                  │
│ Port                 │ 80                                   │
│ Target Port          │ 81                                   │
│ Strategy             │ round-robin                          │
│ Healthcheck Mode     │ http                                 │
│ Healthcheck Port     │ 842                                  │
│ Healthcheck URI      │ /test                                │
│ Healthcheck Interval │ 15s                                  │
│ Healthcheck Timeout  │ 4s                                   │
│ Healthcheck Retries  │ 3                                    │
│ Healthcheck Status   │ 91.92.201.131 | failure              │
│                      │ 91.92.200.21 | failure               │
│ State                │ running                              │
┼──────────────────────┼──────────────────────────────────────┼
```
Update with current version
```
exo  c nlb service update  d03dde14-0436-43e3-8017-0faa958be35a bc2fdb55-0ba8-4f12-a836-b4a9b1cba2f9  -z ch-gva-2   --healthcheck-mode  tcp
 ✔ Updating service "bc2fdb55-0ba8-4f12-a836-b4a9b1cba2f9"... 3s
┼──────────────────────┼──────────────────────────────────────┼
│     NLB SERVICE      │                                      │
┼──────────────────────┼──────────────────────────────────────┼
│ ID                   │ bc2fdb55-0ba8-4f12-a836-b4a9b1cba2f9 │
│ Name                 │ my-nlb-service                       │
│ Description          │                                      │
│ Instance Pool ID     │ 23bd21b9-f8cb-45e1-bb18-e495f457bfb1 │
│ Protocol             │ tcp                                  │
│ Port                 │ 80                                   │
│ Target Port          │ 81                                   │
│ Strategy             │ round-robin                          │
│ Healthcheck Mode     │ tcp                                  │
│ Healthcheck Port     │ 842                                  │
│ Healthcheck Interval │ 15s                                  │
│ Healthcheck Timeout  │ 4s                                   │
│ Healthcheck Retries  │ 3                                    │
│ Healthcheck Status   │ 91.92.201.131 | failure              │
│                      │ 91.92.200.21 | failure               │
│ State                │ running                              │
┼──────────────────────┼──────────────────────────────────────┼
```
Show URI is still set
```
exo x get-load-balancer-service  d03dde14-0436-43e3-8017-0faa958be35a bc2fdb55-0ba8-4f12-a836-b4a9b1cba2f9  -z ch-gva-2
{
  "description": "",
  "healthcheck": {
    "exoscale.entity.load-balancer.service.healthcheck/interval": 15,
    "exoscale.entity.load-balancer.service.healthcheck/mode": "tcp",
    "exoscale.entity.load-balancer.service.healthcheck/port": 842,
    "exoscale.entity.load-balancer.service.healthcheck/retries": 3,
    "exoscale.entity.load-balancer.service.healthcheck/timeout": 4,
    "exoscale.entity.load-balancer.service.healthcheck/uri": "/test"
  },
  "healthcheck-status": [
    {
      "public-ip": "91.92.201.131",
      "status": "failure"
    },
    {
      "public-ip": "91.92.200.21",
      "status": "failure"
    }
  ],
  "id": "bc2fdb55-0ba8-4f12-a836-b4a9b1cba2f9",
  "instance-pool": {
    "exoscale.entity.instance-pool/id": "23bd21b9-f8cb-45e1-bb18-e495f457bfb1"
  },
  "name": "my-nlb-service",
  "port": 80,
  "protocol": "tcp",
  "state": "running",
  "strategy": "round-robin",
  "target-port": 81
}
```

Update mode with the fix
```
go run . c nlb service update  d03dde14-0436-43e3-8017-0faa958be35a bc2fdb55-0ba8-4f12-a836-b4a9b1cba2f9  -z ch-gva-2   --healthcheck-mode  tcp
 ✔ Updating service "bc2fdb55-0ba8-4f12-a836-b4a9b1cba2f9"... 3s
┼──────────────────────┼──────────────────────────────────────┼
│     NLB SERVICE      │                                      │
┼──────────────────────┼──────────────────────────────────────┼
│ ID                   │ bc2fdb55-0ba8-4f12-a836-b4a9b1cba2f9 │
│ Name                 │ my-nlb-service                       │
│ Description          │                                      │
│ Instance Pool ID     │ 23bd21b9-f8cb-45e1-bb18-e495f457bfb1 │
│ Protocol             │ tcp                                  │
│ Port                 │ 80                                   │
│ Target Port          │ 81                                   │
│ Strategy             │ round-robin                          │
│ Healthcheck Mode     │ tcp                                  │
│ Healthcheck Port     │ 842                                  │
│ Healthcheck Interval │ 15s                                  │
│ Healthcheck Timeout  │ 4s                                   │
│ Healthcheck Retries  │ 3                                    │
│ Healthcheck Status   │ 91.92.201.131 | failure              │
│                      │ 91.92.200.21 | failure               │
│ State                │ running                              │
┼──────────────────────┼──────────────────────────────────────┼
```
uri was removed
```
exo x get-load-balancer-service  d03dde14-0436-43e3-8017-0faa958be35a bc2fdb55-0ba8-4f12-a836-b4a9b1cba2f9  -z ch-gva-2
{
  "description": "",
  "healthcheck": {
    "exoscale.entity.load-balancer.service.healthcheck/interval": 15,
    "exoscale.entity.load-balancer.service.healthcheck/mode": "tcp",
    "exoscale.entity.load-balancer.service.healthcheck/port": 842,
    "exoscale.entity.load-balancer.service.healthcheck/retries": 3,
    "exoscale.entity.load-balancer.service.healthcheck/timeout": 4
  },
  "healthcheck-status": [
    {
      "public-ip": "91.92.201.131",
      "status": "failure"
    },
    {
      "public-ip": "91.92.200.21",
      "status": "failure"
    }
  ],
  "id": "bc2fdb55-0ba8-4f12-a836-b4a9b1cba2f9",
  "instance-pool": {
    "exoscale.entity.instance-pool/id": "23bd21b9-f8cb-45e1-bb18-e495f457bfb1"
  },
  "name": "my-nlb-service",
  "port": 80,
  "protocol": "tcp",
  "state": "running",
  "strategy": "round-robin",
  "target-port": 81
}
```