### PR TITLE
release workflow: publish deb packages to SOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
           release_github_token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           registry_username: ${{ secrets.DOCKERHUB_USERNAME }}
           registry_password: ${{ secrets.DOCKERHUB_TOKEN }}
+          exoscale_api_key: ${{ secrets.SOS_PKG_BUCKET_KEY }}
+          exoscale_api_secret: ${{ secrets.SOS_PKG_BUCKET_SECRET }}
 
       - run: echo "version_tag=$(make get-version-tag)" >> $GITHUB_OUTPUT
         id: get-version-tag

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ contrib
 *.snap
 *.xdelta3
 go.work
+.aptlydata

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,6 +57,7 @@ nfpms:
     maintainer: Exoscale Support <support@exoscale.com>
     description: Manage easily your Exoscale infrastructure from the command-line.
     license: Apache 2.0
+    id: nfpms
     formats:
       - deb
       - rpm
@@ -125,3 +126,12 @@ scoops:
       owner: exoscale
       name: cli
       branch: master
+
+publishers:
+  - name: aptly
+    env:
+      - AWS_ACCESS_KEY_ID={{ .Env.EXOSCALE_API_KEY }}
+      - AWS_SECRET_ACCESS_KEY={{ .Env.EXOSCALE_API_SECRET }}
+    ids:
+      - nfpms
+    cmd: ./go.mk/scripts/publish-deb-artifact-to-sos.sh {{ .ArtifactPath }} exoscale-packages deb/cli 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 
+- release workflow: publish deb packages to SOS #544
 - aur releases: skip pgp check #547
 
 ## 1.74.0


### PR DESCRIPTION
# Description

We publish Debian packages to SOS for users to install through the `apt` package manager.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing
The release workflow completed successfully [on my fork](https://github.com/sauterp/cli/actions/runs/6316082862) and released the package to the bucket `sauterp-exoscale-packages`.

We tested installing the released packages with
```shell
docker run -it ubuntu /bin/bash

# in the container
apt update && apt install -y gpg ca-certificates
echo "deb [signed-by=/etc/apt/keyrings/exoscale.gpg] https://sos-ch-gva-2.exo.io/sauterp-exoscale-packages/deb/cli stable main" > /etc/apt/sources.list.d/exoscale.list
gpg --keyserver keyserver.ubuntu.com --recv-keys 7100E8BFD6199CE0374CB7F003686F8CDE378D41
gpg --export 7100E8BFD6199CE0374CB7F003686F8CDE378D41 > /etc/apt/keyrings/exoscale.gpg
apt update
apt install -y exoscale-cli
```
If you try this now, it will fail since the release workflow on my fork cannot sign the repo. However I tested the release locally as well.

The released repo on SOS looks like this
```shell
exo -A exosauterp storage list -z ch-gva-2 -r sauterp-exoscale-packages
2023-09-26 17:25:18 UTC 1.1 KiB  deb/cli/dists/stable/Contents-amd64.gz
2023-09-26 17:25:17 UTC 1.1 KiB  deb/cli/dists/stable/Contents-arm64.gz
2023-09-26 17:25:16 UTC 1.1 KiB  deb/cli/dists/stable/Contents-armhf.gz
2023-09-26 17:25:19 UTC 9.7 KiB  deb/cli/dists/stable/Release
2023-09-26 17:25:17 UTC 1.1 KiB  deb/cli/dists/stable/main/Contents-amd64.gz
2023-09-26 17:25:17 UTC 1.1 KiB  deb/cli/dists/stable/main/Contents-arm64.gz
2023-09-26 17:25:20 UTC 1.1 KiB  deb/cli/dists/stable/main/Contents-armhf.gz
2023-09-26 17:25:20 UTC  679 B   deb/cli/dists/stable/main/binary-amd64/Packages
2023-09-26 17:25:18 UTC  499 B   deb/cli/dists/stable/main/binary-amd64/Packages.bz2
2023-09-26 17:25:18 UTC  474 B   deb/cli/dists/stable/main/binary-amd64/Packages.gz
2023-09-26 17:25:20 UTC   85 B   deb/cli/dists/stable/main/binary-amd64/Release
2023-09-26 17:25:18 UTC  679 B   deb/cli/dists/stable/main/binary-arm64/Packages
2023-09-26 17:25:17 UTC  502 B   deb/cli/dists/stable/main/binary-arm64/Packages.bz2
2023-09-26 17:25:18 UTC  471 B   deb/cli/dists/stable/main/binary-arm64/Packages.gz
2023-09-26 17:25:16 UTC   85 B   deb/cli/dists/stable/main/binary-arm64/Release
2023-09-26 17:25:19 UTC  679 B   deb/cli/dists/stable/main/binary-armhf/Packages
2023-09-26 17:25:19 UTC  498 B   deb/cli/dists/stable/main/binary-armhf/Packages.bz2
2023-09-26 17:25:20 UTC  471 B   deb/cli/dists/stable/main/binary-armhf/Packages.gz
2023-09-26 17:25:19 UTC   85 B   deb/cli/dists/stable/main/binary-armhf/Release
2023-09-26 17:23:43 UTC 11 MiB   deb/cli/pool/main/e/exoscale-cli/exoscale-cli_1.73.1695748397_linux_amd64.deb
2023-09-26 17:24:51 UTC 10 MiB   deb/cli/pool/main/e/exoscale-cli/exoscale-cli_1.73.1695748397_linux_arm64.deb
2023-09-26 17:24:21 UTC 10 MiB   deb/cli/pool/main/e/exoscale-cli/exoscale-cli_1.73.1695748397_linux_armv6.deb
```