### PR TITLE
aur releases: skip pgp check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
                 sed -i "/^sha256sums=/s/.*/sha256sums=\('$checksum'/" PKGBUILD
               fi
 
-              makepkg
+              makepkg --skippgpcheck
 
               makepkg --printsrcinfo >.SRCINFO
               git add PKGBUILD .SRCINFO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- aur releases: skip pgp check #547
+
 ## 1.74.0
 
 - publish cli releases as scoop packages #546


### PR DESCRIPTION
# Description
Both [AUR releases for signed packages](https://github.com/exoscale/cli/actions/runs/6349777603/job/17248953628) failed during the pgp verification:
```shell
==> Verifying source file signatures with gpg...
    exoscale-cli_1.74.0.tar.gz ... FAILED (unknown public key 03686F8CDE378D41)
==> ERROR: One or more PGP signatures could not be verified!
```

I wasn't able to reproduce the issue locally with low effort. I'm able to run makepkg in an archlinux container with no issue. I verified that the public key is not present before I run `makepkg` and that it is present afterwards. This means makepkg must contact keyservers in the background to receive the keys. This can fail for a number of reasons, like keyservers not being available, networking or bugs in the gpg version provided by the GH action runner. Even if we fix it, it might bite us again if the default keyserver is down, which does happen unfortunately.
I concluded that fixing this check is not worth it, since the check happens anyway when the user installs the package unless they explicitly disable it. We are verifying a signature that we created in a previous step of the same workflow and have no strong reason to distrust it.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing
I verified that `makepkg --skippgpcheck` completes on the latest release and that it doesn't affect .SRCINFO.
```shell
archlinux-toolbox[home] ~/src/aur.archlinux.org/exoscale-cli-bin (master)
> makepkg --skippgpcheck
==> Making package: exoscale-cli-bin 1.74.0-1 (Fri Sep 29 16:30:24 2023)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Downloading exoscale-cli_1.74.0_linux_amd64.tar.gz...
** Resuming transfer from byte position 1576960
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 9257k  100 9257k    0     0  10.1M      0 --:--:-- --:--:-- --:--:-- 10.1M
  -> Downloading exoscale-cli_1.74.0_linux_amd64.tar.gz.sig...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   566  100   566    0     0   1053      0 --:--:-- --:--:-- --:--:--  1053
==> WARNING: Skipping verification of source file PGP signatures.
==> Validating source files with sha256sums...
    exoscale-cli_1.74.0_linux_amd64.tar.gz ... Passed
    exoscale-cli_1.74.0_linux_amd64.tar.gz.sig ... Skipped
==> Extracting sources...
  -> Extracting exoscale-cli_1.74.0_linux_amd64.tar.gz with bsdtar
==> Entering fakeroot environment...
==> Starting package()...
==> Tidying install...
  -> Removing libtool files...
  -> Purging unwanted files...
  -> Removing static library files...
  -> Stripping unneeded symbols from binaries and libraries...
  -> Compressing man and info pages...
==> Checking for packaging issues...
==> Creating package "exoscale-cli-bin"...
  -> Generating .PKGINFO file...
  -> Generating .BUILDINFO file...
  -> Generating .MTREE file...
  -> Compressing package...
==> Leaving fakeroot environment.
==> Finished making: exoscale-cli-bin 1.74.0-1 (Fri Sep 29 16:30:29 2023)
```