### PR TITLE
go.mk: remove submodule mention from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ To build `exo` from sources, a Go compiler >= 1.16 is required.
 ```shell
 $ git clone https://github.com/exoscale/cli
 $ cd cli
-$ git submodule update --init --recursive go.mk
 $ make build
 ```
 


### PR DESCRIPTION
The step is no longer necessary to build from source as the Makefile pulls `go.mk`.