### PR TITLE
README: document installation from AUR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- README: document installation from AUR #557 
+
 ## 1.74.3
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ scoop update
 scoop update exoscale-cli
 ```
 
+### From the AUR on Arch Linux
+
+```shell
+gpg --keyserver keys.openpgp.org --recv-key 7100E8BFD6199CE0374CB7F003686F8CDE378D41
+git clone https://aur.archlinux.org/exoscale-cli-bin.git
+cd exoscale-cli-bin/
+makepkg --install
+```
+
+Alternatively there are two packages building from source https://aur.archlinux.org/exoscale-cli.git and https://aur.archlinux.org/exoscale-cli-git.git where the latter builds from the latest commit on the master branch and the former from the latest release commit.
+
 ## Configuration
 
 Running the `exo config` command will guide you through the initial configuration.


### PR DESCRIPTION
# Description
We document how to install the cli on Arch Linux from the AUR.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

Commands were tested in a docker container.
