### PR TITLE
dbaas: don't throw error if dbaas settings JSON schema cannot be loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
-- Allow executing commands when dbaas JSON schema cannot be loaded
+- Allow executing commands when dbaas JSON schema cannot be loaded #554
 
 ## 1.74.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - install script: install from SOS apt repo if possible #551
 
+### Bug Fixes
+
+- Allow executing commands when dbaas JSON schema cannot be loaded
+
 ## 1.74.2
 
 - update go.mk

--- a/cmd/dbaas.go
+++ b/cmd/dbaas.go
@@ -74,7 +74,10 @@ func validateDatabaseServiceSettings(in string, schema interface{}) (map[string]
 		gojsonschema.NewStringLoader(in),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("unable to validate JSON Schema: %w", err)
+		// JSON Schema is provided by API and if loading fails there is nothing a user can to to fix the issue.
+		// One example is incompatible regex engines for pattern validation that will prevent loading JSON schema.
+		// When that happens we should still allow running the command as API would validate request.
+		return userSettings, nil
 	}
 
 	if !res.Valid() {


### PR DESCRIPTION
# Description

Due to incompatible regex engines for pattern validation, JSON Schema for dbaas settings can throw error when loaded by [gojsonschema](github.com/xeipuuv/gojsonschema). This throws error in CLI and prevents running any commands for the database. Client side validation should be considered opportunistic (as server will validate data as well), this PR disables validation if JSON Schema cannot be loaded. 

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

Current:
```
$ exo dbaas update mydb --grafana-settings '{"oauth_allow_insecure_email_lookup": false}'
error: invalid settings: unable to validate JSON Schema: pattern must be a valid regex
```
New:
```
$ go run . dbaas update mydb --grafana-settings '{"oauth_allow_insecure_email_lookup": false}'
 ✔ Updating Database Service "mydb"... 0s
$ go run . dbaas show mydb --settings grafana
{
  "oauth_allow_insecure_email_lookup": false
}
```