### PR TITLE
limits: get block storage volume limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Features
+- limits: get block storage volume limit #577 
+
 ## 1.76.1
 
 ### Improvements

--- a/cmd/limits.go
+++ b/cmd/limits.go
@@ -13,17 +13,18 @@ import (
 )
 
 const (
-	limitComputeInstances  = "instance"
-	limitDatabases         = "database"
-	limitElasticIPs        = "elastic-ip"
-	limitIAMAPIKeys        = "iam-key"
-	limitInstanceGPUs      = "gpu"
-	limitInstanceSnapshots = "snapshot"
-	limitInstanceTemplates = "template"
-	limitNLB               = "network-load-balancer"
-	limitPrivateNetworks   = "private-network"
-	limitSKSClusters       = "sks-cluster"
-	limitSOSBuckets        = "bucket"
+	limitComputeInstances    = "instance"
+	limitDatabases           = "database"
+	limitElasticIPs          = "elastic-ip"
+	limitIAMAPIKeys          = "iam-key"
+	limitInstanceGPUs        = "gpu"
+	limitInstanceSnapshots   = "snapshot"
+	limitInstanceTemplates   = "template"
+	limitNLB                 = "network-load-balancer"
+	limitPrivateNetworks     = "private-network"
+	limitSKSClusters         = "sks-cluster"
+	limitSOSBuckets          = "bucket"
+	limitBlockStorageVolumes = "block-storage-volume"
 )
 
 type LimitsItemOutput struct {
@@ -47,17 +48,18 @@ Supported output template annotations: %s`,
 		strings.Join(output.TemplateAnnotations(&LimitsOutput{}), ", ")),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		resourceLimitLabels := map[string]string{
-			limitComputeInstances:  "Compute instances",
-			limitDatabases:         "Databases",
-			limitElasticIPs:        "Elastic IP addresses",
-			limitIAMAPIKeys:        "IAM API keys",
-			limitInstanceGPUs:      "Compute instance GPUs",
-			limitInstanceSnapshots: "Compute instance snapshots",
-			limitInstanceTemplates: "Compute instance templates",
-			limitNLB:               "Network Load Balancers",
-			limitPrivateNetworks:   "Private networks",
-			limitSKSClusters:       "SKS clusters",
-			limitSOSBuckets:        "SOS buckets",
+			limitComputeInstances:    "Compute instances",
+			limitDatabases:           "Databases",
+			limitElasticIPs:          "Elastic IP addresses",
+			limitIAMAPIKeys:          "IAM API keys",
+			limitInstanceGPUs:        "Compute instance GPUs",
+			limitInstanceSnapshots:   "Compute instance snapshots",
+			limitInstanceTemplates:   "Compute instance templates",
+			limitNLB:                 "Network Load Balancers",
+			limitPrivateNetworks:     "Private networks",
+			limitSKSClusters:         "SKS clusters",
+			limitSOSBuckets:          "SOS buckets",
+			limitBlockStorageVolumes: "Block Storage Volumes",
 		}
 
 		out := LimitsOutput{}


### PR DESCRIPTION
# Description
We don't yet show the limit on block storage volumes in the `exo limits command`.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing
```shell
./bin/exo limits
┼────────────────────────────┼──────┼─────┼
│          RESOURCE          │ USED │ MAX │
┼────────────────────────────┼──────┼─────┼
│ Elastic IP addresses       │ 0    │ 5   │
│ IAM API keys               │ 41   │ 100 │
│ Compute instance GPUs      │ 0    │ 1   │
│ Private networks           │ 0    │ 32  │
│ Compute instances          │ 2    │ 20  │
│ Compute instance templates │ 0    │ 30  │
│ Network Load Balancers     │ 0    │ 5   │
│ Compute instance snapshots │ 0    │ 30  │
│ SKS clusters               │ 1    │ 3   │
│ SOS buckets                │ 16   │ 100 │
│ Block Storage Volumes      │ 14   │ 20  │
┼────────────────────────────┼──────┼─────┼
```
