### PR TITLE
SOS download: output warning when no objects exist at prefix

### DIFF
--- a/cmd/storage_download.go
+++ b/cmd/storage_download.go
@@ -103,6 +103,12 @@ Examples:
 			return fmt.Errorf("error listing objects: %s", err)
 		}
 
+		if len(objects) == 0 {
+			fmt.Printf("no objects exist at %q\n", prefix)
+
+			return nil
+		}
+
 		return storage.DownloadFiles(gContext, &sos.DownloadConfig{
 			Bucket:      bucket,
 			Prefix:      prefix,


### PR DESCRIPTION
# Description
We output a warning if the user tries to download a prefix from SOS where no objects can be found.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

```shell
./bin/exo storage download test-bucket/asdf
no objects exist at "asdf"

no objects exist at "asdfqwer/"
./bin/exo storage download -r test-bucket/asdfqwer/
```