### PR TITLE
release: adapt AUR release script for signed packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
               cd /home/runner/$aurpkg
               sed -i "/^pkgver=/s/.*/pkgver=$version_tag/" PKGBUILD
               if [ $aurpkg == "exoscale-cli-bin" ]; then
-                sed -i "/^sha256sums=/s/.*/sha256sums=\('$checksum'\)/" PKGBUILD
+                sed -i "/^sha256sums=/s/.*/sha256sums=\('$checksum'/" PKGBUILD
               fi
 
               makepkg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- release: adapt AUR release script for signed packages #541
+
 ## 1.73.0
 
 ### Features


### PR DESCRIPTION
# Description
We adapted the 'exoscale-cli' and exoscale-cli-bin' packages on AUR to verify GPG signatures before installation. The sha256sums list now contains a 'SKIP' element for the corresponding element in the sources list that references the signature file. We need to adapt the sed line that substitutes the checksum to respect this.

## Checklist

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing
I tested the release script locally on the adapted PKGBUILD files in 'exoscale-cli' and 'exoscale-cli-bin' and was able to build and install the packages.