### PR TITLE
publish releases as rpm packages on SOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,21 +1,21 @@
-# name: CI
+name: CI
 
-# on:
-#   push:
-#     branches:
-#     - '**'
-#     paths-ignore:
-#     - '**.md'
-#     - 'bucket/**'
-#     tags-ignore:
-#     - 'v*' # Don't run CI tests on release tags
+on:
+  push:
+    branches:
+    - '**'
+    paths-ignore:
+    - '**.md'
+    - 'bucket/**'
+    tags-ignore:
+    - 'v*' # Don't run CI tests on release tags
 
-# jobs:
-#   build:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v3
-#         with:
-#           fetch-depth: 0
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-#       - uses: ./.github/actions/build
+      - uses: ./.github/actions/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,21 +1,21 @@
-name: CI
+# name: CI
 
-on:
-  push:
-    branches:
-    - '**'
-    paths-ignore:
-    - '**.md'
-    - 'bucket/**'
-    tags-ignore:
-    - 'v*' # Don't run CI tests on release tags
+# on:
+#   push:
+#     branches:
+#     - '**'
+#     paths-ignore:
+#     - '**.md'
+#     - 'bucket/**'
+#     tags-ignore:
+#     - 'v*' # Don't run CI tests on release tags
 
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+# jobs:
+#   build:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v3
+#         with:
+#           fetch-depth: 0
 
-      - uses: ./.github/actions/build
+#       - uses: ./.github/actions/build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,21 +20,21 @@ jobs:
 
       - uses: ./.github/actions/build
 
-      # - name: Import GPG key
-      #   # This is a third-party GitHub action and we trust it with our GPG key.
-      #   # To be on the safer side, we should always pin to the commit SHA.
-      #   # It's not a perfect mitigation, but we should always do some due diligence before upgrading.
-      #   # The author seems trustworthy, as the author is part of the docker and goreleaser organizations on GitHub.
-      #   uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41
-      #   with:
-      #     gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-      #     passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Import GPG key
+        # This is a third-party GitHub action and we trust it with our GPG key.
+        # To be on the safer side, we should always pin to the commit SHA.
+        # It's not a perfect mitigation, but we should always do some due diligence before upgrading.
+        # The author seems trustworthy, as the author is part of the docker and goreleaser organizations on GitHub.
+        uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - uses: ./go.mk/.github/actions/release
         with:
           release_github_token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
-          # registry_username: ${{ secrets.DOCKERHUB_USERNAME }}
-          # registry_password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          registry_password: ${{ secrets.DOCKERHUB_TOKEN }}
           exoscale_api_key: ${{ secrets.SOS_PKG_BUCKET_KEY }}
           exoscale_api_secret: ${{ secrets.SOS_PKG_BUCKET_SECRET }}
 
@@ -46,79 +46,79 @@ jobs:
         id: get-linux-amd64-checksum
         shell: bash
 
-  # archrelease:
-  #   needs: goreleaser
+  archrelease:
+    needs: goreleaser
 
-  #   runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       aurpkg:
-  #         - exoscale-cli
-  #         - exoscale-cli-bin
-  #         - exoscale-cli-git
+    strategy:
+      fail-fast: false
+      matrix:
+        aurpkg:
+          - exoscale-cli
+          - exoscale-cli-bin
+          - exoscale-cli-git
 
-  #   container:
-  #     image: archlinux
+    container:
+      image: archlinux
 
-  #   steps:
-  #     - name: create build user
-  #       run: |
-  #         useradd -G root runner
-  #         mkdir /home/runner/
-  #         chown -R runner /home/runner
-  #       shell: bash
+    steps:
+      - name: create build user
+        run: |
+          useradd -G root runner
+          mkdir /home/runner/
+          chown -R runner /home/runner
+        shell: bash
 
-  #     - name: install tools
-  #       run: pacman --noconfirm -Sy git openssh glibc sudo binutils make gcc pkg-config fakeroot go which
-  #       shell: bash
+      - name: install tools
+        run: pacman --noconfirm -Sy git openssh glibc sudo binutils make gcc pkg-config fakeroot go which
+        shell: bash
 
-  #     - name: release
-  #       run: |
-  #           cd /home/runner/
-  #           sudo -u runner mkdir -p /home/runner/.ssh
-  #           sudo -u runner sh -c "echo \"${{ secrets.AUR_SSH_PRIVATE_KEY }}\" > /home/runner/.ssh/github_actions"
+      - name: release
+        run: |
+            cd /home/runner/
+            sudo -u runner mkdir -p /home/runner/.ssh
+            sudo -u runner sh -c "echo \"${{ secrets.AUR_SSH_PRIVATE_KEY }}\" > /home/runner/.ssh/github_actions"
 
-  #           cat << 'EOF' > release.bash
-  #             #!/usr/bin/env bash
+            cat << 'EOF' > release.bash
+              #!/usr/bin/env bash
 
-  #             set -e
-  #             set -o pipefail
+              set -e
+              set -o pipefail
 
-  #             aurpkg=$1
-  #             version_tag=$2
-  #             checksum=$3
+              aurpkg=$1
+              version_tag=$2
+              checksum=$3
 
-  #             export GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/home/runner/.ssh/known_hosts"
+              export GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/home/runner/.ssh/known_hosts"
 
-  #             ssh-keyscan aur.archlinux.org >>/home/runner/.ssh/known_hosts
-  #             chmod 600 /home/runner/.ssh/github_actions
-  #             eval $(ssh-agent)
-  #             ssh-add /home/runner/.ssh/github_actions
+              ssh-keyscan aur.archlinux.org >>/home/runner/.ssh/known_hosts
+              chmod 600 /home/runner/.ssh/github_actions
+              eval $(ssh-agent)
+              ssh-add /home/runner/.ssh/github_actions
 
-  #             git clone aur@aur.archlinux.org:$aurpkg.git
+              git clone aur@aur.archlinux.org:$aurpkg.git
 
-  #             cd /home/runner/$aurpkg
-  #             sed -i "/^pkgver=/s/.*/pkgver=$version_tag/" PKGBUILD
-  #             if [ $aurpkg == "exoscale-cli-bin" ]; then
-  #               sed -i "/^sha256sums=/s/.*/sha256sums=\('$checksum'/" PKGBUILD
-  #             fi
+              cd /home/runner/$aurpkg
+              sed -i "/^pkgver=/s/.*/pkgver=$version_tag/" PKGBUILD
+              if [ $aurpkg == "exoscale-cli-bin" ]; then
+                sed -i "/^sha256sums=/s/.*/sha256sums=\('$checksum'/" PKGBUILD
+              fi
 
-  #             makepkg --skippgpcheck
+              makepkg --skippgpcheck
 
-  #             makepkg --printsrcinfo >.SRCINFO
-  #             git add PKGBUILD .SRCINFO
-  #             git config --global user.email "ops@exoscale.com"
-  #             git config --global user.name "Exoscale"
-  #             git commit -m "release $version_tag"
-  #             git push
-  #           EOF
+              makepkg --printsrcinfo >.SRCINFO
+              git add PKGBUILD .SRCINFO
+              git config --global user.email "ops@exoscale.com"
+              git config --global user.name "Exoscale"
+              git commit -m "release $version_tag"
+              git push
+            EOF
 
-  #           chown runner release.bash
-  #           sudo -u runner chmod +x release.bash
-  #           sudo -u runner ./release.bash \
-  #             ${{ matrix.aurpkg }} \
-  #             ${{ needs.goreleaser.outputs.version_tag }} \
-  #             ${{ needs.goreleaser.outputs.linux_amd64_checksum }}
-  #       shell: bash
+            chown runner release.bash
+            sudo -u runner chmod +x release.bash
+            sudo -u runner ./release.bash \
+              ${{ matrix.aurpkg }} \
+              ${{ needs.goreleaser.outputs.version_tag }} \
+              ${{ needs.goreleaser.outputs.linux_amd64_checksum }}
+        shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,21 +20,21 @@ jobs:
 
       - uses: ./.github/actions/build
 
-      - name: Import GPG key
-        # This is a third-party GitHub action and we trust it with our GPG key.
-        # To be on the safer side, we should always pin to the commit SHA.
-        # It's not a perfect mitigation, but we should always do some due diligence before upgrading.
-        # The author seems trustworthy, as the author is part of the docker and goreleaser organizations on GitHub.
-        uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      # - name: Import GPG key
+      #   # This is a third-party GitHub action and we trust it with our GPG key.
+      #   # To be on the safer side, we should always pin to the commit SHA.
+      #   # It's not a perfect mitigation, but we should always do some due diligence before upgrading.
+      #   # The author seems trustworthy, as the author is part of the docker and goreleaser organizations on GitHub.
+      #   uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41
+      #   with:
+      #     gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+      #     passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - uses: ./go.mk/.github/actions/release
         with:
           release_github_token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
-          registry_username: ${{ secrets.DOCKERHUB_USERNAME }}
-          registry_password: ${{ secrets.DOCKERHUB_TOKEN }}
+          # registry_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          # registry_password: ${{ secrets.DOCKERHUB_TOKEN }}
           exoscale_api_key: ${{ secrets.SOS_PKG_BUCKET_KEY }}
           exoscale_api_secret: ${{ secrets.SOS_PKG_BUCKET_SECRET }}
 
@@ -46,79 +46,79 @@ jobs:
         id: get-linux-amd64-checksum
         shell: bash
 
-  archrelease:
-    needs: goreleaser
+  # archrelease:
+  #   needs: goreleaser
 
-    runs-on: ubuntu-latest
+  #   runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        aurpkg:
-          - exoscale-cli
-          - exoscale-cli-bin
-          - exoscale-cli-git
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       aurpkg:
+  #         - exoscale-cli
+  #         - exoscale-cli-bin
+  #         - exoscale-cli-git
 
-    container:
-      image: archlinux
+  #   container:
+  #     image: archlinux
 
-    steps:
-      - name: create build user
-        run: |
-          useradd -G root runner
-          mkdir /home/runner/
-          chown -R runner /home/runner
-        shell: bash
+  #   steps:
+  #     - name: create build user
+  #       run: |
+  #         useradd -G root runner
+  #         mkdir /home/runner/
+  #         chown -R runner /home/runner
+  #       shell: bash
 
-      - name: install tools
-        run: pacman --noconfirm -Sy git openssh glibc sudo binutils make gcc pkg-config fakeroot go which
-        shell: bash
+  #     - name: install tools
+  #       run: pacman --noconfirm -Sy git openssh glibc sudo binutils make gcc pkg-config fakeroot go which
+  #       shell: bash
 
-      - name: release
-        run: |
-            cd /home/runner/
-            sudo -u runner mkdir -p /home/runner/.ssh
-            sudo -u runner sh -c "echo \"${{ secrets.AUR_SSH_PRIVATE_KEY }}\" > /home/runner/.ssh/github_actions"
+  #     - name: release
+  #       run: |
+  #           cd /home/runner/
+  #           sudo -u runner mkdir -p /home/runner/.ssh
+  #           sudo -u runner sh -c "echo \"${{ secrets.AUR_SSH_PRIVATE_KEY }}\" > /home/runner/.ssh/github_actions"
 
-            cat << 'EOF' > release.bash
-              #!/usr/bin/env bash
+  #           cat << 'EOF' > release.bash
+  #             #!/usr/bin/env bash
 
-              set -e
-              set -o pipefail
+  #             set -e
+  #             set -o pipefail
 
-              aurpkg=$1
-              version_tag=$2
-              checksum=$3
+  #             aurpkg=$1
+  #             version_tag=$2
+  #             checksum=$3
 
-              export GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/home/runner/.ssh/known_hosts"
+  #             export GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/home/runner/.ssh/known_hosts"
 
-              ssh-keyscan aur.archlinux.org >>/home/runner/.ssh/known_hosts
-              chmod 600 /home/runner/.ssh/github_actions
-              eval $(ssh-agent)
-              ssh-add /home/runner/.ssh/github_actions
+  #             ssh-keyscan aur.archlinux.org >>/home/runner/.ssh/known_hosts
+  #             chmod 600 /home/runner/.ssh/github_actions
+  #             eval $(ssh-agent)
+  #             ssh-add /home/runner/.ssh/github_actions
 
-              git clone aur@aur.archlinux.org:$aurpkg.git
+  #             git clone aur@aur.archlinux.org:$aurpkg.git
 
-              cd /home/runner/$aurpkg
-              sed -i "/^pkgver=/s/.*/pkgver=$version_tag/" PKGBUILD
-              if [ $aurpkg == "exoscale-cli-bin" ]; then
-                sed -i "/^sha256sums=/s/.*/sha256sums=\('$checksum'/" PKGBUILD
-              fi
+  #             cd /home/runner/$aurpkg
+  #             sed -i "/^pkgver=/s/.*/pkgver=$version_tag/" PKGBUILD
+  #             if [ $aurpkg == "exoscale-cli-bin" ]; then
+  #               sed -i "/^sha256sums=/s/.*/sha256sums=\('$checksum'/" PKGBUILD
+  #             fi
 
-              makepkg --skippgpcheck
+  #             makepkg --skippgpcheck
 
-              makepkg --printsrcinfo >.SRCINFO
-              git add PKGBUILD .SRCINFO
-              git config --global user.email "ops@exoscale.com"
-              git config --global user.name "Exoscale"
-              git commit -m "release $version_tag"
-              git push
-            EOF
+  #             makepkg --printsrcinfo >.SRCINFO
+  #             git add PKGBUILD .SRCINFO
+  #             git config --global user.email "ops@exoscale.com"
+  #             git config --global user.name "Exoscale"
+  #             git commit -m "release $version_tag"
+  #             git push
+  #           EOF
 
-            chown runner release.bash
-            sudo -u runner chmod +x release.bash
-            sudo -u runner ./release.bash \
-              ${{ matrix.aurpkg }} \
-              ${{ needs.goreleaser.outputs.version_tag }} \
-              ${{ needs.goreleaser.outputs.linux_amd64_checksum }}
-        shell: bash
+  #           chown runner release.bash
+  #           sudo -u runner chmod +x release.bash
+  #           sudo -u runner ./release.bash \
+  #             ${{ matrix.aurpkg }} \
+  #             ${{ needs.goreleaser.outputs.version_tag }} \
+  #             ${{ needs.goreleaser.outputs.linux_amd64_checksum }}
+  #       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         id: get-version-tag
         shell: bash
 
-      - run: echo "linux_amd64_checksum="$(grep -P 'exoscale-cli_[0-9]+\.[0-9]+\.[0-9]_linux_amd64.tar.gz' dist/exoscale-cli_*_checksums.txt | head -n 1 | cut -c1-64) >> $GITHUB_OUTPUT
+      - run: echo "linux_amd64_checksum="$(grep -P 'exoscale-cli_[0-9]+\.[0-9]+\.[0-9]+_linux_amd64.tar.gz' dist/exoscale-cli_*_checksums.txt | head -n 1 | cut -c1-64) >> $GITHUB_OUTPUT
         id: get-linux-amd64-checksum
         shell: bash
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,10 +14,10 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
     goos:
-      # - windows
-      # - darwin
+      - windows
+      - darwin
       - linux
-      # - openbsd
+      - openbsd
     goarch:
       - amd64
       - arm
@@ -32,24 +32,23 @@ builds:
         goarch: arm64
 
 # macOS Universal Binaries
-# universal_binaries:
-#   - replace: true
-#     name_template: 'exo'
+universal_binaries:
+  - replace: true
+    name_template: 'exo'
 
-# archives:
-#   - id: windows
-#     format_overrides:
-#       - goos: windows
-#         format: zip
-#     files:
-#       - LICENSE
-#       - contrib/completion/**/*
-#       - manpage/*
+archives:
+  - id: windows
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - LICENSE
+      - contrib/completion/**/*
+      - manpage/*
 
 release:
-  disable: true
   github:
-    owner: sauterp
+    owner: exoscale
     name: cli
 
 nfpms:
@@ -73,60 +72,60 @@ nfpms:
       - src: "./contrib/completion/zsh/_exo"
         dst: "/usr/share/zsh/vendor-completions/_exo"
 
-# brews:
-#   - tap:
-#       owner: exoscale
-#       name: homebrew-tap
-#     folder: Formula
-#     homepage: "https://exoscale.github.io/cli/"
-#     description: Manage easily your Exoscale infrastructure from the command-line.
-#     install: |
-#       bin.install "exo"
-#       man1.install Dir["manpage/exo*.1"]
-#       bash_completion.install "contrib/completion/bash/exo"
-#       zsh_completion.install "contrib/completion/zsh/_exo"
+brews:
+  - tap:
+      owner: exoscale
+      name: homebrew-tap
+    folder: Formula
+    homepage: "https://exoscale.github.io/cli/"
+    description: Manage easily your Exoscale infrastructure from the command-line.
+    install: |
+      bin.install "exo"
+      man1.install Dir["manpage/exo*.1"]
+      bash_completion.install "contrib/completion/bash/exo"
+      zsh_completion.install "contrib/completion/zsh/_exo"
 
-# dockers:
-#   - goos: linux
-#     goarch: amd64
-#     image_templates:
-#       - "exoscale/cli:latest"
-#       - "exoscale/cli:{{ .Major }}"
-#       - "exoscale/cli:{{ .Major }}.{{ .Minor }}"
-#       - "exoscale/cli:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
-#     dockerfile: Dockerfile.goreleaser
-#     build_flag_templates:
-#       - --pull
-#       - --build-arg="VERSION={{.Version}}"
-#       - --build-arg="VCS_REF={{.ShortCommit}}"
-#       - --build-arg="BUILD_DATE={{.Date}}"
+dockers:
+  - goos: linux
+    goarch: amd64
+    image_templates:
+      - "exoscale/cli:latest"
+      - "exoscale/cli:{{ .Major }}"
+      - "exoscale/cli:{{ .Major }}.{{ .Minor }}"
+      - "exoscale/cli:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+    dockerfile: Dockerfile.goreleaser
+    build_flag_templates:
+      - --pull
+      - --build-arg="VERSION={{.Version}}"
+      - --build-arg="VCS_REF={{.ShortCommit}}"
+      - --build-arg="BUILD_DATE={{.Date}}"
 
-# source:
-#   enabled: true
-#   prefix_template: "{{ .ProjectName }}_{{ .Version }}/"
-#   name_template: "{{ .ProjectName }}_{{ .Version }}"
-#   rlcp: true
-#   files:
-#     - go.mk/*
+source:
+  enabled: true
+  prefix_template: "{{ .ProjectName }}_{{ .Version }}/"
+  name_template: "{{ .ProjectName }}_{{ .Version }}"
+  rlcp: true
+  files:
+    - go.mk/*
 
-# signs:
-# - cmd: gpg
-#   args: ["--default-key", "7100E8BFD6199CE0374CB7F003686F8CDE378D41", "--detach-sign", "${artifact}"]
-#   artifacts: all
+signs:
+- cmd: gpg
+  args: ["--default-key", "7100E8BFD6199CE0374CB7F003686F8CDE378D41", "--detach-sign", "${artifact}"]
+  artifacts: all
 
-# scoops:
-#   - description: "Command-line tool for everything at Exoscale: compute, storage, dns."
-#     folder: "bucket"
-#     commit_author:
-#       name: "Exoscale Tooling"
-#       email: "tooling@exoscale.ch"
-#     commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
-#     homepage: "https://github.com/exoscale/cli"
-#     license: "Apache License 2.0"
-#     repository:
-#       owner: exoscale
-#       name: cli
-#       branch: master
+scoops:
+  - description: "Command-line tool for everything at Exoscale: compute, storage, dns."
+    folder: "bucket"
+    commit_author:
+      name: "Exoscale Tooling"
+      email: "tooling@exoscale.ch"
+    commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
+    homepage: "https://github.com/exoscale/cli"
+    license: "Apache License 2.0"
+    repository:
+      owner: exoscale
+      name: cli
+      branch: master
 
 publishers:
   - name: rpms
@@ -135,15 +134,11 @@ publishers:
       - AWS_SECRET_ACCESS_KEY={{ .Env.EXOSCALE_API_SECRET }}
     ids:
       - nfpms
-      # TODO(sc-78178) remove sauterp
-      # TODO(sc-78178) set number of versions to keep to 10
-    cmd: ./go.mk/scripts/publish-rpm-artifact-to-sos.sh {{ .ArtifactPath }} sauterp-exoscale-packages rpm/cli 3
+    cmd: ./go.mk/scripts/publish-rpm-artifact-to-sos.sh {{ .ArtifactPath }} exoscale-packages rpm/cli 10
   - name: aptly
     env:
       - AWS_ACCESS_KEY_ID={{ .Env.EXOSCALE_API_KEY }}
       - AWS_SECRET_ACCESS_KEY={{ .Env.EXOSCALE_API_SECRET }}
     ids:
       - nfpms
-      # TODO(sc-78178) remove sauterp
-      # TODO(sc-78178) set number of versions to keep to 10
-    cmd: ./go.mk/scripts/publish-deb-artifact-to-sos.sh {{ .ArtifactPath }} sauterp-exoscale-packages deb/cli 3 {{ .ProjectName }}
+    cmd: ./go.mk/scripts/publish-deb-artifact-to-sos.sh {{ .ArtifactPath }} exoscale-packages deb/cli 10 {{ .ProjectName }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,11 +20,11 @@ builds:
       # - openbsd
     goarch:
       - amd64
-      # - arm
-      # - arm64
-    # goarm:
-    #   - 6
-    #   - 7
+      - arm
+      - arm64
+    goarm:
+      - 6
+      - 7
     ignore:
       - goos: openbsd
         goarch: arm
@@ -60,7 +60,7 @@ nfpms:
     license: Apache 2.0
     id: nfpms
     formats:
-      # - deb
+      - deb
       - rpm
     contents:
       # manpages
@@ -129,10 +129,21 @@ nfpms:
 #       branch: master
 
 publishers:
-  # - name: aptly
-  #   env:
-  #     - AWS_ACCESS_KEY_ID={{ .Env.EXOSCALE_API_KEY }}
-  #     - AWS_SECRET_ACCESS_KEY={{ .Env.EXOSCALE_API_SECRET }}
-  #   ids:
-  #     - nfpms
-  #   cmd: ./go.mk/scripts/publish-deb-artifact-to-sos.sh {{ .ArtifactPath }} exoscale-packages deb/cli 10
+  - name: rpms
+    env:
+      - AWS_ACCESS_KEY_ID={{ .Env.EXOSCALE_API_KEY }}
+      - AWS_SECRET_ACCESS_KEY={{ .Env.EXOSCALE_API_SECRET }}
+    ids:
+      - nfpms
+      # TODO(sc-78178) remove sauterp
+      # TODO(sc-78178) set number of versions to keep to 10
+    cmd: ./go.mk/scripts/publish-rpm-artifact-to-sos.sh {{ .ArtifactPath }} sauterp-exoscale-packages rpm/cli 3
+  - name: aptly
+    env:
+      - AWS_ACCESS_KEY_ID={{ .Env.EXOSCALE_API_KEY }}
+      - AWS_SECRET_ACCESS_KEY={{ .Env.EXOSCALE_API_SECRET }}
+    ids:
+      - nfpms
+      # TODO(sc-78178) remove sauterp
+      # TODO(sc-78178) set number of versions to keep to 10
+    cmd: ./go.mk/scripts/publish-deb-artifact-to-sos.sh {{ .ArtifactPath }} sauterp-exoscale-packages deb/cli 3 {{ .ProjectName }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,17 +14,17 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
     goos:
-      - windows
-      - darwin
+      # - windows
+      # - darwin
       - linux
-      - openbsd
+      # - openbsd
     goarch:
       - amd64
-      - arm
-      - arm64
-    goarm:
-      - 6
-      - 7
+      # - arm
+      # - arm64
+    # goarm:
+    #   - 6
+    #   - 7
     ignore:
       - goos: openbsd
         goarch: arm
@@ -32,23 +32,24 @@ builds:
         goarch: arm64
 
 # macOS Universal Binaries
-universal_binaries:
-  - replace: true
-    name_template: 'exo'
+# universal_binaries:
+#   - replace: true
+#     name_template: 'exo'
 
-archives:
-  - id: windows
-    format_overrides:
-      - goos: windows
-        format: zip
-    files:
-      - LICENSE
-      - contrib/completion/**/*
-      - manpage/*
+# archives:
+#   - id: windows
+#     format_overrides:
+#       - goos: windows
+#         format: zip
+#     files:
+#       - LICENSE
+#       - contrib/completion/**/*
+#       - manpage/*
 
 release:
+  disable: true
   github:
-    owner: exoscale
+    owner: sauterp
     name: cli
 
 nfpms:
@@ -59,7 +60,7 @@ nfpms:
     license: Apache 2.0
     id: nfpms
     formats:
-      - deb
+      # - deb
       - rpm
     contents:
       # manpages
@@ -72,66 +73,66 @@ nfpms:
       - src: "./contrib/completion/zsh/_exo"
         dst: "/usr/share/zsh/vendor-completions/_exo"
 
-brews:
-  - tap:
-      owner: exoscale
-      name: homebrew-tap
-    folder: Formula
-    homepage: "https://exoscale.github.io/cli/"
-    description: Manage easily your Exoscale infrastructure from the command-line.
-    install: |
-      bin.install "exo"
-      man1.install Dir["manpage/exo*.1"]
-      bash_completion.install "contrib/completion/bash/exo"
-      zsh_completion.install "contrib/completion/zsh/_exo"
+# brews:
+#   - tap:
+#       owner: exoscale
+#       name: homebrew-tap
+#     folder: Formula
+#     homepage: "https://exoscale.github.io/cli/"
+#     description: Manage easily your Exoscale infrastructure from the command-line.
+#     install: |
+#       bin.install "exo"
+#       man1.install Dir["manpage/exo*.1"]
+#       bash_completion.install "contrib/completion/bash/exo"
+#       zsh_completion.install "contrib/completion/zsh/_exo"
 
-dockers:
-  - goos: linux
-    goarch: amd64
-    image_templates:
-      - "exoscale/cli:latest"
-      - "exoscale/cli:{{ .Major }}"
-      - "exoscale/cli:{{ .Major }}.{{ .Minor }}"
-      - "exoscale/cli:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
-    dockerfile: Dockerfile.goreleaser
-    build_flag_templates:
-      - --pull
-      - --build-arg="VERSION={{.Version}}"
-      - --build-arg="VCS_REF={{.ShortCommit}}"
-      - --build-arg="BUILD_DATE={{.Date}}"
+# dockers:
+#   - goos: linux
+#     goarch: amd64
+#     image_templates:
+#       - "exoscale/cli:latest"
+#       - "exoscale/cli:{{ .Major }}"
+#       - "exoscale/cli:{{ .Major }}.{{ .Minor }}"
+#       - "exoscale/cli:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+#     dockerfile: Dockerfile.goreleaser
+#     build_flag_templates:
+#       - --pull
+#       - --build-arg="VERSION={{.Version}}"
+#       - --build-arg="VCS_REF={{.ShortCommit}}"
+#       - --build-arg="BUILD_DATE={{.Date}}"
 
-source:
-  enabled: true
-  prefix_template: "{{ .ProjectName }}_{{ .Version }}/"
-  name_template: "{{ .ProjectName }}_{{ .Version }}"
-  rlcp: true
-  files:
-    - go.mk/*
+# source:
+#   enabled: true
+#   prefix_template: "{{ .ProjectName }}_{{ .Version }}/"
+#   name_template: "{{ .ProjectName }}_{{ .Version }}"
+#   rlcp: true
+#   files:
+#     - go.mk/*
 
-signs:
-- cmd: gpg
-  args: ["--default-key", "7100E8BFD6199CE0374CB7F003686F8CDE378D41", "--detach-sign", "${artifact}"]
-  artifacts: all
+# signs:
+# - cmd: gpg
+#   args: ["--default-key", "7100E8BFD6199CE0374CB7F003686F8CDE378D41", "--detach-sign", "${artifact}"]
+#   artifacts: all
 
-scoops:
-  - description: "Command-line tool for everything at Exoscale: compute, storage, dns."
-    folder: "bucket"
-    commit_author:
-      name: "Exoscale Tooling"
-      email: "tooling@exoscale.ch"
-    commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
-    homepage: "https://github.com/exoscale/cli"
-    license: "Apache License 2.0"
-    repository:
-      owner: exoscale
-      name: cli
-      branch: master
+# scoops:
+#   - description: "Command-line tool for everything at Exoscale: compute, storage, dns."
+#     folder: "bucket"
+#     commit_author:
+#       name: "Exoscale Tooling"
+#       email: "tooling@exoscale.ch"
+#     commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
+#     homepage: "https://github.com/exoscale/cli"
+#     license: "Apache License 2.0"
+#     repository:
+#       owner: exoscale
+#       name: cli
+#       branch: master
 
 publishers:
-  - name: aptly
-    env:
-      - AWS_ACCESS_KEY_ID={{ .Env.EXOSCALE_API_KEY }}
-      - AWS_SECRET_ACCESS_KEY={{ .Env.EXOSCALE_API_SECRET }}
-    ids:
-      - nfpms
-    cmd: ./go.mk/scripts/publish-deb-artifact-to-sos.sh {{ .ArtifactPath }} exoscale-packages deb/cli 10
+  # - name: aptly
+  #   env:
+  #     - AWS_ACCESS_KEY_ID={{ .Env.EXOSCALE_API_KEY }}
+  #     - AWS_SECRET_ACCESS_KEY={{ .Env.EXOSCALE_API_SECRET }}
+  #   ids:
+  #     - nfpms
+  #   cmd: ./go.mk/scripts/publish-deb-artifact-to-sos.sh {{ .ArtifactPath }} exoscale-packages deb/cli 10


### PR DESCRIPTION
# Description

We use a script in go.mk as a custom publisher to publish releases to SOS. As with debian releases, we only keep the last 10 versions of the cli available in the bucket.

This PR depends on https://github.com/exoscale/go.mk/pull/38

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

The publisher ran successfully [on my fork](https://github.com/sauterp/cli/actions/runs/6624841931/job/17994621129)

I tested that the released RPMs can be installed with DNF on Fedora 37 by adding a repo file `/etc/yum.repos.d/sauterp-rpm-test-repo.repo` with the following content:
```
[sauterp-rpm-test-repo]
name=created by dnf config-manager from s3:exoscale-package
baseurl=https://sos-ch-gva-2.exo.io/sauterp-exoscale-packages/rpm/cli
enabled=1
repo_gpgcheck=1
gpgcheck=0
gpgkey=https://keys.openpgp.org/vks/v1/by-fingerprint/7100E8BFD6199CE0374CB7F003686F8CDE378D41
```

Then I tested whether the new and old releases are visible and whether they can be installed through dnf.
```shell
# get a list of all available versions and architectures
$ sudo dnf upgrade --refresh --assumeno || sudo dnf list --showduplicates exoscale-cli
...

Last metadata expiration check: 0:00:04 ago on Tue 24 Oct 2023 03:17:30 PM CEST.
Installed Packages
exoscale-cli.x86_64                               1.74.1698151249-1                              @sauterp-rpm-test-repo
Available Packages
exoscale-cli.aarch64                              1.74.1698150184-1                              sauterp-rpm-test-repo
exoscale-cli.armv6hl                              1.74.1698150184-1                              sauterp-rpm-test-repo
exoscale-cli.armv7hl                              1.74.1698150184-1                              sauterp-rpm-test-repo
exoscale-cli.x86_64                               1.74.1698150184-1                              sauterp-rpm-test-repo
exoscale-cli.aarch64                              1.74.1698150981-1                              sauterp-rpm-test-repo
exoscale-cli.armv6hl                              1.74.1698150981-1                              sauterp-rpm-test-repo
exoscale-cli.armv7hl                              1.74.1698150981-1                              sauterp-rpm-test-repo
exoscale-cli.x86_64                               1.74.1698150981-1                              sauterp-rpm-test-repo
exoscale-cli.aarch64                              1.74.1698151249-1                              sauterp-rpm-test-repo
exoscale-cli.armv6hl                              1.74.1698151249-1                              sauterp-rpm-test-repo
exoscale-cli.armv7hl                              1.74.1698151249-1                              sauterp-rpm-test-repo
exoscale-cli.x86_64                               1.74.1698151249-1                              sauterp-rpm-test-repo

# install an older version
$ sudo dnf install exoscale-cli-1.74.1698150184-1
sudo dnf install exoscale-cli-1.74.1698150184-1
Last metadata expiration check: 0:00:26 ago on Tue 24 Oct 2023 03:17:30 PM CEST.
Dependencies resolved.
=======================================================================================================================
 Package                   Architecture        Version                        Repository                          Size
=======================================================================================================================
Downgrading:
 exoscale-cli              x86_64              1.74.1698150184-1              sauterp-rpm-test-repo               11 M

Transaction Summary
=======================================================================================================================
Downgrade  1 Package

Total download size: 11 M
Is this ok [y/N]: y
Downloading Packages:
exoscale-cli_1.74.1698150184_linux_amd64.rpm                                           9.7 MB/s |  11 MB     00:01
-----------------------------------------------------------------------------------------------------------------------
Total                                                                                  9.7 MB/s |  11 MB     00:01
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                               1/1
  Downgrading      : exoscale-cli-1.74.1698150184-1.x86_64                                                         1/2
  Cleanup          : exoscale-cli-1.74.1698151249-1.x86_64                                                         2/2
  Running scriptlet: exoscale-cli-1.74.1698151249-1.x86_64                                                         2/2
  Verifying        : exoscale-cli-1.74.1698150184-1.x86_64                                                         1/2
  Verifying        : exoscale-cli-1.74.1698151249-1.x86_64                                                         2/2

Downgraded:
  exoscale-cli-1.74.1698150184-1.x86_64

Complete!

$ exo version
exo 1.74.1698150184 54d78471 (egoscale 0.101.0)

# install the latest version
$ sudo dnf update exoscale-cli
Last metadata expiration check: 0:03:44 ago on Tue 24 Oct 2023 03:17:30 PM CEST.
Dependencies resolved.
=======================================================================================================================
 Package                   Architecture        Version                        Repository                          Size
=======================================================================================================================
Upgrading:
 exoscale-cli              x86_64              1.74.1698151249-1              sauterp-rpm-test-repo               11 M

Transaction Summary
=======================================================================================================================
Upgrade  1 Package

Total download size: 11 M
Is this ok [y/N]: y
Downloading Packages:
exoscale-cli_1.74.1698151249_linux_amd64.rpm                                            13 MB/s |  11 MB     00:00
-----------------------------------------------------------------------------------------------------------------------
Total                                                                                   13 MB/s |  11 MB     00:00
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                               1/1
  Upgrading        : exoscale-cli-1.74.1698151249-1.x86_64                                                         1/2
  Cleanup          : exoscale-cli-1.74.1698150184-1.x86_64                                                         2/2
  Running scriptlet: exoscale-cli-1.74.1698150184-1.x86_64                                                         2/2
  Verifying        : exoscale-cli-1.74.1698151249-1.x86_64                                                         1/2
  Verifying        : exoscale-cli-1.74.1698150184-1.x86_64                                                         2/2

Upgraded:
  exoscale-cli-1.74.1698151249-1.x86_64

Complete!

$ exo version
exo 1.74.1698151249 54d78471 (egoscale 0.101.0)