### PR TITLE
Remove Windows ARM targets from prebuilt binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,6 +30,10 @@ builds:
         goarch: arm
       - goos: openbsd
         goarch: arm64
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: arm64
 
 # macOS Universal Binaries
 universal_binaries:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Deprecations
+
+- Removed Windows ARM targets from prebuilt binaries #582
+
 ## 1.76.2
 
 ### Features


### PR DESCRIPTION
# Description

This PR removes Windows ARM build targets from goreleaser configuration.

Stats show we have no downloads for those, by removing them we will speed up the build time a bit.

We can revert it if we receive a request for specific builds in the future. 

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

Not applicable.
