### PR TITLE
go.mk: use as a plain repo instead of a submodule

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -6,8 +6,9 @@ runs:
       with:
         fetch-depth: 0
 
-    - run: git submodule update --init --recursive go.mk
+    - run: make go.mk
       shell: bash
+
     - uses: ./go.mk/.github/actions/setup
 
     - uses: ./go.mk/.github/actions/pre-check

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .git
+/go.mk
 dist
 release
 exo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+- go.mk: use as a plain repo instead of a submodule #575 
+
 ## 1.76.0
 
 ### Bug Fixes

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,36 @@
+ifndef MAKE_RESTARTS
+# This section will be processed the first time that make reads this file.
+
 # make go.mk a dependency for all targets
 .EXTRA_PREREQS = go.mk
-
-go.mk/init.mk:
-include go.mk/init.mk
-go.mk/public.mk:
-include go.mk/public.mk
 
 # This causes make to re-read the Makefile
 # and all included makefiles after go.mk
 # has been cloned.
 Makefile:
 	touch Makefile
+else
+# This section will be processed the second time that make reads this file.
+
+# make go.mk-ref a dependency for all targets
+.EXTRA_PREREQS = go.mk-ref
+endif
+
+go.mk/init.mk:
+include go.mk/init.mk
+go.mk/public.mk:
+include go.mk/public.mk
 
 .ONESHELL:
 go.mk:
 	git clone \
 		--depth 1 \
-		--branch philippsauter/sc-88913/go-mk-provide-alternative-to-submodule-approach \
 		git@github.com:exoscale/go.mk.git
+
+.PHONY: go.mk-ref
+go.mk-ref:
+	cd go.mk && \
+	git checkout philippsauter/sc-88913/go-mk-provide-alternative-to-submodule-approach
 
 PROJECT_URL = https://github.com/exoscale/cli
 GO_BIN_OUTPUT_NAME := exo

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,10 @@ GO_MK_REF := master
 ifndef MAKE_RESTARTS
 # This section will be processed the first time that make reads this file.
 
-# make go.mk a dependency for all targets
-.EXTRA_PREREQS = go.mk
-
 # This causes make to re-read the Makefile
 # and all included makefiles after go.mk
 # has been cloned.
-Makefile:
+Makefile: go.mk
 	@touch Makefile
 else
 # This section will be processed the second time that make reads this file.
@@ -23,9 +20,12 @@ include go.mk/init.mk
 go.mk/public.mk:
 include go.mk/public.mk
 
+.PHONY:
 .ONESHELL:
 go.mk:
-	git clone https://github.com/exoscale/go.mk.git
+	@if [ ! -d "go.mk" ]; then
+		git clone https://github.com/exoscale/go.mk.git
+	fi
 
 .PHONY: go.mk-ref
 go.mk-ref:

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,30 @@
 GO_MK_REF := master
 
+# make go.mk a dependency for all targets
+.EXTRA_PREREQS = go.mk
+
 ifndef MAKE_RESTARTS
 # This section will be processed the first time that make reads this file.
 
-# This causes make to re-read the Makefile
-# and all included makefiles after go.mk
-# has been cloned.
-Makefile: go.mk
+# This causes make to re-read the Makefile and all included
+# makefiles after go.mk has been cloned.
+Makefile:
 	@touch Makefile
-else
-# This section will be processed the second time that make reads this file.
-
-# make go.mk-ref a dependency for all targets
-.EXTRA_PREREQS = go.mk-ref
 endif
 
+# All files included from go.mk need an associated target or make will error
+# before go.mk can be cloned.
 go.mk/init.mk:
 include go.mk/init.mk
 go.mk/public.mk:
 include go.mk/public.mk
 
-.PHONY:
+.PHONY: go.mk
 .ONESHELL:
 go.mk:
 	@if [ ! -d "go.mk" ]; then
 		git clone https://github.com/exoscale/go.mk.git
 	fi
-
-.PHONY: go.mk-ref
-go.mk-ref:
 	@cd go.mk && \
 		git checkout --quiet ${GO_MK_REF}
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO_MK_REF := master
+GO_MK_REF := v1.0.0
 
 # make go.mk a dependency for all targets
 .EXTRA_PREREQS = go.mk
@@ -25,8 +25,14 @@ go.mk:
 	@if [ ! -d "go.mk" ]; then
 		git clone https://github.com/exoscale/go.mk.git
 	fi
-	@cd go.mk && \
-		git checkout --quiet ${GO_MK_REF}
+	@cd go.mk
+	@if ! git show-ref --quiet --verify "refs/heads/${GO_MK_REF}"; then
+		git fetch
+	fi
+	@if ! git show-ref --quiet --verify "refs/tags/${GO_MK_REF}"; then
+		git fetch --tags
+	fi
+	git checkout --quiet ${GO_MK_REF}
 
 PROJECT_URL = https://github.com/exoscale/cli
 GO_BIN_OUTPUT_NAME := exo

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ifndef MAKE_RESTARTS
 # and all included makefiles after go.mk
 # has been cloned.
 Makefile:
-	touch Makefile
+	@touch Makefile
 else
 # This section will be processed the second time that make reads this file.
 
@@ -23,14 +23,12 @@ include go.mk/public.mk
 
 .ONESHELL:
 go.mk:
-	git clone \
-		--depth 1 \
-		git@github.com:exoscale/go.mk.git
+	git clone git@github.com:exoscale/go.mk.git
 
 .PHONY: go.mk-ref
 go.mk-ref:
-	cd go.mk && \
-	git checkout philippsauter/sc-88913/go-mk-provide-alternative-to-submodule-approach
+	@cd go.mk && \
+		git checkout --quiet philippsauter/sc-88913/go-mk-provide-alternative-to-submodule-approach
 
 PROJECT_URL = https://github.com/exoscale/cli
 GO_BIN_OUTPUT_NAME := exo

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+include go.mk/init.mk
+include go.mk/public.mk
+
 go.mk/init.mk: go.mk
 go.mk/public.mk: go.mk
 
@@ -6,13 +9,12 @@ go.mk/public.mk: go.mk
 go.mk:
 	@if [ ! -d "go.mk" ]; then
 		git clone --depth 1 git@github.com:exoscale/go.mk.git
+		cd go.mk
+		git fetch --tags
+		git checkout 314a757ba0e1668ebfe7252269d4b58560854c69
+		cd ..
+		$(MAKE) $(MAKECMDGOALS)
 	fi
-	cd go.mk && \
-	git fetch --tags && \
-	git checkout 314a757ba0e1668ebfe7252269d4b58560854c69 > /dev/null
-
-include go.mk/init.mk
-include go.mk/public.mk
 
 PROJECT_URL = https://github.com/exoscale/cli
 GO_BIN_OUTPUT_NAME := exo

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+GO_MK_REF := master
+
 ifndef MAKE_RESTARTS
 # This section will be processed the first time that make reads this file.
 
@@ -23,12 +25,12 @@ include go.mk/public.mk
 
 .ONESHELL:
 go.mk:
-	git clone git@github.com:exoscale/go.mk.git
+	git clone https://github.com/exoscale/go.mk.git
 
 .PHONY: go.mk-ref
 go.mk-ref:
 	@cd go.mk && \
-		git checkout --quiet philippsauter/sc-88913/go-mk-provide-alternative-to-submodule-approach
+		git checkout --quiet ${GO_MK_REF}
 
 PROJECT_URL = https://github.com/exoscale/cli
 GO_BIN_OUTPUT_NAME := exo

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,13 @@ include go.mk/public.mk
 go.mk/init.mk: go.mk
 go.mk/public.mk: go.mk
 
-.PHONY: go.mk
 .ONESHELL:
 go.mk:
-	@if [ ! -d "go.mk" ]; then
-		git clone --depth 1 git@github.com:exoscale/go.mk.git
-		cd go.mk
-		git fetch --tags
-		git checkout 314a757ba0e1668ebfe7252269d4b58560854c69
-		cd ..
-		$(MAKE) $(MAKECMDGOALS)
-	fi
+	git clone \
+		--depth 1 \
+		--branch philippsauter/sc-88913/go-mk-provide-alternative-to-submodule-approach \
+		git@github.com:exoscale/go.mk.git
+	$(MAKE) $(MAKEFLAGS) $(MFLAGS) $(MAKECMDGOALS)
 
 PROJECT_URL = https://github.com/exoscale/cli
 GO_BIN_OUTPUT_NAME := exo

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,16 @@
+go.mk/init.mk: go.mk
+go.mk/public.mk: go.mk
+
+.PHONY: go.mk
+.ONESHELL:
+go.mk:
+	@if [ ! -d "go.mk" ]; then
+		git clone --depth 1 git@github.com:exoscale/go.mk.git
+	fi
+	cd go.mk && \
+	git fetch --tags && \
+	git checkout 314a757ba0e1668ebfe7252269d4b58560854c69 > /dev/null
+
 include go.mk/init.mk
 include go.mk/public.mk
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
-go.mk/init.mk: go.mk
+# make go.mk a dependency for all targets
+.EXTRA_PREREQS = go.mk
+
+go.mk/init.mk:
 include go.mk/init.mk
-go.mk/public.mk: go.mk
+go.mk/public.mk:
 include go.mk/public.mk
 
-Makefile: go.mk
+# This causes make to re-read the Makefile
+# and all included makefiles after go.mk
+# has been cloned.
+Makefile:
 	touch Makefile
 
 .ONESHELL:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
+go.mk/init.mk: go.mk
 include go.mk/init.mk
+go.mk/public.mk: go.mk
 include go.mk/public.mk
 
-go.mk/init.mk: go.mk
-go.mk/public.mk: go.mk
+Makefile: go.mk
+	touch Makefile
 
 .ONESHELL:
 go.mk:
@@ -10,7 +12,6 @@ go.mk:
 		--depth 1 \
 		--branch philippsauter/sc-88913/go-mk-provide-alternative-to-submodule-approach \
 		git@github.com:exoscale/go.mk.git
-	$(MAKE) $(MAKEFLAGS) $(MFLAGS) $(MAKECMDGOALS)
 
 PROJECT_URL = https://github.com/exoscale/cli
 GO_BIN_OUTPUT_NAME := exo


### PR DESCRIPTION
# Description
We remove the `go.mk` as a submodule and ensure that it is automatically cloned and kept up to date with make.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing
If `go.mk` doesn't exist, it will be cloned:
```shell
❯ make build
Cloning into 'go.mk'...
remote: Enumerating objects: 308, done.
remote: Counting objects: 100% (194/194), done.
remote: Compressing objects: 100% (94/94), done.
remote: Total 308 (delta 130), reused 135 (delta 91), pack-reused 114
Receiving objects: 100% (308/308), 60.52 KiB | 911.00 KiB/s, done.
Resolving deltas: 100% (173/173), done.
mkdir -p '/home/sauterp/src/github.com/exoscale/cli/bin'
'/home/sauterp/bin/go' build \
   \
  -ldflags "-X main.commit=5890d142 -X main.branch=philippsauter/sc-88913/go-mk-provide-alternative-to-submodule-approach -X main.buildDate=2024-02-16T13:57:06+0000 -X main.version=dev " \
   \
  -o '/home/sauterp/src/github.com/exoscale/cli/bin/exo' \
  '.'
```

Once it exists, it will not be cloned anymore, but make ensures, that the same ref is checked out in `go.mk` even if it was changed before.
```
❯ cd go.mk
❯ git checkout HEAD^
❯ cd ..
❯ make build
mkdir -p '/home/sauterp/src/github.com/exoscale/cli/bin'
'/home/sauterp/bin/go' build \
   \
  -ldflags "-X main.commit=13af661a -X main.branch=philippsauter/sc-88913/go-mk-provide-alternative-to-submodule-approach -X main.buildDate=2024-02-16T15:23:06+0000 -X main.version=dev " \
   \
  -o '/home/sauterp/src/github.com/exoscale/cli/bin/exo' \
  '.'
```