### PR TITLE
sks: flag for CSI addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+- sks: flag for CSI addon #572 
+
+### Improvements
 - Instance reset password: remove wrong "rm" alias #583
 
 ### Deprecations

--- a/cmd/sks_create.go
+++ b/cmd/sks_create.go
@@ -19,6 +19,7 @@ var (
 	defaultSKSClusterCNI          = "calico"
 	defaultSKSClusterServiceLevel = "pro"
 	sksClusterAddonExoscaleCCM    = "exoscale-cloud-controller"
+	sksClusterAddonExoscaleCSI    = "exoscale-container-storage-interface"
 	sksClusterAddonMetricsServer  = "metrics-server"
 )
 
@@ -37,6 +38,7 @@ type sksCreateCmd struct {
 	NoCNI                      bool              `cli-usage:"do not deploy a default Container Network Interface plugin in the cluster control plane"`
 	NoExoscaleCCM              bool              `cli-usage:"do not deploy the Exoscale Cloud Controller Manager in the cluster control plane"`
 	NoMetricsServer            bool              `cli-usage:"do not deploy the Kubernetes Metrics Server in the cluster control plane"`
+	ExoscaleCSI                bool              `cli-usage:"deploy the Exoscale Container Storage Interface on worker nodes"`
 	NodepoolAntiAffinityGroups []string          `cli-flag:"nodepool-anti-affinity-group" cli-usage:"default Nodepool Anti-Affinity Group NAME|ID (can be specified multiple times)"`
 	NodepoolDeployTarget       string            `cli-usage:"default Nodepool Deploy Target NAME|ID"`
 	NodepoolDescription        string            `cli-usage:"default Nodepool description"`
@@ -120,6 +122,9 @@ func (c *sksCreateCmd) cmdRun(_ *cobra.Command, _ []string) error { //nolint:goc
 		}
 		if c.NoMetricsServer {
 			delete(addOns, sksClusterAddonMetricsServer)
+		}
+		if c.ExoscaleCSI {
+			addOns[sksClusterAddonExoscaleCSI] = struct{}{}
 		}
 
 		if len(addOns) > 0 {

--- a/cmd/sks_create.go
+++ b/cmd/sks_create.go
@@ -112,27 +112,23 @@ func (c *sksCreateCmd) cmdRun(_ *cobra.Command, _ []string) error { //nolint:goc
 		cluster.CNI = nil
 	}
 
-	addOns := map[string]struct{}{
-		sksClusterAddonExoscaleCCM:   {},
-		sksClusterAddonMetricsServer: {},
-	}
 	cluster.AddOns = func() (v *[]string) {
-		if c.NoExoscaleCCM {
-			delete(addOns, sksClusterAddonExoscaleCCM)
+		addOns := make([]string, 0)
+
+		if !c.NoExoscaleCCM {
+			addOns = append(addOns, sksClusterAddonExoscaleCCM)
 		}
-		if c.NoMetricsServer {
-			delete(addOns, sksClusterAddonMetricsServer)
+
+		if !c.NoMetricsServer {
+			addOns = append(addOns, sksClusterAddonMetricsServer)
 		}
+
 		if c.ExoscaleCSI {
-			addOns[sksClusterAddonExoscaleCSI] = struct{}{}
+			addOns = append(addOns, sksClusterAddonExoscaleCSI)
 		}
 
 		if len(addOns) > 0 {
-			list := make([]string, 0)
-			for k := range addOns {
-				list = append(list, k)
-			}
-			v = &list
+			v = &addOns
 		}
 		return
 	}()


### PR DESCRIPTION
# Description

We add the flag `--exoscale-csi` to the `exo compute sks create` command. If set, a cluster with the CSI addon will be created. Unlike the `CCM` and `metrics-server` addons which have to be explicitly disabled with a `--no-...` flag, the CSI addon has to be explicitly enabled because for some users may not need it.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

```shell
❯ ./bin/exo compute sks create --exoscale-csi --zone ch-gva-2 --nodepool-size 1 my-csi-test-cluster

❯ ./bin/exo compute sks --zone ch-gva-2 show my-csi-test-cluster
┼───────────────┼──────────────────────────────────────────────────────────────────┼
│  SKS CLUSTER  │                                                                  │
┼───────────────┼──────────────────────────────────────────────────────────────────┼
│ ID            │ 7b4c6f18-58e0-4013-a351-4c9d69d4364c                             │
│ Name          │ my-csi-test-cluster                                              │
│ Description   │                                                                  │
│ Zone          │ ch-gva-2                                                         │
│ Creation Date │ 2024-02-12 17:10:35 +0000 UTC                                    │
│ Auto-upgrade  │ false                                                            │
│ Endpoint      │ https://7b4c6f18-58e0-4013-a351-4c9d69d4364c.sks-ch-gva-2.exo.io │
│ Version       │ 1.29.1                                                           │
│ Service Level │ pro                                                              │
│ CNI           │ calico                                                           │
│ Add-Ons       │ exoscale-cloud-controller                                        │
│               │ exoscale-container-storage-interface                             │
│               │ metrics-server                                                   │
│ State         │ running                                                          │
│ Labels        │ n/a                                                              │
│ Nodepools     │ n/a                                                              │
┼───────────────┼──────────────────────────────────────────────────────────────────┼

./bin/exo compute sks --zone ch-gva-2 nodepool add --size 2 my-csi-test-cluster my-csi-test-cluster-pool

❯ KUBECONFIG=kubeconfig kubectl get pods -A
NAMESPACE     NAME                                       READY   STATUS    RESTARTS   AGE
kube-system   calico-kube-controllers-558d465845-tcgb8   1/1     Running   0          18m
kube-system   calico-node-q4vps                          1/1     Running   0          7m2s
kube-system   calico-node-rvbrg                          1/1     Running   0          7m3s
kube-system   coredns-6f5866f786-f66ft                   1/1     Running   0          17m
kube-system   coredns-6f5866f786-nvfvx                   1/1     Running   0          17m
kube-system   exoscale-csi-controller-67c9d7ddb-hjsff    7/7     Running   0          17m
kube-system   exoscale-csi-controller-67c9d7ddb-pmg4z    7/7     Running   0          17m
kube-system   exoscale-csi-node-9plgw                    3/3     Running   0          6m48s
kube-system   exoscale-csi-node-c8sbg                    3/3     Running   0          6m21s
kube-system   konnectivity-agent-67467cf7b6-j4zmk        1/1     Running   0          17m
kube-system   konnectivity-agent-67467cf7b6-n5m95        1/1     Running   0          17m
kube-system   kube-proxy-77lq4                           1/1     Running   0          7m3s
kube-system   kube-proxy-v5cb7                           1/1     Running   0          7m2s
kube-system   metrics-server-8499c9d7ff-qpcxg            1/1     Running   0          17m
```
