### PR TITLE
Instance reset password: remove wrong "rm" alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Instance reset password: remove wrong "rm" alias #583
+
 ### Deprecations
 
 - Removed Windows ARM targets from prebuilt binaries #582

--- a/cmd/instance_reset_password.go
+++ b/cmd/instance_reset_password.go
@@ -21,7 +21,7 @@ type instanceResetPasswordCmd struct {
 	Zone string `cli-short:"z" cli-usage:"instance zone"`
 }
 
-func (c *instanceResetPasswordCmd) cmdAliases() []string { return gRemoveAlias }
+func (c *instanceResetPasswordCmd) cmdAliases() []string { return nil }
 
 func (c *instanceResetPasswordCmd) cmdShort() string {
 	return "Reset the password of a Compute instance"


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Remove the wrong instance reset password `rm` alias.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

<!--
Describe the tests you did
-->
