### PR TITLE
install script: install from SOS apt repo if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Improvements
+
+- install script: install from SOS apt repo if possible #551
+
 ## 1.74.2
 
 - update go.mk

--- a/README.md
+++ b/README.md
@@ -7,7 +7,15 @@ Manage your Exoscale infrastructure easily from the command-line with `exo`.
 
 ## Installation
 
-### Using pre-built releases (recommended)
+### Debian and Red Hat based distributions
+
+On Debian and Red Hat based distributions like Ubuntu and Fedora, we recommend using the installation script.
+
+```shell
+curl -fsSL https://raw.githubusercontent.com/exoscale/cli/master/install-latest.sh | sh
+```
+
+### Using pre-built releases
 
 You can find pre-built releases of the CLI [here][releases].
 

--- a/install-latest.sh
+++ b/install-latest.sh
@@ -15,11 +15,33 @@ CPUARCHITECTURE=""
 FILEEXT=""
 PACKAGETYPE=""
 
+is_apt_newer_than_v2_2() {
+    apt_version=$(apt-get --version 2>&1 | grep -oP '(?<=apt )[0-9]+\.[0-9]+\.[0-9]+')
+
+    if [ -z "$apt_version" ]; then
+        # can't determine apt version
+        return 1
+    elif [ "$(
+        dpkg --compare-versions "$apt_version" ge "2.2.0"
+        echo $?
+    )" -eq 0 ]; then
+        # apt is >= 2.2.0
+        return 0
+    else
+        # apt is < 2.2.0
+        return 1
+    fi
+}
+
 if [ -f /etc/os-release ]; then
     . /etc/os-release
     case "$ID" in
         debian | ubuntu | pop | neon | zorin | linuxmint | elementary | parrot | mendel | galliumos | pureos | raspian | kali | Deepin)
-            PACKAGETYPE="dpkg"
+            if is_apt_newer_than_v2_2; then
+                PACKAGETYPE="apt"
+            else
+                PACKAGETYPE="dpkg"
+            fi
             FILEEXT="deb"
             OSTYPE="linux"
             ;;
@@ -137,27 +159,49 @@ if [ "$COMPUTED_CHECKSUM" != "$EXPECTED_CHECKSUM" ]; then
     exit 1
 fi
 
-if command -v gpg >/dev/null 2>&1; then
-    TOOLING_KEY_NAME="Exoscale Tooling <tooling@exoscale.ch>"
-    TOOLING_KEY_FINGERPRINT="7100E8BFD6199CE0374CB7F003686F8CDE378D41"
+TOOLING_KEY_NAME="Exoscale Tooling <tooling@exoscale.ch>"
+TOOLING_KEY_FINGERPRINT="7100E8BFD6199CE0374CB7F003686F8CDE378D41"
 
+GPG_AVAILABLE=no
+verify_pkg() {
+    if [ "$GPG_AVAILABLE" = "yes" ]; then
+        $CURL "$GITHUB_DOWNLOAD_URL/${LATEST_TAG}/$PKGSIGFILE" >$PKGSIGPATH
+        gpg --verify $PKGSIGPATH $PKGPATH
+    fi
+}
+
+if command -v gpg >/dev/null 2>&1; then
     if ! gpg --list-keys | grep -q $TOOLING_KEY_FINGERPRINT; then
         gpg --recv-keys "$TOOLING_KEY_FINGERPRINT"
     fi
 
-    $CURL "$GITHUB_DOWNLOAD_URL/${LATEST_TAG}/$PKGSIGFILE" >$PKGSIGPATH
-    gpg --verify $PKGSIGPATH $PKGPATH
+    GPG_AVAILABLE=yes
+else
+    if [ "$PACKAGETYPE" = "apt" ]; then
+        # since gpg is not available, we have to fall back to installing via dpkg
+        PACKAGETYPE="dpkg"
+    fi
 fi
 
 echo "Installing exo CLI, using $PACKAGETYPE"
 case "$PACKAGETYPE" in
+    apt)
+        $SUDO mkdir -p /etc/apt/keyrings
+        gpg --export $TOOLING_KEY_FINGERPRINT | $SUDO tee /etc/apt/keyrings/exoscale.gpg >/dev/null
+        echo "deb [signed-by=/etc/apt/keyrings/exoscale.gpg] https://sos-ch-gva-2.exo.io/exoscale-packages/deb/cli stable main" | $SUDO tee /etc/apt/sources.list.d/exoscale.list >/dev/null
+        $SUDO apt-get update
+        $SUDO apt-get install -y exoscale-cli
+        ;;
     dpkg)
+        verify_pkg
         $SUDO dpkg -i $PKGPATH
         ;;
     yum)
+        verify_pkg
         $SUDO yum install -y $PKGPATH
         ;;
     dnf)
+        verify_pkg
         $SUDO dnf install -y $PKGPATH
         ;;
 esac

--- a/install-latest.sh
+++ b/install-latest.sh
@@ -163,6 +163,7 @@ TOOLING_KEY_NAME="Exoscale Tooling <tooling@exoscale.ch>"
 TOOLING_KEY_FINGERPRINT="7100E8BFD6199CE0374CB7F003686F8CDE378D41"
 
 GPG_AVAILABLE=no
+# downloads and verifies the signature file for the package if gpg is available
 verify_pkg() {
     if [ "$GPG_AVAILABLE" = "yes" ]; then
         $CURL "$GITHUB_DOWNLOAD_URL/${LATEST_TAG}/$PKGSIGFILE" >$PKGSIGPATH


### PR DESCRIPTION
# Description
We install the cli as a debian package through apt from the repository on SOS, if the version of apt is >= 2.2.0. With version 2.2.0 keyrings under `/etc/apt/keyrings` became the recommended way to install GPG keys. Distributions who have older versions of apt may still use the legacy keyring. On these older distributions we keep installing the package through dpkg.

The advantage of installing from the SOS repo is that apt will detect new versions when they are released, so users won't have to manually install them anymore.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

test on ubuntu
```shell
root@3a631c8cc8ef:/# ./install-latest.sh
gpg: directory '/root/.gnupg' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key 03686F8CDE378D41: public key "Exoscale Tooling <tooling@exoscale.ch>" imported
gpg: Total number processed: 1
gpg:               imported: 1
Installing exo CLI, using apt
Hit:1 http://security.ubuntu.com/ubuntu jammy-security InRelease
Get:2 https://sos-ch-gva-2.exo.io/exoscale-packages/deb/cli stable InRelease [10.8 kB]
Hit:3 http://archive.ubuntu.com/ubuntu jammy InRelease
Get:4 https://sos-ch-gva-2.exo.io/exoscale-packages/deb/cli stable/main amd64 Packages [465 B]
Hit:5 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:6 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Fetched 11.2 kB in 0s (23.2 kB/s)
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  exoscale-cli
0 upgraded, 1 newly installed, 0 to remove and 4 not upgraded.
Need to get 11.1 MB of archives.
After this operation, 38.9 MB of additional disk space will be used.
Get:1 https://sos-ch-gva-2.exo.io/exoscale-packages/deb/cli stable/main amd64 exoscale-cli amd64 1.74.2 [11.1 MB]
Fetched 11.1 MB in 1s (15.7 MB/s)
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package exoscale-cli.
(Reading database ... 5222 files and directories currently installed.)
Preparing to unpack .../exoscale-cli_1.74.2_amd64.deb ...
Unpacking exoscale-cli (1.74.2) ...
Setting up exoscale-cli (1.74.2) ...
root@3a631c8cc8ef:/# exo version
exo 1.74.2 a7627235 (egoscale 0.101.0)
```

test on ubuntu:focal with apt < 2.2.0
```shell
root@695cfe50b073:/# apt --version
apt 2.0.9 (amd64)
root@695cfe50b073:/# ./install-latest.sh
./install-latest.sh: 24: [: Illegal number:
gpg: directory '/root/.gnupg' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key 03686F8CDE378D41: public key "Exoscale Tooling <tooling@exoscale.ch>" imported
gpg: Total number processed: 1
gpg:               imported: 1
Installing exo CLI, using dpkg
gpg: Signature made Wed Oct  4 09:58:17 2023 UTC
gpg:                using RSA key 7100E8BFD6199CE0374CB7F003686F8CDE378D41
gpg: Good signature from "Exoscale Tooling <tooling@exoscale.ch>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 7100 E8BF D619 9CE0 374C  B7F0 0368 6F8C DE37 8D41
Selecting previously unselected package exoscale-cli.
(Reading database ... 4903 files and directories currently installed.)
Preparing to unpack .../exoscale-cli_1.74.2_linux_amd64.deb ...
Unpacking exoscale-cli (1.74.2) ...
Setting up exoscale-cli (1.74.2) ...
root@695cfe50b073:/# exo version
exo 1.74.2 a7627235 (egoscale 0.101.0)
```

test on fedora:latest
```shell
[root@d86fc1f7ee18 /]# ./install-latest.sh
gpg: directory '/root/.gnupg' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key 03686F8CDE378D41: public key "Exoscale Tooling <tooling@exoscale.ch>" imported
gpg: Total number processed: 1
gpg:               imported: 1
Installing exo CLI, using dnf
gpg: Signature made Wed Oct  4 09:58:18 2023 UTC
gpg:                using RSA key 7100E8BFD6199CE0374CB7F003686F8CDE378D41
gpg: Good signature from "Exoscale Tooling <tooling@exoscale.ch>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 7100 E8BF D619 9CE0 374C  B7F0 0368 6F8C DE37 8D41
Fedora 38 - x86_64                                                                      15 MB/s |  83 MB     00:05
Fedora 38 openh264 (From Cisco) - x86_64                                               2.9 kB/s | 2.5 kB     00:00
Fedora Modular 38 - x86_64                                                             4.9 MB/s | 2.8 MB     00:00
Fedora 38 - x86_64 - Updates                                                            18 MB/s |  33 MB     00:01
Fedora Modular 38 - x86_64 - Updates                                                   2.6 MB/s | 2.1 MB     00:00
Dependencies resolved.
=======================================================================================================================
 Package                       Architecture            Version                     Repository                     Size
=======================================================================================================================
Installing:
 exoscale-cli                  x86_64                  1.74.2-1                    @commandline                   11 M

Transaction Summary
=======================================================================================================================
Install  1 Package

Total size: 11 M
Installed size: 37 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                               1/1
  Installing       : exoscale-cli-1.74.2-1.x86_64                                                                  1/1
  Verifying        : exoscale-cli-1.74.2-1.x86_64                                                                  1/1

Installed:
  exoscale-cli-1.74.2-1.x86_64

Complete!
[root@d86fc1f7ee18 /]# exo version
exo 1.74.2 a7627235 (egoscale 0.101.0)
```

test on debian:latest
```shell
root@e9630772975b:/# ./install-latest.sh
gpg: directory '/root/.gnupg' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key 03686F8CDE378D41: public key "Exoscale Tooling <tooling@exoscale.ch>" imported
gpg: Total number processed: 1
gpg:               imported: 1
Installing exo CLI, using apt
Hit:1 http://deb.debian.org/debian bookworm InRelease
Hit:2 http://deb.debian.org/debian bookworm-updates InRelease
Hit:3 http://deb.debian.org/debian-security bookworm-security InRelease
Get:4 https://sos-ch-gva-2.exo.io/exoscale-packages/deb/cli stable InRelease [10.8 kB]
Get:5 https://sos-ch-gva-2.exo.io/exoscale-packages/deb/cli stable/main amd64 Packages [496 B]
Fetched 11.3 kB in 1s (20.2 kB/s)
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  exoscale-cli
0 upgraded, 1 newly installed, 0 to remove and 2 not upgraded.
Need to get 11.1 MB of archives.
After this operation, 38.9 MB of additional disk space will be used.
Get:1 https://sos-ch-gva-2.exo.io/exoscale-packages/deb/cli stable/main amd64 exoscale-cli amd64 1.74.2 [11.1 MB]
Fetched 11.1 MB in 1s (12.4 MB/s)
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package exoscale-cli.
(Reading database ... 7058 files and directories currently installed.)
Preparing to unpack .../exoscale-cli_1.74.2_amd64.deb ...
Unpacking exoscale-cli (1.74.2) ...
Setting up exoscale-cli (1.74.2) ...
root@e9630772975b:/# exo version
exo 1.74.2 a7627235 (egoscale 0.101.0)
```

test on debian:latest without gpg
```shell
Successfully tagged apttest:latest
root@b60a61ccaae4:/# ./install-latest.sh
Installing exo CLI, using dpkg
Selecting previously unselected package exoscale-cli.
(Reading database ... 6753 files and directories currently installed.)
Preparing to unpack .../exoscale-cli_1.74.2_linux_amd64.deb ...
Unpacking exoscale-cli (1.74.2) ...
Setting up exoscale-cli (1.74.2) ...
root@b60a61ccaae4:/# exo version
exo 1.74.2 a7627235 (egoscale 0.101.0)
```
