### PR TITLE
x: make `exo api` an alias to `exo x`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Features
 - limits: get block storage volume limit #577 
 
+### Improvements
+- x: make `exo api` an alias to `exo x` #579
+
 ## 1.76.1
 
 ### Improvements

--- a/cmd/x.go
+++ b/cmd/x.go
@@ -16,6 +16,7 @@ var xCmd *cobra.Command
 func init() {
 	xCmd = x.InitCommand()
 	xCmd.Use = "x"
+	xCmd.Aliases = append(xCmd.Aliases, "api")
 	xCmd.Hidden = true
 	xCmd.Long = `Low-level Exoscale API calls -- don't use this unless you have to.
 


### PR DESCRIPTION
# Description
Initially the idea of the `exo x` command was for it to be a last resort only, however since it has been quite stable and is now used by many customers we add the alias `exo api` which is less discouraging.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

```shell
$ ./bin/exo api help-input
# CLI Request Input

Input to the CLI is handled via ...

$ ./bin/exo x help-input
# CLI Request Input

Input to the CLI is handled via ...
```