### PR TITLE
release: create source tarball and sign all artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,16 @@ jobs:
 
       - uses: ./.github/actions/build
 
+      - name: Import GPG key
+        # This is a third-party GitHub action and we trust it with our GPG key.
+        # To be on the safer side, we should always pin to the commit SHA.
+        # It's not a perfect mitigation, but we should always do some due diligence before upgrading.
+        # The author seems trustworthy, as the author is part of the docker and goreleaser organizations on GitHub.
+        uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
       - uses: ./go.mk/.github/actions/release
         with:
           release_github_token: ${{ secrets.RELEASE_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -98,3 +98,16 @@ dockers:
       - --build-arg="VERSION={{.Version}}"
       - --build-arg="VCS_REF={{.ShortCommit}}"
       - --build-arg="BUILD_DATE={{.Date}}"
+
+source:
+  enabled: true
+  prefix_template: "{{ .ProjectName }}_{{ .Version }}/"
+  name_template: "{{ .ProjectName }}_{{ .Version }}"
+  rlcp: true
+  files:
+    - go.mk/*
+
+signs:
+- cmd: gpg
+  args: ["--default-key", "7100E8BFD6199CE0374CB7F003686F8CDE378D41", "--detach-sign", "${artifact}"]
+  artifacts: all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - compute instance: implement reset-password command #536
 
+### Improvements
+
+- release: create source tarball and sign all artifacts #538
+
 ## 1.72.2
 
 ### Improvements


### PR DESCRIPTION
# Description
We want to verify signatures of released packages before installing them with the install-latest.sh script and in makepkg. For the AUR source package we need a signature that includes the source of the go.mk submodule.

## Checklist

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

```shell
goreleaser release --skip-docker --skip-publish --skip-announce --skip-validate --clean
  • starting release...
  • loading config file                              file=.goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=7b144e8e5914e2e6cb6c3569bc5821b7cbfe4024 latest tag=v1.72.1
    • pipe skipped                                   reason=validation is disabled
  • parsing tag
  • setting defaults
      • DEPRECATED: `archives.rlcp` will be the default soon, check https://goreleaser.com/deprecations#archivesrlcp for more info
  • running before hooks
    • running                                        hook=make manpages completions
    • took: 3s
  • checking distribution directory
    • cleaning dist
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/exoscale-cli_linux_arm_6/exo
    • building                                       binary=dist/exoscale-cli_windows_arm_7/exo.exe
    • building                                       binary=dist/exoscale-cli_windows_arm_6/exo.exe
    • building                                       binary=dist/exoscale-cli_darwin_arm64/exo
    • building                                       binary=dist/exoscale-cli_windows_amd64_v1/exo.exe
    • building                                       binary=dist/exoscale-cli_windows_arm64/exo.exe
    • building                                       binary=dist/exoscale-cli_linux_amd64_v1/exo
    • building                                       binary=dist/exoscale-cli_darwin_amd64_v1/exo
    • building                                       binary=dist/exoscale-cli_linux_arm_7/exo
    • building                                       binary=dist/exoscale-cli_linux_arm64/exo
    • building                                       binary=dist/exoscale-cli_openbsd_amd64_v1/exo
    • took: 7s
  • universal binaries
    • creating from 2 binaries                       id=exoscale-cli binary=dist/exoscale-cli_darwin_all/exo
  • generating changelog
    • writing                                        changelog=dist/CHANGELOG.md
  • archives
    • creating                                       archive=dist/exoscale-cli_1.72.1_linux_armv6.tar.gz
    • creating                                       archive=dist/exoscale-cli_1.72.1_windows_amd64.zip
    • creating                                       archive=dist/exoscale-cli_1.72.1_darwin_all.tar.gz
    • creating                                       archive=dist/exoscale-cli_1.72.1_linux_amd64.tar.gz
    • creating                                       archive=dist/exoscale-cli_1.72.1_windows_arm64.zip
    • creating                                       archive=dist/exoscale-cli_1.72.1_openbsd_amd64.tar.gz
    • creating                                       archive=dist/exoscale-cli_1.72.1_linux_arm64.tar.gz
    • creating                                       archive=dist/exoscale-cli_1.72.1_linux_armv7.tar.gz
    • creating                                       archive=dist/exoscale-cli_1.72.1_windows_armv6.zip
    • creating                                       archive=dist/exoscale-cli_1.72.1_windows_armv7.zip
    • took: 12s
  • creating source archive
    • creating source archive                        file=exoscale-cli_1.72.1.tar.gz
    • took: 7s
  • linux packages
    • creating                                       package=exoscale-cli format=rpm arch=arm6 file=dist/exoscale-cli_1.72.1_linux_armv6.rpm
    • creating                                       package=exoscale-cli format=deb arch=arm64 file=dist/exoscale-cli_1.72.1_linux_arm64.deb
    • creating                                       package=exoscale-cli format=deb arch=amd64v1 file=dist/exoscale-cli_1.72.1_linux_amd64.deb
    • creating                                       package=exoscale-cli format=rpm arch=amd64v1 file=dist/exoscale-cli_1.72.1_linux_amd64.rpm
    • creating                                       package=exoscale-cli format=rpm arch=arm64 file=dist/exoscale-cli_1.72.1_linux_arm64.rpm
    • creating                                       package=exoscale-cli format=deb arch=arm7 file=dist/exoscale-cli_1.72.1_linux_armv7.deb
    • creating                                       package=exoscale-cli format=deb arch=arm6 file=dist/exoscale-cli_1.72.1_linux_armv6.deb
    • creating                                       package=exoscale-cli format=rpm arch=arm7 file=dist/exoscale-cli_1.72.1_linux_armv7.rpm
    • took: 2s
  • calculating checksums
  • signing artifacts
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_linux_armv6.tar.gz signature=dist/exoscale-cli_1.72.1_linux_armv6.tar.gz.sig
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_linux_armv7.tar.gz signature=dist/exoscale-cli_1.72.1_linux_armv7.tar.gz.sig
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_windows_arm64.zip signature=dist/exoscale-cli_1.72.1_windows_arm64.zip.sig
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_linux_arm64.tar.gz signature=dist/exoscale-cli_1.72.1_linux_arm64.tar.gz.sig
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_windows_amd64.zip signature=dist/exoscale-cli_1.72.1_windows_amd64.zip.sig
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_openbsd_amd64.tar.gz signature=dist/exoscale-cli_1.72.1_openbsd_amd64.tar.gz.sig
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_linux_amd64.tar.gz signature=dist/exoscale-cli_1.72.1_linux_amd64.tar.gz.sig
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_windows_armv7.zip signature=dist/exoscale-cli_1.72.1_windows_armv7.zip.sig
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_windows_armv6.zip signature=dist/exoscale-cli_1.72.1_windows_armv6.zip.sig
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_darwin_all.tar.gz signature=dist/exoscale-cli_1.72.1_darwin_all.tar.gz.sig
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1.tar.gz signature=dist/exoscale-cli_1.72.1.tar.gz.sig
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_linux_arm64.deb signature=dist/exoscale-cli_1.72.1_linux_arm64.deb.sig
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_linux_armv6.deb signature=dist/exoscale-cli_1.72.1_linux_armv6.deb.sig
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_linux_amd64.deb signature=dist/exoscale-cli_1.72.1_linux_amd64.deb.sig
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_linux_armv7.deb signature=dist/exoscale-cli_1.72.1_linux_armv7.deb.sig
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_linux_arm64.rpm signature=dist/exoscale-cli_1.72.1_linux_arm64.rpm.sig
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_linux_amd64.rpm signature=dist/exoscale-cli_1.72.1_linux_amd64.rpm.sig
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_linux_armv7.rpm signature=dist/exoscale-cli_1.72.1_linux_armv7.rpm.sig
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_linux_armv6.rpm signature=dist/exoscale-cli_1.72.1_linux_armv6.rpm.sig
    • refreshing checksums                           file=exoscale-cli_1.72.1_checksums.txt
    • signing                                        cmd=gpg artifact=exoscale-cli_1.72.1_checksums.txt signature=dist/exoscale-cli_1.72.1_checksums.txt.sig
    • refreshing checksums                           file=exoscale-cli_1.72.1_checksums.txt
    • took: 7s
  • homebrew tap formula
    • writing                                        formula=dist/exoscale-cli.rb
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • you are using deprecated options, check the output above for details
  • release succeeded after 39s
  • thanks for using goreleaser!
```