### PR TITLE
iam role create: fix description and policy when not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Bug Fixes
 - SOS download: output warning when no objects exist at prefix #563
-- Fix the bug in `iam role create` description that made them required #569
+- Fix the bug in `iam role create` description that made it required #569
+- Fix creating role with empty policy #569
 
 ### Features
 - Updated 'exo x' list-block-storage-volumes #562
@@ -12,6 +13,7 @@
 
 ### Improvements
 - Update `exo iam role create` pro tip #55
+- `exo iam org-policy`  `replace` command renamed to `update` where `replace` is now alias #569
 
 ## 1.75.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 - SOS download: output warning when no objects exist at prefix #563
+- Fix the bug in `iam role create` description that made them required #569
 
 ### Features
 - Updated 'exo x' list-block-storage-volumes #562

--- a/cmd/iam_org_policy_update.go
+++ b/cmd/iam_org_policy_update.go
@@ -15,21 +15,23 @@ import (
 	exoapi "github.com/exoscale/egoscale/v2/api"
 )
 
-type iamOrgPolicyReplaceCmd struct {
+type iamOrgPolicyUpdateCmd struct {
 	cliCommandSettings `cli-cmd:"-"`
 
 	Policy string `cli-arg:"#"`
 
-	_ bool `cli-cmd:"replace"`
+	_ bool `cli-cmd:"update"`
 }
 
-func (c *iamOrgPolicyReplaceCmd) cmdAliases() []string { return nil }
-
-func (c *iamOrgPolicyReplaceCmd) cmdShort() string {
-	return "Replace Org policy"
+func (c *iamOrgPolicyUpdateCmd) cmdAliases() []string {
+	return []string{"replace"}
 }
 
-func (c *iamOrgPolicyReplaceCmd) cmdLong() string {
+func (c *iamOrgPolicyUpdateCmd) cmdShort() string {
+	return "Update Org policy"
+}
+
+func (c *iamOrgPolicyUpdateCmd) cmdLong() string {
 	return fmt.Sprintf(`This command replaces the complete IAM Organization Policy with the new one provided in JSON format.
 To read the Policy from STDIN provide '-' as an argument.
 
@@ -41,11 +43,11 @@ Supported output template annotations: %s`,
 		strings.Join(output.TemplateAnnotations(&iamPolicyOutput{}), ", "))
 }
 
-func (c *iamOrgPolicyReplaceCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+func (c *iamOrgPolicyUpdateCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
 	return cliCommandDefaultPreRun(c, cmd, args)
 }
 
-func (c *iamOrgPolicyReplaceCmd) cmdRun(cmd *cobra.Command, _ []string) error {
+func (c *iamOrgPolicyUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 	zone := account.CurrentAccount.DefaultZone
 	ctx := exoapi.WithEndpoint(
 		gContext,
@@ -123,7 +125,7 @@ func (c *iamOrgPolicyReplaceCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(registerCLICommand(iamOrgPolicyCmd, &iamOrgPolicyReplaceCmd{
+	cobra.CheckErr(registerCLICommand(iamOrgPolicyCmd, &iamOrgPolicyUpdateCmd{
 		cliCommandSettings: defaultCLICmdSettings(),
 	}))
 }

--- a/cmd/iam_org_policy_update.go
+++ b/cmd/iam_org_policy_update.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -11,7 +10,6 @@ import (
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
-	exoscale "github.com/exoscale/egoscale/v2"
 	exoapi "github.com/exoscale/egoscale/v2/api"
 )
 
@@ -64,50 +62,9 @@ func (c *iamOrgPolicyUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 		c.Policy = string(b)
 	}
 
-	var obj iamPolicyOutput
-	err := json.Unmarshal([]byte(c.Policy), &obj)
+	policy, err := iamPolicyFromJSON([]byte(c.Policy))
 	if err != nil {
-		return fmt.Errorf("failed to parse policy: %w", err)
-	}
-
-	policy := &exoscale.IAMPolicy{
-		DefaultServiceStrategy: obj.DefaultServiceStrategy,
-		Services:               map[string]exoscale.IAMPolicyService{},
-	}
-
-	if len(obj.Services) > 0 {
-		for name, sv := range obj.Services {
-			service := exoscale.IAMPolicyService{
-				Type: func() *string {
-					t := sv.Type
-					return &t
-				}(),
-			}
-
-			if len(sv.Rules) > 0 {
-				service.Rules = []exoscale.IAMPolicyServiceRule{}
-				for _, rl := range sv.Rules {
-
-					rule := exoscale.IAMPolicyServiceRule{
-						Action: func() *string {
-							t := rl.Action
-							return &t
-						}(),
-					}
-
-					if rl.Expression != "" {
-						rule.Expression = func() *string {
-							t := rl.Expression
-							return &t
-						}()
-					}
-
-					service.Rules = append(service.Rules, rule)
-				}
-			}
-
-			policy.Services[name] = service
-		}
+		return fmt.Errorf("failed to parse IAM policy: %w", err)
 	}
 
 	err = globalstate.EgoscaleClient.UpdateIAMOrgPolicy(ctx, zone, policy)

--- a/cmd/iam_role_create.go
+++ b/cmd/iam_role_create.go
@@ -41,7 +41,7 @@ To read the Policy from STDIN, append '-' to the '--policy' flag.
 
 Pro Tip: you can reuse an existing role policy by providing the output of the show command as input:
 
-	exo iam role show --policy --output-format json <role-name> | exo iam role create <new-role-name> --description "new role description" --policy -
+	exo iam role show --policy --output-format json <role-name> | exo iam role create <new-role-name> --policy -
 
 Supported output template annotations: %s`,
 		strings.Join(output.TemplateAnnotations(&iamRoleShowOutput{}), ", "))
@@ -62,69 +62,78 @@ func (c *iamRoleCreateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 		exoapi.NewReqEndpoint(account.CurrentAccount.Environment, zone),
 	)
 
-	if c.Policy == "-" {
-		inputReader := cmd.InOrStdin()
-		b, err := io.ReadAll(inputReader)
-		if err != nil {
-			return fmt.Errorf("failed to read policy from stdin: %w", err)
+	var policy *exoscale.IAMPolicy
+
+	// Policy is optional, if not set API will default to `allow all`
+	if c.Policy != "" {
+		// If Policy value is `-` read from STDIN
+		if c.Policy == "-" {
+			inputReader := cmd.InOrStdin()
+			b, err := io.ReadAll(inputReader)
+			if err != nil {
+				return fmt.Errorf("failed to read policy from stdin: %w", err)
+			}
+
+			c.Policy = string(b)
 		}
 
-		c.Policy = string(b)
-	}
+		var obj iamPolicyOutput
+		err := json.Unmarshal([]byte(c.Policy), &obj)
+		if err != nil {
+			return fmt.Errorf("failed to parse policy: %w", err)
+		}
 
-	var obj iamPolicyOutput
-	err := json.Unmarshal([]byte(c.Policy), &obj)
-	if err != nil {
-		return fmt.Errorf("failed to parse policy: %w", err)
-	}
+		policy = &exoscale.IAMPolicy{
+			DefaultServiceStrategy: obj.DefaultServiceStrategy,
+			Services:               map[string]exoscale.IAMPolicyService{},
+		}
 
-	policy := &exoscale.IAMPolicy{
-		DefaultServiceStrategy: obj.DefaultServiceStrategy,
-		Services:               map[string]exoscale.IAMPolicyService{},
-	}
-
-	if len(obj.Services) > 0 {
-		for name, sv := range obj.Services {
-			service := exoscale.IAMPolicyService{
-				Type: func() *string {
-					t := sv.Type
-					return &t
-				}(),
-			}
-
-			if len(sv.Rules) > 0 {
-				service.Rules = []exoscale.IAMPolicyServiceRule{}
-				for _, rl := range sv.Rules {
-
-					rule := exoscale.IAMPolicyServiceRule{
-						Action: func() *string {
-							t := rl.Action
-							return &t
-						}(),
-					}
-
-					if rl.Expression != "" {
-						rule.Expression = func() *string {
-							t := rl.Expression
-							return &t
-						}()
-					}
-
-					service.Rules = append(service.Rules, rule)
+		if len(obj.Services) > 0 {
+			for name, sv := range obj.Services {
+				service := exoscale.IAMPolicyService{
+					Type: func() *string {
+						t := sv.Type
+						return &t
+					}(),
 				}
-			}
 
-			policy.Services[name] = service
+				if len(sv.Rules) > 0 {
+					service.Rules = []exoscale.IAMPolicyServiceRule{}
+					for _, rl := range sv.Rules {
+
+						rule := exoscale.IAMPolicyServiceRule{
+							Action: func() *string {
+								t := rl.Action
+								return &t
+							}(),
+						}
+
+						if rl.Expression != "" {
+							rule.Expression = func() *string {
+								t := rl.Expression
+								return &t
+							}()
+						}
+
+						service.Rules = append(service.Rules, rule)
+					}
+				}
+
+				policy.Services[name] = service
+			}
 		}
 	}
 
 	role := &exoscale.IAMRole{
 		Name:        &c.Name,
-		Description: &c.Description,
 		Editable:    &c.Editable,
 		Labels:      c.Labels,
 		Permissions: c.Permissions,
 		Policy:      policy,
+	}
+
+	if c.Description != "" {
+		role.Description = &c.Description
 	}
 
 	r, err := globalstate.EgoscaleClient.CreateIAMRole(ctx, zone, role)

--- a/cmd/iam_role_create.go
+++ b/cmd/iam_role_create.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -77,50 +76,11 @@ func (c *iamRoleCreateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 			c.Policy = string(b)
 		}
 
-		var obj iamPolicyOutput
-		err := json.Unmarshal([]byte(c.Policy), &obj)
+		var err error
+
+		policy, err = iamPolicyFromJSON([]byte(c.Policy))
 		if err != nil {
-			return fmt.Errorf("failed to parse policy: %w", err)
-		}
-
-		policy = &exoscale.IAMPolicy{
-			DefaultServiceStrategy: obj.DefaultServiceStrategy,
-			Services:               map[string]exoscale.IAMPolicyService{},
-		}
-
-		if len(obj.Services) > 0 {
-			for name, sv := range obj.Services {
-				service := exoscale.IAMPolicyService{
-					Type: func() *string {
-						t := sv.Type
-						return &t
-					}(),
-				}
-
-				if len(sv.Rules) > 0 {
-					service.Rules = []exoscale.IAMPolicyServiceRule{}
-					for _, rl := range sv.Rules {
-
-						rule := exoscale.IAMPolicyServiceRule{
-							Action: func() *string {
-								t := rl.Action
-								return &t
-							}(),
-						}
-
-						if rl.Expression != "" {
-							rule.Expression = func() *string {
-								t := rl.Expression
-								return &t
-							}()
-						}
-
-						service.Rules = append(service.Rules, rule)
-					}
-				}
-
-				policy.Services[name] = service
-			}
+			return fmt.Errorf("failed to parse IAM policy: %w", err)
 		}
 	}
 


### PR DESCRIPTION
# Description

Fixes issues with empty description and policy in `iam role create` command.
Also renames `iam org-policy` command `replace` to `update` (to be inline with `role`). `replace` is now alias command so it is backward compatible change.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

```bash
$ go run . iam role create api5                                                                                                                                           
┼─────────────┼──────────────────────────────────────┼                                        
│ ID          │ 7df88e66-5986-4b15-b908-8811460c0225 │                                        
│ Name        │ api5                                 │                                                                                                                                       
│ Description │                                      │                                                                                                                                       
│ Editable    │ true                                 │
│ Labels      │ n/a                                  │
│ Permissions │ n/a                                  │
┼─────────────┼──────────────────────────────────────┼
$ go run . iam role show api5 --policy                                      
┼─────────┼─────────────────────────────────┼─────────────┼─────────────────┼
│ SERVICE │ TYPE (DEFAULT STRATEGY "ALLOW") │ RULE ACTION │ RULE EXPRESSION │
┼─────────┼─────────────────────────────────┼─────────────┼─────────────────┼
┼─────────┼─────────────────────────────────┼─────────────┼─────────────────┼
```
