### PR TITLE
Config: Remove unused field on config reload 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+### Improvements
+
+### Deprecations
+- Config: Remove unused field on config reload #585
+
 ## 1.77.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ defaultaccount = "account_name"
 
 [[accounts]]
   account = "account_name"
-  endpoint = "https://api.exoscale.com/v1"
   key = "API_KEY"
   name = "account_name"
   secret = "API_SECRET"

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ The configuration parameters are then saved in a `exoscale.toml` file with the f
 defaultaccount = "account_name"
 
 [[accounts]]
-  account = "account_name"
   key = "API_KEY"
   name = "account_name"
   secret = "API_SECRET"

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -62,10 +62,14 @@ func buildClient() {
 
 	httpClient := &http.Client{Transport: newCLIRoundTripper(http.DefaultTransport, account.CurrentAccount.CustomHeaders)}
 
+	clientTimeout := account.CurrentAccount.ClientTimeout
+	if clientTimeout == 0 {
+		clientTimeout = defaultClientTimeout
+	}
 	clientExoV2, err := exov2.NewClient(
 		account.CurrentAccount.Key,
 		account.CurrentAccount.APISecret(),
-		exov2.ClientOptWithTimeout(time.Minute*time.Duration(account.CurrentAccount.ClientTimeout)),
+		exov2.ClientOptWithTimeout(time.Minute*time.Duration(clientTimeout)),
 		exov2.ClientOptWithHTTPClient(httpClient),
 		exov2.ClientOptCond(func() bool {
 			if v := os.Getenv("EXOSCALE_TRACE"); v != "" {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -81,7 +81,11 @@ func cmdSetZoneFlagFromDefault(cmd *cobra.Command) {
 // set once this function returns.
 func cmdSetTemplateFlagFromDefault(cmd *cobra.Command) {
 	if cmd.Flag("template").Value.String() == "" {
-		cmd.Flag("template").Value.Set(account.CurrentAccount.DefaultTemplate) // nolint:errcheck
+		if account.CurrentAccount.DefaultTemplate != "" {
+			cmd.Flag("template").Value.Set(account.CurrentAccount.DefaultTemplate) // nolint:errcheck
+		} else {
+			cmd.Flag("template").Value.Set(defaultTemplate) // nolint:errcheck
+		}
 	}
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -120,6 +120,10 @@ func saveConfig(filePath string, newAccounts *account.Config) error {
 		if acc.DefaultOutputFormat != "" {
 			accounts[i]["defaultOutputFormat"] = acc.DefaultOutputFormat
 		}
+		// TODO(pej): This is a workaround to not propagate Environment 'api' on config reload.
+		// By default, acc.Environment is set to 'api' to be used for egoscale v2 in the whole codebase.
+		// We can not tweak it like DefaultTemplate by using the 'api' default const.
+		// Remove the environment when egoscale v3 will be fully integrated.
 		if acc.Environment != "" && acc.Environment != "api" {
 			accounts[i]["environment"] = acc.Environment
 		}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -113,11 +113,19 @@ func saveConfig(filePath string, newAccounts *account.Config) error {
 
 		accounts[i]["name"] = acc.Name
 		accounts[i]["key"] = acc.Key
-		accounts[i]["endpoint"] = acc.Endpoint
 		accounts[i]["defaultZone"] = acc.DefaultZone
-		accounts[i]["defaultOutputFormat"] = acc.DefaultOutputFormat
-		accounts[i]["clientTimeout"] = acc.ClientTimeout
-		accounts[i]["environment"] = acc.Environment
+		if acc.ClientTimeout != 0 {
+			accounts[i]["clientTimeout"] = acc.ClientTimeout
+		}
+		if acc.DefaultOutputFormat != "" {
+			accounts[i]["defaultOutputFormat"] = acc.DefaultOutputFormat
+		}
+		if acc.Environment != "" {
+			accounts[i]["environment"] = acc.Environment
+		}
+		if acc.Endpoint != "" {
+			accounts[i]["endpoint"] = acc.Endpoint
+		}
 		if acc.DefaultSSHKey != "" {
 			accounts[i]["defaultSSHKey"] = acc.DefaultSSHKey
 		}
@@ -140,10 +148,14 @@ func saveConfig(filePath string, newAccounts *account.Config) error {
 
 			accounts[accountsSize+i]["name"] = acc.Name
 			accounts[accountsSize+i]["key"] = acc.Key
-			accounts[accountsSize+i]["endpoint"] = acc.Endpoint
 			accounts[accountsSize+i]["secret"] = acc.Secret
 			accounts[accountsSize+i]["defaultZone"] = acc.DefaultZone
-			accounts[accountsSize+i]["environment"] = acc.Environment
+			if acc.Environment != "" {
+				accounts[i]["environment"] = acc.Environment
+			}
+			if acc.Endpoint != "" {
+				accounts[i]["endpoint"] = acc.Endpoint
+			}
 			if acc.DefaultSSHKey != "" {
 				accounts[accountsSize+i]["defaultSSHKey"] = acc.DefaultSSHKey
 			}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -120,7 +120,7 @@ func saveConfig(filePath string, newAccounts *account.Config) error {
 		if acc.DefaultOutputFormat != "" {
 			accounts[i]["defaultOutputFormat"] = acc.DefaultOutputFormat
 		}
-		if acc.Environment != "" {
+		if acc.Environment != "" && acc.Environment != "api" {
 			accounts[i]["environment"] = acc.Environment
 		}
 		if acc.Endpoint != "" {
@@ -132,12 +132,14 @@ func saveConfig(filePath string, newAccounts *account.Config) error {
 		if acc.DefaultTemplate != "" {
 			accounts[i]["defaultTemplate"] = acc.DefaultTemplate
 		}
+		if acc.Account != "" {
+			accounts[i]["account"] = acc.Account
+		}
 		if len(acc.SecretCommand) != 0 {
 			accounts[i]["secretCommand"] = acc.SecretCommand
 		} else {
 			accounts[i]["secret"] = acc.Secret
 		}
-		accounts[i]["account"] = acc.Account
 
 		conf.Accounts = append(conf.Accounts, acc)
 	}
@@ -150,7 +152,7 @@ func saveConfig(filePath string, newAccounts *account.Config) error {
 			accounts[accountsSize+i]["key"] = acc.Key
 			accounts[accountsSize+i]["secret"] = acc.Secret
 			accounts[accountsSize+i]["defaultZone"] = acc.DefaultZone
-			if acc.Environment != "" {
+			if acc.Environment != "" && acc.Environment != "api" {
 				accounts[i]["environment"] = acc.Environment
 			}
 			if acc.Endpoint != "" {
@@ -159,7 +161,6 @@ func saveConfig(filePath string, newAccounts *account.Config) error {
 			if acc.DefaultSSHKey != "" {
 				accounts[accountsSize+i]["defaultSSHKey"] = acc.DefaultSSHKey
 			}
-			accounts[accountsSize+i]["account"] = acc.Account
 			conf.Accounts = append(conf.Accounts, acc)
 		}
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -152,15 +152,6 @@ func saveConfig(filePath string, newAccounts *account.Config) error {
 			accounts[accountsSize+i]["key"] = acc.Key
 			accounts[accountsSize+i]["secret"] = acc.Secret
 			accounts[accountsSize+i]["defaultZone"] = acc.DefaultZone
-			if acc.Environment != "" && acc.Environment != "api" {
-				accounts[i]["environment"] = acc.Environment
-			}
-			if acc.Endpoint != "" {
-				accounts[i]["endpoint"] = acc.Endpoint
-			}
-			if acc.DefaultSSHKey != "" {
-				accounts[accountsSize+i]["defaultSSHKey"] = acc.DefaultSSHKey
-			}
 			conf.Accounts = append(conf.Accounts, acc)
 		}
 	}

--- a/cmd/config_add.go
+++ b/cmd/config_add.go
@@ -68,10 +68,7 @@ func promptAccountInformation() (*account.Account, error) {
 	var client *exo.Client
 
 	reader := bufio.NewReader(os.Stdin)
-	account := &account.Account{
-		Key:    "",
-		Secret: "",
-	}
+	account := &account.Account{}
 
 	apiKey, err := readInput(reader, "API Key", account.Key)
 	if err != nil {
@@ -92,14 +89,6 @@ func promptAccountInformation() (*account.Account, error) {
 	}
 	if secretKey != secret && secretKey != secretShow {
 		account.Secret = secretKey
-	}
-
-	acc, err := readInput(reader, "Account name", account.Account)
-	if err != nil {
-		return nil, err
-	}
-	if acc != "" {
-		account.Account = acc
 	}
 
 	name, err := readInput(reader, "Name", account.Name)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,10 +87,9 @@ func Execute(version, commit string) {
 
 func init() {
 	account.CurrentAccount = &account.Account{
-		DefaultZone:     defaultZone,
-		DefaultTemplate: defaultTemplate,
-		Environment:     defaultEnvironment,
-		SosEndpoint:     defaultSosEndpoint,
+		DefaultZone: defaultZone,
+		Environment: defaultEnvironment,
+		SosEndpoint: defaultSosEndpoint,
 	}
 
 	gConfig = viper.New()
@@ -159,7 +158,6 @@ func initConfig() { //nolint:gocyclo
 	if apiKeyFromEnv != "" && apiSecretFromEnv != "" {
 		account.CurrentAccount.Name = "<environment variables>"
 		gConfigFilePath = "<environment variables>"
-		account.CurrentAccount.Account = "unknown"
 		account.CurrentAccount.Key = apiKeyFromEnv
 		account.CurrentAccount.Secret = apiSecretFromEnv
 
@@ -172,9 +170,6 @@ func initConfig() { //nolint:gocyclo
 		}
 		if sosEndpointFromEnv != "" {
 			account.CurrentAccount.SosEndpoint = sosEndpointFromEnv
-		}
-		if account.CurrentAccount.ClientTimeout == 0 {
-			account.CurrentAccount.ClientTimeout = defaultClientTimeout
 		}
 
 		account.GAllAccount = &account.Config{
@@ -307,17 +302,10 @@ func initConfig() { //nolint:gocyclo
 		}
 	}
 
-	if account.CurrentAccount.DefaultTemplate == "" {
-		account.CurrentAccount.DefaultTemplate = defaultTemplate
-	}
-
 	if account.CurrentAccount.SosEndpoint == "" {
 		account.CurrentAccount.SosEndpoint = defaultSosEndpoint
 	}
 
-	if account.CurrentAccount.ClientTimeout == 0 {
-		account.CurrentAccount.ClientTimeout = defaultClientTimeout
-	}
 	clientTimeoutFromEnv := readFromEnv("EXOSCALE_API_TIMEOUT")
 	if clientTimeoutFromEnv != "" {
 		if t, err := strconv.Atoi(clientTimeoutFromEnv); err == nil {

--- a/pkg/account/account.go
+++ b/pkg/account/account.go
@@ -13,7 +13,8 @@ var (
 )
 
 type Account struct {
-	Name    string
+	Name string
+	// TODO: deprecated field, will be deleted.
 	Account string
 	// TODO: remove it to replace it with the new API listZones.
 	SosEndpoint string


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

At config creation with exo cli here is the output:
```Toml
[[accounts]]
account = 'no longer used name foo'
defaultZone = 'ch-gva-2'
key = 'EXOxxx'
name = 'foo'
secret = 'xxx'
``` 

When you switch account with `exo config` here is the reloaded config account foo:
```Toml
[[accounts]]
account = 'no longer used name foo'
clientTimeout = 20
defaultTemplate = 'Linux Ubuntu 22.04 LTS 64-bit'
defaultZone = 'ch-gva-2'
environment = 'api'
key = 'EXOxxx'
name = 'foo'
secret = 'xxx'
```

I agree those config fields can be useful to be set by the user if needed but not auto generated on basic configuration profile.

Here is what I Updated in the change, by default we create the config:
```Bash
✔ <Configure a new account>
[+] API Key [none]: EXOxxx
[+] Secret Key [none]: xxx
[+] Name [none]: foo
```
No more Account string name is required or asked.

Here is the generated config:
```Toml
[[accounts]]
defaultZone = 'ch-gva-2'
key = 'EXOxxx'
name = 'foo'
secret = 'xxx'
```

When the config reloads, the config remains the same.
If an attribute like `defaultTemplate = 'Linux Ubuntu 22.04 LTS 64-bit'` has been set or from the past config it will be kept
same for other one like `environment`...etc

The benefits of that, config are generated lighter and remain light, user can still personalize it like before...etc.

Now, default value (`defaultTemplate`, `timeout`...etc) will be used from code `const` variable, and will be not ingested at config runtime, and will be no more generated at config reload.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing
