### PR TITLE
SKS nodepool: allow specifying kubelet image gc parameters on creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- SKS nodepool: allow specifying kubelet image gc parameters on creation #586
+
 ### Features
 
 ### Improvements

--- a/cmd/sks_create.go
+++ b/cmd/sks_create.go
@@ -30,36 +30,39 @@ type sksCreateCmd struct {
 
 	Name string `cli-arg:"#" cli-usage:"NAME"`
 
-	AutoUpgrade                bool              `cli-usage:"enable automatic upgrading of the SKS cluster control plane Kubernetes version"`
-	CNI                        string            `cli-usage:"CNI plugin to deploy. e.g. 'calico', or 'cilium'"`
-	Description                string            `cli-usage:"SKS cluster description"`
-	KubernetesVersion          string            `cli-usage:"SKS cluster control plane Kubernetes version"`
-	Labels                     map[string]string `cli-flag:"label" cli-usage:"SKS cluster label (format: key=value)"`
-	NoCNI                      bool              `cli-usage:"do not deploy a default Container Network Interface plugin in the cluster control plane"`
-	NoExoscaleCCM              bool              `cli-usage:"do not deploy the Exoscale Cloud Controller Manager in the cluster control plane"`
-	NoMetricsServer            bool              `cli-usage:"do not deploy the Kubernetes Metrics Server in the cluster control plane"`
-	ExoscaleCSI                bool              `cli-usage:"deploy the Exoscale Container Storage Interface on worker nodes"`
-	NodepoolAntiAffinityGroups []string          `cli-flag:"nodepool-anti-affinity-group" cli-usage:"default Nodepool Anti-Affinity Group NAME|ID (can be specified multiple times)"`
-	NodepoolDeployTarget       string            `cli-usage:"default Nodepool Deploy Target NAME|ID"`
-	NodepoolDescription        string            `cli-usage:"default Nodepool description"`
-	NodepoolDiskSize           int64             `cli-usage:"default Nodepool Compute instances disk size"`
-	NodepoolInstancePrefix     string            `cli-usage:"string to prefix default Nodepool member names with"`
-	NodepoolInstanceType       string            `cli-usage:"default Nodepool Compute instances type"`
-	NodepoolLabels             map[string]string `cli-flag:"nodepool-label" cli-usage:"default Nodepool label (format: key=value)"`
-	NodepoolName               string            `cli-usage:"default Nodepool name"`
-	NodepoolPrivateNetworks    []string          `cli-flag:"nodepool-private-network" cli-usage:"default Nodepool Private Network NAME|ID (can be specified multiple times)"`
-	NodepoolSecurityGroups     []string          `cli-flag:"nodepool-security-group" cli-usage:"default Nodepool Security Group NAME|ID (can be specified multiple times)"`
-	NodepoolSize               int64             `cli-usage:"default Nodepool size. If 0, no default Nodepool will be added to the cluster."`
-	NodepoolTaints             []string          `cli-flag:"nodepool-taint" cli-usage:"Kubernetes taint to apply to default Nodepool Nodes (format: KEY=VALUE:EFFECT, can be specified multiple times)"`
-	OIDCClientID               string            `cli-flag:"oidc-client-id" cli-usage:"OpenID client ID"`
-	OIDCGroupsClaim            string            `cli-flag:"oidc-groups-claim" cli-usage:"OpenID JWT claim to use as the user's group"`
-	OIDCGroupsPrefix           string            `cli-flag:"oidc-groups-prefix" cli-usage:"OpenID prefix prepended to group claims"`
-	OIDCIssuerURL              string            `cli-flag:"oidc-issuer-url" cli-usage:"OpenID provider URL"`
-	OIDCRequiredClaim          map[string]string `cli-flag:"oidc-required-claim" cli-usage:"OpenID token required claim (format: key=value)"`
-	OIDCUsernameClaim          string            `cli-flag:"oidc-username-claim" cli-usage:"OpenID JWT claim to use as the user name"`
-	OIDCUsernamePrefix         string            `cli-flag:"oidc-username-prefix" cli-usage:"OpenID prefix prepended to username claims"`
-	ServiceLevel               string            `cli-usage:"SKS cluster control plane service level (starter|pro)"`
-	Zone                       string            `cli-short:"z" cli-usage:"SKS cluster zone"`
+	AutoUpgrade                  bool              `cli-usage:"enable automatic upgrading of the SKS cluster control plane Kubernetes version"`
+	CNI                          string            `cli-usage:"CNI plugin to deploy. e.g. 'calico', or 'cilium'"`
+	Description                  string            `cli-usage:"SKS cluster description"`
+	KubernetesVersion            string            `cli-usage:"SKS cluster control plane Kubernetes version"`
+	Labels                       map[string]string `cli-flag:"label" cli-usage:"SKS cluster label (format: key=value)"`
+	NoCNI                        bool              `cli-usage:"do not deploy a default Container Network Interface plugin in the cluster control plane"`
+	NoExoscaleCCM                bool              `cli-usage:"do not deploy the Exoscale Cloud Controller Manager in the cluster control plane"`
+	NoMetricsServer              bool              `cli-usage:"do not deploy the Kubernetes Metrics Server in the cluster control plane"`
+	ExoscaleCSI                  bool              `cli-usage:"deploy the Exoscale Container Storage Interface on worker nodes"`
+	NodepoolAntiAffinityGroups   []string          `cli-flag:"nodepool-anti-affinity-group" cli-usage:"default Nodepool Anti-Affinity Group NAME|ID (can be specified multiple times)"`
+	NodepoolDeployTarget         string            `cli-usage:"default Nodepool Deploy Target NAME|ID"`
+	NodepoolDescription          string            `cli-usage:"default Nodepool description"`
+	NodepoolDiskSize             int64             `cli-usage:"default Nodepool Compute instances disk size"`
+	NodepoolImageGcLowThreshold  int64             `cli-flag:"nodepool-image-gc-low-threshold" cli-usage:"default Nodepool the percent of disk usage after which image garbage collection is never run"`
+	NodepoolImageGcHighThreshold int64             `cli-flag:"nodepool-image-gc-high-threshold" cli-usage:"default Nodepool the percent of disk usage after which image garbage collection is always run"`
+	NodepoolImageGcMinAge        string            `cli-flag:"nodepool-image-gc-min-age" cli-usage:"default Nodepool maximum age an image can be unused before it is garbage collected"`
+	NodepoolInstancePrefix       string            `cli-usage:"string to prefix default Nodepool member names with"`
+	NodepoolInstanceType         string            `cli-usage:"default Nodepool Compute instances type"`
+	NodepoolLabels               map[string]string `cli-flag:"nodepool-label" cli-usage:"default Nodepool label (format: key=value)"`
+	NodepoolName                 string            `cli-usage:"default Nodepool name"`
+	NodepoolPrivateNetworks      []string          `cli-flag:"nodepool-private-network" cli-usage:"default Nodepool Private Network NAME|ID (can be specified multiple times)"`
+	NodepoolSecurityGroups       []string          `cli-flag:"nodepool-security-group" cli-usage:"default Nodepool Security Group NAME|ID (can be specified multiple times)"`
+	NodepoolSize                 int64             `cli-usage:"default Nodepool size. If 0, no default Nodepool will be added to the cluster."`
+	NodepoolTaints               []string          `cli-flag:"nodepool-taint" cli-usage:"Kubernetes taint to apply to default Nodepool Nodes (format: KEY=VALUE:EFFECT, can be specified multiple times)"`
+	OIDCClientID                 string            `cli-flag:"oidc-client-id" cli-usage:"OpenID client ID"`
+	OIDCGroupsClaim              string            `cli-flag:"oidc-groups-claim" cli-usage:"OpenID JWT claim to use as the user's group"`
+	OIDCGroupsPrefix             string            `cli-flag:"oidc-groups-prefix" cli-usage:"OpenID prefix prepended to group claims"`
+	OIDCIssuerURL                string            `cli-flag:"oidc-issuer-url" cli-usage:"OpenID provider URL"`
+	OIDCRequiredClaim            map[string]string `cli-flag:"oidc-required-claim" cli-usage:"OpenID token required claim (format: key=value)"`
+	OIDCUsernameClaim            string            `cli-flag:"oidc-username-claim" cli-usage:"OpenID JWT claim to use as the user name"`
+	OIDCUsernamePrefix           string            `cli-flag:"oidc-username-prefix" cli-usage:"OpenID prefix prepended to username claims"`
+	ServiceLevel                 string            `cli-usage:"SKS cluster control plane service level (starter|pro)"`
+	Zone                         string            `cli-short:"z" cli-usage:"SKS cluster zone"`
 }
 
 func (c *sksCreateCmd) cmdAliases() []string { return gCreateAlias }
@@ -188,6 +191,11 @@ func (c *sksCreateCmd) cmdRun(_ *cobra.Command, _ []string) error { //nolint:goc
 				return c.Name
 			}()),
 			Size: &c.NodepoolSize,
+			KubeletImageGc: &egoscale.SKSNodepoolKubeletImageGc{
+				MinAge:        &c.NodepoolImageGcMinAge,
+				LowThreshold:  &c.NodepoolImageGcLowThreshold,
+				HighThreshold: &c.NodepoolImageGcHighThreshold,
+			},
 		}
 
 		if l := len(c.NodepoolAntiAffinityGroups); l > 0 {
@@ -275,12 +283,14 @@ func init() {
 	cobra.CheckErr(registerCLICommand(sksCmd, &sksCreateCmd{
 		cliCommandSettings: defaultCLICmdSettings(),
 
-		CNI:                  defaultSKSClusterCNI,
-		KubernetesVersion:    "latest",
-		NodepoolDiskSize:     50,
-		NodepoolInstanceType: fmt.Sprintf("%s.%s", defaultInstanceTypeFamily, defaultInstanceType),
-
-		ServiceLevel: defaultSKSClusterServiceLevel,
+		CNI:                          defaultSKSClusterCNI,
+		KubernetesVersion:            "latest",
+		NodepoolDiskSize:             50,
+		NodepoolInstanceType:         fmt.Sprintf("%s.%s", defaultInstanceTypeFamily, defaultInstanceType),
+		NodepoolImageGcLowThreshold:  80,
+		NodepoolImageGcHighThreshold: 85,
+		NodepoolImageGcMinAge:        "2m",
+		ServiceLevel:                 defaultSKSClusterServiceLevel,
 	}))
 
 }

--- a/cmd/sks_create.go
+++ b/cmd/sks_create.go
@@ -287,9 +287,9 @@ func init() {
 		KubernetesVersion:            "latest",
 		NodepoolDiskSize:             50,
 		NodepoolInstanceType:         fmt.Sprintf("%s.%s", defaultInstanceTypeFamily, defaultInstanceType),
-		NodepoolImageGcLowThreshold:  80,
-		NodepoolImageGcHighThreshold: 85,
-		NodepoolImageGcMinAge:        "2m",
+		NodepoolImageGcLowThreshold:  kubeletImageGcLowThreshold,
+		NodepoolImageGcHighThreshold: kubeletImageGcHighThreshold,
+		NodepoolImageGcMinAge:        kubeletImageGcMinAge,
 		ServiceLevel:                 defaultSKSClusterServiceLevel,
 	}))
 

--- a/cmd/sks_nodepool_add.go
+++ b/cmd/sks_nodepool_add.go
@@ -15,6 +15,12 @@ import (
 	exoapi "github.com/exoscale/egoscale/v2/api"
 )
 
+const (
+	kubeletImageGcLowThreshold  = 80
+	kubeletImageGcHighThreshold = 85
+	kubeletImageGcMinAge        = "2m"
+)
+
 type sksNodepoolAddCmd struct {
 	cliCommandSettings `cli-cmd:"-"`
 
@@ -191,8 +197,8 @@ func init() {
 		Size:                 2,
 		InstanceType:         fmt.Sprintf("%s.%s", defaultInstanceTypeFamily, defaultInstanceType),
 		DiskSize:             50,
-		ImageGcLowThreshold:  80,
-		ImageGcHighThreshold: 85,
-		ImageGcMinAge:        "2m",
+		ImageGcLowThreshold:  kubeletImageGcLowThreshold,
+		ImageGcHighThreshold: kubeletImageGcHighThreshold,
+		ImageGcMinAge:        kubeletImageGcMinAge,
 	}))
 }

--- a/cmd/sks_nodepool_show.go
+++ b/cmd/sks_nodepool_show.go
@@ -16,24 +16,27 @@ import (
 )
 
 type sksNodepoolShowOutput struct {
-	ID                 string            `json:"id"`
-	Name               string            `json:"name"`
-	Description        string            `json:"description"`
-	CreationDate       string            `json:"creation_date"`
-	InstancePoolID     string            `json:"instance_pool_id"`
-	InstancePrefix     string            `json:"instance_prefix"`
-	InstanceType       string            `json:"instance_type"`
-	Template           string            `json:"template"`
-	DiskSize           int64             `json:"disk_size"`
-	AntiAffinityGroups []string          `json:"anti_affinity_groups"`
-	SecurityGroups     []string          `json:"security_groups"`
-	PrivateNetworks    []string          `json:"private_networks"`
-	Version            string            `json:"version"`
-	Size               int64             `json:"size"`
-	State              string            `json:"state"`
-	Taints             []string          `json:"taints"`
-	Labels             map[string]string `json:"labels"`
-	AddOns             []string          `json:"addons"`
+	ID                   string            `json:"id"`
+	Name                 string            `json:"name"`
+	Description          string            `json:"description"`
+	CreationDate         string            `json:"creation_date"`
+	InstancePoolID       string            `json:"instance_pool_id"`
+	InstancePrefix       string            `json:"instance_prefix"`
+	InstanceType         string            `json:"instance_type"`
+	Template             string            `json:"template"`
+	DiskSize             int64             `json:"disk_size"`
+	AntiAffinityGroups   []string          `json:"anti_affinity_groups"`
+	SecurityGroups       []string          `json:"security_groups"`
+	PrivateNetworks      []string          `json:"private_networks"`
+	Version              string            `json:"version"`
+	Size                 int64             `json:"size"`
+	State                string            `json:"state"`
+	Taints               []string          `json:"taints"`
+	Labels               map[string]string `json:"labels"`
+	AddOns               []string          `json:"addons"`
+	ImageGCMin           string            `json:"image_gc_min_age"`
+	ImageGcLowThreshold  int64             `json:"image_gc_low_threshold"`
+	ImageGcHighThreshold int64             `json:"image_gc_high_threshold"`
 }
 
 func (o *sksNodepoolShowOutput) Type() string { return "SKS Nodepool" }
@@ -124,6 +127,24 @@ func (c *sksNodepoolShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 				}
 			}
 			return
+		}(),
+		ImageGCMin: func() (s string) {
+			if nodepool.KubeletImageGc != nil && nodepool.KubeletImageGc.MinAge != nil {
+				return *nodepool.KubeletImageGc.MinAge
+			}
+			return "2m"
+		}(),
+		ImageGcLowThreshold: func() (s int64) {
+			if nodepool.KubeletImageGc != nil && nodepool.KubeletImageGc.LowThreshold != nil {
+				return *nodepool.KubeletImageGc.LowThreshold
+			}
+			return 80
+		}(),
+		ImageGcHighThreshold: func() (s int64) {
+			if nodepool.KubeletImageGc != nil && nodepool.KubeletImageGc.HighThreshold != nil {
+				return *nodepool.KubeletImageGc.HighThreshold
+			}
+			return 85
 		}(),
 		Version: *nodepool.Version,
 	}

--- a/cmd/sks_nodepool_show.go
+++ b/cmd/sks_nodepool_show.go
@@ -132,19 +132,19 @@ func (c *sksNodepoolShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 			if nodepool.KubeletImageGc != nil && nodepool.KubeletImageGc.MinAge != nil {
 				return *nodepool.KubeletImageGc.MinAge
 			}
-			return "2m"
+			return kubeletImageGcMinAge
 		}(),
 		ImageGcLowThreshold: func() (s int64) {
 			if nodepool.KubeletImageGc != nil && nodepool.KubeletImageGc.LowThreshold != nil {
 				return *nodepool.KubeletImageGc.LowThreshold
 			}
-			return 80
+			return kubeletImageGcLowThreshold
 		}(),
 		ImageGcHighThreshold: func() (s int64) {
 			if nodepool.KubeletImageGc != nil && nodepool.KubeletImageGc.HighThreshold != nil {
 				return *nodepool.KubeletImageGc.HighThreshold
 			}
-			return 85
+			return kubeletImageGcHighThreshold
 		}(),
 		Version: *nodepool.Version,
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/exoscale/egoscale v0.102.4-0.20240223092311-76285ea0504f
+	github.com/exoscale/egoscale v0.102.4-0.20240327105104-a8a8cb197ac6
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/google/uuid v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,8 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/go-control-plane v0.10.1/go.mod h1:AY7fTTXNdv/aJ2O5jwpxAPOWUZ7hQAEvzN5Pf27BkQQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
-github.com/exoscale/egoscale v0.102.4-0.20240223092311-76285ea0504f h1:Ivacu1126KBSLhXvXST6H0ftMjehMV637fL/nb222LM=
-github.com/exoscale/egoscale v0.102.4-0.20240223092311-76285ea0504f/go.mod h1:sFBCvHJx/h6u8Z5igoIcgbPs+wltBbEJrXA2xp05KoU=
+github.com/exoscale/egoscale v0.102.4-0.20240327105104-a8a8cb197ac6 h1:UQwsohHjLp5mkcB+vZ7UuYrTi0FsBrQvgYD0guyNcSo=
+github.com/exoscale/egoscale v0.102.4-0.20240327105104-a8a8cb197ac6/go.mod h1:sFBCvHJx/h6u8Z5igoIcgbPs+wltBbEJrXA2xp05KoU=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.1
 ## explicit; go 1.16
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.102.4-0.20240223092311-76285ea0504f
+# github.com/exoscale/egoscale v0.102.4-0.20240327105104-a8a8cb197ac6
 ## explicit; go 1.20
 github.com/exoscale/egoscale/v2
 github.com/exoscale/egoscale/v2/api


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Adds the following flags:

On SKS Cluster creation:
* nodepool-image-gc-low-threshold
* nodepool-image-gc-high-threshold
* nodepool-image-gc-min-age

The equivalent on SKS Nodepool add:
* image-gc-low-threshold
* image-gc-high-threshold
* image-gc-min-age

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

<!--
Describe the tests you did
-->

```

# creating with custom gc params

➜  ~/exo/cli git:(tgrondier/sc-66948/cli) go run . compute sks create my-test-cluster \                                                                     
    --zone de-muc-1 \
    --service-level starter \
    --nodepool-name my-test-nodepool \
    --nodepool-size 3 \
    --nodepool-security-group sks-security-group --nodepool-image-gc-high-threshold 66 --nodepool-image-gc-low-threshold 33 --nodepool-image-gc-min-age "6m"
 ✔ Creating SKS cluster "my-test-cluster"... 2m3s
 ✔ Adding Nodepool "my-test-nodepool"... 33s
┼───────────────┼──────────────────────────────────────────────────────────────────┼
│  SKS CLUSTER  │                                                                  │
┼───────────────┼──────────────────────────────────────────────────────────────────┼
│ ID            │ f9a80f9c-c51a-4245-93c1-a99bf22f57d7                             │
│ Name          │ my-test-cluster                                                  │
│ Description   │                                                                  │
│ Zone          │ de-muc-1                                                         │
│ Creation Date │ 2024-04-08 08:04:24 +0000 UTC                                    │
│ Auto-upgrade  │ false                                                            │
│ Endpoint      │ https://f9a80f9c-c51a-4245-93c1-a99bf22f57d7.sks-de-muc-1.exo.io │
│ Version       │ 1.29.2                                                           │
│ Service Level │ starter                                                          │
│ CNI           │ calico                                                           │
│ Add-Ons       │ exoscale-cloud-controller                                        │
│               │ metrics-server                                                   │
│ State         │ running                                                          │
│ Labels        │ n/a                                                              │
│ Nodepools     │ edb63168-65ae-4650-a30f-0b2bb479d01e | my-test-nodepool          │
┼───────────────┼──────────────────────────────────────────────────────────────────┼
➜  ~/exo/cli git:(tgrondier/sc-66948/cli) go run . compute sks nodepool show my-test-cluster my-test-nodepool
┼─────────────────────────┼──────────────────────────────────────┼
│      SKS NODEPOOL       │                                      │
┼─────────────────────────┼──────────────────────────────────────┼
│ ID                      │ edb63168-65ae-4650-a30f-0b2bb479d01e │
│ Name                    │ my-test-nodepool                     │
│ Description             │                                      │
│ Creation Date           │ 2024-04-08 08:06:28 +0000 UTC        │
│ Instance Pool ID        │ 8b386584-117d-44f2-aa32-575b045abf01 │
│ Instance Prefix         │ pool                                 │
│ Instance Type           │ medium                               │
│ Template                │ sks-node-1.29.jammy                  │
│ Disk Size               │ 50                                   │
│ Anti Affinity Groups    │ n/a                                  │
│ Security Groups         │ sks-security-group                   │
│ Private Networks        │ n/a                                  │
│ Version                 │ 1.29.2                               │
│ Size                    │ 3                                    │
│ State                   │ running                              │
│ Taints                  │ n/a                                  │
│ Labels                  │ n/a                                  │
│ Add Ons                 │ n/a                                  │
│ Image GC Min            │ 6m                                   │
│ Image Gc Low Threshold  │ 33                                   │
│ Image Gc High Threshold │ 66                                   │
┼─────────────────────────┼──────────────────────────────────────┼


# creating with default values
➜  ~/exo/cli git:(tgrondier/sc-66948/cli) go run . compute sks create my-test-cluster \                          
    --zone de-muc-1 \
    --service-level starter \
    --nodepool-name my-test-nodepool \
    --nodepool-size 1 \
    --nodepool-security-group sks-security-group                                                                                                            
 ✔ Creating SKS cluster "my-test-cluster"... 2m0s
 ✔ Adding Nodepool "my-test-nodepool"... 24s
┼───────────────┼──────────────────────────────────────────────────────────────────┼
│  SKS CLUSTER  │                                                                  │
┼───────────────┼──────────────────────────────────────────────────────────────────┼
│ ID            │ 7f55fe93-d0ea-494c-ab80-e798e3291404                             │
│ Name          │ my-test-cluster                                                  │
│ Description   │                                                                  │
│ Zone          │ de-muc-1                                                         │
│ Creation Date │ 2024-04-08 07:59:42 +0000 UTC                                    │
│ Auto-upgrade  │ false                                                            │
│ Endpoint      │ https://7f55fe93-d0ea-494c-ab80-e798e3291404.sks-de-muc-1.exo.io │
│ Version       │ 1.29.2                                                           │
│ Service Level │ starter                                                          │
│ CNI           │ calico                                                           │
│ Add-Ons       │ exoscale-cloud-controller                                        │
│               │ metrics-server                                                   │
│ State         │ running                                                          │
│ Labels        │ n/a                                                              │
│ Nodepools     │ c7fcd079-29eb-490a-96a0-0444e1875c6d | my-test-nodepool          │
┼───────────────┼──────────────────────────────────────────────────────────────────┼

➜  ~/exo/cli git:(tgrondier/sc-66948/cli) go run . compute sks nodepool show my-test-cluster my-test-nodepool                                                                                     
┼─────────────────────────┼──────────────────────────────────────┼
│      SKS NODEPOOL       │                                      │
┼─────────────────────────┼──────────────────────────────────────┼
│ ID                      │ c7fcd079-29eb-490a-96a0-0444e1875c6d │
│ Name                    │ my-test-nodepool                     │
│ Description             │                                      │
│ Creation Date           │ 2024-04-08 08:01:43 +0000 UTC        │
│ Instance Pool ID        │ a2a738e0-3708-45a4-af1c-d02f67f0bffb │
│ Instance Prefix         │ pool                                 │
│ Instance Type           │ medium                               │
│ Template                │ sks-node-1.29.jammy                  │
│ Disk Size               │ 50                                   │
│ Anti Affinity Groups    │ n/a                                  │
│ Security Groups         │ sks-security-group                   │
│ Private Networks        │ n/a                                  │
│ Version                 │ 1.29.2                               │
│ Size                    │ 1                                    │
│ State                   │ running                              │
│ Taints                  │ n/a                                  │
│ Labels                  │ n/a                                  │
│ Add Ons                 │ n/a                                  │
│ Image GC Min            │ 2m                                   │
│ Image Gc Low Threshold  │ 80                                   │
│ Image Gc High Threshold │ 85                                   │
┼─────────────────────────┼──────────────────────────────────────┼

# adding nodepool with custom gc params
➜  ~/exo/cli git:(tgrondier/sc-66948/cli) go run . compute sks nodepool add my-test-cluster my-test-bar --size 1 --image-gc-high-threshold 90 --image-gc-low-threshold 70 --image-gc-min-age "3m" 
 ✔ Adding Nodepool "my-test-bar"... 24s
┼─────────────────────────┼──────────────────────────────────────┼
│      SKS NODEPOOL       │                                      │
┼─────────────────────────┼──────────────────────────────────────┼
│ ID                      │ 8536338b-f865-41fa-a2b6-bb075161de8c │
│ Name                    │ my-test-bar                          │
│ Description             │                                      │
│ Creation Date           │ 2024-04-08 08:02:45 +0000 UTC        │
│ Instance Pool ID        │ 37ec10e5-7465-480a-b1ec-00eb0634f4f9 │
│ Instance Prefix         │ pool                                 │
│ Instance Type           │ medium                               │
│ Template                │ sks-node-1.29.jammy                  │
│ Disk Size               │ 50                                   │
│ Anti Affinity Groups    │ n/a                                  │
│ Security Groups         │ n/a                                  │
│ Private Networks        │ n/a                                  │
│ Version                 │ 1.29.2                               │
│ Size                    │ 1                                    │
│ State                   │ running                              │
│ Taints                  │ n/a                                  │
│ Labels                  │ n/a                                  │
│ Add Ons                 │ n/a                                  │
│ Image GC Min            │ 3m                                   │
│ Image Gc Low Threshold  │ 70                                   │
│ Image Gc High Threshold │ 90                                   │
┼─────────────────────────┼──────────────────────────────────────┼

# adding nodepool with default params

➜  ~/exo/cli git:(tgrondier/sc-66948/cli) go run . compute sks nodepool add my-test-cluster my-test-bar --size 1 
 ✔ Adding Nodepool "my-test-bar"... 27s
┼─────────────────────────┼──────────────────────────────────────┼
│      SKS NODEPOOL       │                                      │
┼─────────────────────────┼──────────────────────────────────────┼
│ ID                      │ 10e64207-8d67-4372-affd-f5cf4338f746 │
│ Name                    │ my-test-bar                          │
│ Description             │                                      │
│ Creation Date           │ 2024-04-08 08:07:59 +0000 UTC        │
│ Instance Pool ID        │ 0d324d1f-a870-4216-9d43-66bae836b4c9 │
│ Instance Prefix         │ pool                                 │
│ Instance Type           │ medium                               │
│ Template                │ sks-node-1.29.jammy                  │
│ Disk Size               │ 50                                   │
│ Anti Affinity Groups    │ n/a                                  │
│ Security Groups         │ n/a                                  │
│ Private Networks        │ n/a                                  │
│ Version                 │ 1.29.2                               │
│ Size                    │ 1                                    │
│ State                   │ running                              │
│ Taints                  │ n/a                                  │
│ Labels                  │ n/a                                  │
│ Add Ons                 │ n/a                                  │
│ Image GC Min            │ 2m                                   │
│ Image Gc Low Threshold  │ 80                                   │
│ Image Gc High Threshold │ 85                                   │
┼─────────────────────────┼──────────────────────────────────────┼


```