### PR TITLE
install-script: install rpms from SOS repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Improvements
+
+- install-script: install rpms from SOS repo #556 
+
 ## 1.74.4
 
 ### Improvements

--- a/install-latest.sh
+++ b/install-latest.sh
@@ -187,12 +187,11 @@ else
 fi
 
 install_rpm_pkg() {
-    # TODO (sc-78179) remove sauterp
     repofile=/etc/yum.repos.d/exoscale-cli.repo
     cat <<EOF >$repofile
 [exoscale-cli-repo]
 name=exoscale-cli-repo
-baseurl=https://sos-ch-gva-2.exo.io/sauterp-exoscale-packages/rpm/cli
+baseurl=https://sos-ch-gva-2.exo.io/exoscale-packages/rpm/cli
 enabled=1
 repo_gpgcheck=1
 gpgcheck=0

--- a/install-latest.sh
+++ b/install-latest.sh
@@ -188,7 +188,7 @@ fi
 
 install_rpm_pkg() {
     repofile=/etc/yum.repos.d/exoscale-cli.repo
-    cat <<EOF >$repofile
+    cat <<EOF | $SUDO tee $repofile
 [exoscale-cli-repo]
 name=exoscale-cli-repo
 baseurl=https://sos-ch-gva-2.exo.io/exoscale-packages/rpm/cli


### PR DESCRIPTION
# Description
We change the installation script so it can install packages from SOS repos directly trhough yum and dnf.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing
The script was tested in docker containers for ubuntu:jammy(apt), ubunty:focal(dpkg), fedora(dnf), centos:7(yum). I tested both fresh installs, downgrading and upgrading an existing installation.
