### PR TITLE
Update iam org-policy reset confirmation text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Improvements
 - x: make `exo api` an alias to `exo x` #579
+- Update `iam org-policy reset` confirmation text #568
 
 ## 1.76.1
 

--- a/cmd/iam_org_policy_reset.go
+++ b/cmd/iam_org_policy_reset.go
@@ -34,7 +34,7 @@ func (c *iamOrgPolicyResetCmd) cmdPreRun(cmd *cobra.Command, args []string) erro
 
 func (c *iamOrgPolicyResetCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 	if !c.Force {
-		if !askQuestion("This action will remove any resource constraints you may have set in your Org Policy. Proceed?") {
+		if !askQuestion("This action will reset your Org Policy to the default, removing any constraints that were set in the Org Policy. Proceed?") {
 			return nil
 		}
 	}


### PR DESCRIPTION
# Description
Updates `exo iam org-policy reset` confirmation text to remove ambiguity.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

```bash
$ go run . iam org-policy reset
[+] This action will reset your Org Policy to the default, removing any constraints that were set in the Org Policy. Proceed? [yN]: y
```
