### PR TITLE
exo x cmds: secondary volume add create from snapshot-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - release: adapt AUR release script for signed packages #541
+- Updated `exo x` #542
 
 ## 1.73.0
 

--- a/cmd/internal/x/x.gen.go
+++ b/cmd/internal/x/x.gen.go
@@ -8072,7 +8072,7 @@ func XUpdateReverseDnsInstance(paramId string, params *viper.Viper, body string)
 	return resp, decoded, nil
 }
 
-// XCreateSecondaryVolume Create a secondary volume
+// XCreateSecondaryVolume Create a secondary volume. If snapshot-id is passed in from an existing secondary volume snapshot.
 func XCreateSecondaryVolume(params *viper.Viper, body string) (*gentleman.Response, map[string]interface{}, error) {
 	handlerPath := "create-secondary-volume"
 	if xSubcommand {
@@ -17496,8 +17496,8 @@ func xRegister(subcommand bool) {
 
 		cmd := &cobra.Command{
 			Use:     "create-secondary-volume",
-			Short:   "Create a secondary volume",
-			Long:    cli.Markdown("\n## Request Schema (application/json)\n\nproperties:\n  labels:\n    $ref: '#/components/schemas/labels'\n  name:\n    description: Volume name\n    maxLength: 255\n    minLength: 1\n    type: string\n  size:\n    description: Volume size in GB\n    format: int64\n    maximum: 1024\n    minimum: 100\n    type: integer\nrequired:\n- size\ntype: object\n"),
+			Short:   "Create a secondary volume. If snapshot-id is passed in from an existing secondary volume snapshot.",
+			Long:    cli.Markdown("\n## Request Schema (application/json)\n\nproperties:\n  labels:\n    $ref: '#/components/schemas/labels'\n  name:\n    description: Volume name\n    maxLength: 255\n    minLength: 1\n    type: string\n  size:\n    description: Volume size in GB\n    format: int64\n    maximum: 1024\n    minimum: 100\n    type: integer\n  snapshot-id:\n    description: Secondary volume snapshot ID\n    format: uuid\n    type: string\ntype: object\n"),
 			Example: examples,
 			Args:    cobra.MinimumNArgs(0),
 			Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
# Description
[SC-77650]

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

Local dev test:
```
(exo3) ~$ exo x list-secondary-volume-snapshots
{
  "secondary-volumes": [
    {
      "created-at": "2023-09-19T14:19:01Z",
      "id": "615cfd09-e76a-4bea-9c16-00d552c5ddce",
      "labels": {},
      "name": "null_20230919141901",
      "size": 107374182400,
      "state": "created",
      "volume-id": "0f173f38-cb86-46bf-8b0f-a2e5aaa9b2da"
    }
  ]
}
(exo3) ~$ exo x create-secondary-volume snapshot-id:615cfd09-e76a-4bea-9c16-00d552c5ddce
{
  "id": "3e83c032-9a7e-4a0e-bfe1-4afcaddb8314",
  "reference": {
    "command": "get-secondary-volume",
    "id": "068dd0f2-3465-4586-a0f0-4bb374d74161",
    "link": "/v2/secondary-volume/068dd0f2-3465-4586-a0f0-4bb374d74161"
  },
  "state": "pending"
}
(exo3) ~$ exo x list-secondary-volumes
{
  "secondary-volumes": [
    {
      "blocksize": 4096,
      "created-at": "2023-09-19T14:19:50Z",
      "id": "068dd0f2-3465-4586-a0f0-4bb374d74161",
      "labels": {},
      "name": "null_20230919141901",
      "size": 107374182400,
      "state": "promoting"
    }
  ]
}

```

