### PR TITLE
Egoscale v3: Fix the exoscale trace output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Egoscale v3: Fix the exoscale trace output #587
 - SKS nodepool: allow specifying kubelet image gc parameters on creation #586
 
 ### Features

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -86,7 +86,13 @@ func buildClient() {
 
 	clientV3, err := v3.NewClient(
 		creds,
-		v3.ClientOptWithHTTPClient(httpClient),
+		v3.ClientOptWithRequestInterceptors(func(ctx context.Context, req *http.Request) error {
+			for k, v := range account.CurrentAccount.CustomHeaders {
+				req.Header.Add(k, v)
+			}
+
+			return nil
+		}),
 	)
 	if err != nil {
 		panic(fmt.Sprintf("unable to initialize Exoscale API V3 client: %v", err))

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/exoscale/egoscale v0.102.4-0.20240223092311-76285ea0504f
+	github.com/exoscale/egoscale v0.102.4-0.20240411151757-e59fc2d046ea
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/google/uuid v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/exoscale/egoscale v0.102.4-0.20240327105104-a8a8cb197ac6
+	github.com/exoscale/egoscale v0.102.4-0.20240411151757-e59fc2d046ea
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/google/uuid v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,8 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/go-control-plane v0.10.1/go.mod h1:AY7fTTXNdv/aJ2O5jwpxAPOWUZ7hQAEvzN5Pf27BkQQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
-github.com/exoscale/egoscale v0.102.4-0.20240327105104-a8a8cb197ac6 h1:UQwsohHjLp5mkcB+vZ7UuYrTi0FsBrQvgYD0guyNcSo=
-github.com/exoscale/egoscale v0.102.4-0.20240327105104-a8a8cb197ac6/go.mod h1:sFBCvHJx/h6u8Z5igoIcgbPs+wltBbEJrXA2xp05KoU=
+github.com/exoscale/egoscale v0.102.4-0.20240411151757-e59fc2d046ea h1:4aA5D9bWRWtXiknjBWqoCgnwI9+KCFDCInrCx8AigV8=
+github.com/exoscale/egoscale v0.102.4-0.20240411151757-e59fc2d046ea/go.mod h1:sFBCvHJx/h6u8Z5igoIcgbPs+wltBbEJrXA2xp05KoU=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,8 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/go-control-plane v0.10.1/go.mod h1:AY7fTTXNdv/aJ2O5jwpxAPOWUZ7hQAEvzN5Pf27BkQQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
-github.com/exoscale/egoscale v0.102.4-0.20240223092311-76285ea0504f h1:Ivacu1126KBSLhXvXST6H0ftMjehMV637fL/nb222LM=
-github.com/exoscale/egoscale v0.102.4-0.20240223092311-76285ea0504f/go.mod h1:sFBCvHJx/h6u8Z5igoIcgbPs+wltBbEJrXA2xp05KoU=
+github.com/exoscale/egoscale v0.102.4-0.20240411151757-e59fc2d046ea h1:4aA5D9bWRWtXiknjBWqoCgnwI9+KCFDCInrCx8AigV8=
+github.com/exoscale/egoscale v0.102.4-0.20240411151757-e59fc2d046ea/go.mod h1:sFBCvHJx/h6u8Z5igoIcgbPs+wltBbEJrXA2xp05KoU=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/v3/api.go
+++ b/vendor/github.com/exoscale/egoscale/v3/api.go
@@ -290,10 +290,10 @@ func handleHTTPErrorResp(resp *http.Response) error {
 	return nil
 }
 
-func dumpRequest(req *http.Request) {
+func dumpRequest(req *http.Request, operationID string) {
 	if req != nil {
 		if dump, err := httputil.DumpRequest(req, true); err == nil {
-			fmt.Fprintf(os.Stderr, ">>> %s\n", dump)
+			fmt.Fprintf(os.Stderr, ">>> Operation: %s\n%s\n", operationID, dump)
 		}
 	}
 }

--- a/vendor/github.com/exoscale/egoscale/v3/operations.go
+++ b/vendor/github.com/exoscale/egoscale/v3/operations.go
@@ -24,17 +24,18 @@ func (c Client) ListAccessKeys(ctx context.Context) (*ListAccessKeysResponse, er
 	if err != nil {
 		return nil, fmt.Errorf("ListAccessKeys: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListAccessKeys: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListAccessKeys: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-access-keys")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -83,6 +84,7 @@ func (c Client) CreateAccessKey(ctx context.Context, req CreateAccessKeyRequest)
 	if err != nil {
 		return nil, fmt.Errorf("CreateAccessKey: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -90,12 +92,12 @@ func (c Client) CreateAccessKey(ctx context.Context, req CreateAccessKeyRequest)
 		return nil, fmt.Errorf("CreateAccessKey: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateAccessKey: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-access-key")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -131,17 +133,18 @@ func (c Client) ListAccessKeyKnownOperations(ctx context.Context) (*ListAccessKe
 	if err != nil {
 		return nil, fmt.Errorf("ListAccessKeyKnownOperations: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListAccessKeyKnownOperations: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListAccessKeyKnownOperations: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-access-key-known-operations")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -177,17 +180,18 @@ func (c Client) ListAccessKeyOperations(ctx context.Context) (*ListAccessKeyOper
 	if err != nil {
 		return nil, fmt.Errorf("ListAccessKeyOperations: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListAccessKeyOperations: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListAccessKeyOperations: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-access-key-operations")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -219,17 +223,18 @@ func (c Client) RevokeAccessKey(ctx context.Context, key string) (*Operation, er
 	if err != nil {
 		return nil, fmt.Errorf("RevokeAccessKey: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("RevokeAccessKey: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("RevokeAccessKey: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "revoke-access-key")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -261,17 +266,18 @@ func (c Client) GetAccessKey(ctx context.Context, key string) (*AccessKey, error
 	if err != nil {
 		return nil, fmt.Errorf("GetAccessKey: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetAccessKey: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetAccessKey: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-access-key")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -318,17 +324,18 @@ func (c Client) ListAntiAffinityGroups(ctx context.Context) (*ListAntiAffinityGr
 	if err != nil {
 		return nil, fmt.Errorf("ListAntiAffinityGroups: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListAntiAffinityGroups: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListAntiAffinityGroups: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-anti-affinity-groups")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -372,6 +379,7 @@ func (c Client) CreateAntiAffinityGroup(ctx context.Context, req CreateAntiAffin
 	if err != nil {
 		return nil, fmt.Errorf("CreateAntiAffinityGroup: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -379,12 +387,12 @@ func (c Client) CreateAntiAffinityGroup(ctx context.Context, req CreateAntiAffin
 		return nil, fmt.Errorf("CreateAntiAffinityGroup: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateAntiAffinityGroup: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-anti-affinity-group")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -416,17 +424,18 @@ func (c Client) DeleteAntiAffinityGroup(ctx context.Context, id UUID) (*Operatio
 	if err != nil {
 		return nil, fmt.Errorf("DeleteAntiAffinityGroup: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteAntiAffinityGroup: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteAntiAffinityGroup: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-anti-affinity-group")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -458,17 +467,18 @@ func (c Client) GetAntiAffinityGroup(ctx context.Context, id UUID) (*AntiAffinit
 	if err != nil {
 		return nil, fmt.Errorf("GetAntiAffinityGroup: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetAntiAffinityGroup: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetAntiAffinityGroup: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-anti-affinity-group")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -504,17 +514,18 @@ func (c Client) ListAPIKeys(ctx context.Context) (*ListAPIKeysResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("ListAPIKeys: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListAPIKeys: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListAPIKeys: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-api-keys")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -558,6 +569,7 @@ func (c Client) CreateAPIKey(ctx context.Context, req CreateAPIKeyRequest) (*IAM
 	if err != nil {
 		return nil, fmt.Errorf("CreateAPIKey: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -565,12 +577,12 @@ func (c Client) CreateAPIKey(ctx context.Context, req CreateAPIKeyRequest) (*IAM
 		return nil, fmt.Errorf("CreateAPIKey: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateAPIKey: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-api-key")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -602,17 +614,18 @@ func (c Client) DeleteAPIKey(ctx context.Context, id string) (*Operation, error)
 	if err != nil {
 		return nil, fmt.Errorf("DeleteAPIKey: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteAPIKey: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteAPIKey: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-api-key")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -644,17 +657,18 @@ func (c Client) GetAPIKey(ctx context.Context, id string) (*IAMAPIKey, error) {
 	if err != nil {
 		return nil, fmt.Errorf("GetAPIKey: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetAPIKey: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetAPIKey: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-api-key")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -709,6 +723,7 @@ func (c Client) ListBlockStorageVolumes(ctx context.Context, opts ...ListBlockSt
 	if err != nil {
 		return nil, fmt.Errorf("ListBlockStorageVolumes: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if len(opts) > 0 {
 		q := request.URL.Query()
@@ -722,12 +737,12 @@ func (c Client) ListBlockStorageVolumes(ctx context.Context, opts ...ListBlockSt
 		return nil, fmt.Errorf("ListBlockStorageVolumes: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListBlockStorageVolumes: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-block-storage-volumes")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -756,10 +771,10 @@ type CreateBlockStorageVolumeRequest struct {
 	BlockStorageSnapshot *BlockStorageSnapshotTarget `json:"block-storage-snapshot,omitempty"`
 	Labels               Labels                      `json:"labels,omitempty"`
 	// Volume name
-	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
+	Name string `json:"name,omitempty" validate:"omitempty,lte=255"`
 	// Volume size in GB.
 	// When a snapshot ID is supplied, this defaults to the size of the source volume, but can be set to a larger value.
-	Size int64 `json:"size,omitempty" validate:"omitempty,gte=10,lte=10240"`
+	Size int64 `json:"size,omitempty" validate:"omitempty,gte=10"`
 }
 
 // Create a block storage volume
@@ -775,6 +790,7 @@ func (c Client) CreateBlockStorageVolume(ctx context.Context, req CreateBlockSto
 	if err != nil {
 		return nil, fmt.Errorf("CreateBlockStorageVolume: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -782,12 +798,12 @@ func (c Client) CreateBlockStorageVolume(ctx context.Context, req CreateBlockSto
 		return nil, fmt.Errorf("CreateBlockStorageVolume: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateBlockStorageVolume: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-block-storage-volume")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -834,17 +850,18 @@ func (c Client) ListBlockStorageSnapshots(ctx context.Context) (*ListBlockStorag
 	if err != nil {
 		return nil, fmt.Errorf("ListBlockStorageSnapshots: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListBlockStorageSnapshots: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListBlockStorageSnapshots: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-block-storage-snapshots")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -876,17 +893,18 @@ func (c Client) DeleteBlockStorageSnapshot(ctx context.Context, id UUID) (*Opera
 	if err != nil {
 		return nil, fmt.Errorf("DeleteBlockStorageSnapshot: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteBlockStorageSnapshot: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteBlockStorageSnapshot: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-block-storage-snapshot")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -918,17 +936,18 @@ func (c Client) GetBlockStorageSnapshot(ctx context.Context, id UUID) (*BlockSto
 	if err != nil {
 		return nil, fmt.Errorf("GetBlockStorageSnapshot: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetBlockStorageSnapshot: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetBlockStorageSnapshot: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-block-storage-snapshot")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -960,17 +979,18 @@ func (c Client) DeleteBlockStorageVolume(ctx context.Context, id UUID) (*Operati
 	if err != nil {
 		return nil, fmt.Errorf("DeleteBlockStorageVolume: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteBlockStorageVolume: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteBlockStorageVolume: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-block-storage-volume")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1002,17 +1022,18 @@ func (c Client) GetBlockStorageVolume(ctx context.Context, id UUID) (*BlockStora
 	if err != nil {
 		return nil, fmt.Errorf("GetBlockStorageVolume: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetBlockStorageVolume: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetBlockStorageVolume: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-block-storage-volume")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1053,6 +1074,7 @@ func (c Client) UpdateBlockStorageVolumeLabels(ctx context.Context, id UUID, req
 	if err != nil {
 		return nil, fmt.Errorf("UpdateBlockStorageVolumeLabels: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -1060,12 +1082,12 @@ func (c Client) UpdateBlockStorageVolumeLabels(ctx context.Context, id UUID, req
 		return nil, fmt.Errorf("UpdateBlockStorageVolumeLabels: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateBlockStorageVolumeLabels: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-block-storage-volume-labels")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1107,6 +1129,7 @@ func (c Client) AttachBlockStorageVolumeToInstance(ctx context.Context, id UUID,
 	if err != nil {
 		return nil, fmt.Errorf("AttachBlockStorageVolumeToInstance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -1114,12 +1137,12 @@ func (c Client) AttachBlockStorageVolumeToInstance(ctx context.Context, id UUID,
 		return nil, fmt.Errorf("AttachBlockStorageVolumeToInstance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("AttachBlockStorageVolumeToInstance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "attach-block-storage-volume-to-instance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1162,6 +1185,7 @@ func (c Client) CreateBlockStorageSnapshot(ctx context.Context, id UUID, req Cre
 	if err != nil {
 		return nil, fmt.Errorf("CreateBlockStorageSnapshot: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -1169,12 +1193,12 @@ func (c Client) CreateBlockStorageSnapshot(ctx context.Context, id UUID, req Cre
 		return nil, fmt.Errorf("CreateBlockStorageSnapshot: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateBlockStorageSnapshot: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-block-storage-snapshot")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1206,17 +1230,18 @@ func (c Client) DetachBlockStorageVolume(ctx context.Context, id UUID) (*Operati
 	if err != nil {
 		return nil, fmt.Errorf("DetachBlockStorageVolume: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DetachBlockStorageVolume: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DetachBlockStorageVolume: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "detach-block-storage-volume")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1242,7 +1267,7 @@ func (c Client) DetachBlockStorageVolume(ctx context.Context, id UUID) (*Operati
 
 type ResizeBlockStorageVolumeRequest struct {
 	// Volume size in GB
-	Size int64 `json:"size" validate:"required,gte=11,lte=10240"`
+	Size int64 `json:"size" validate:"required,gte=11"`
 }
 
 // This operation resizes a Block storage volume. Note: the volume can only grow, cannot be shrunk.
@@ -1258,6 +1283,7 @@ func (c Client) ResizeBlockStorageVolume(ctx context.Context, id UUID, req Resiz
 	if err != nil {
 		return nil, fmt.Errorf("ResizeBlockStorageVolume: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -1265,12 +1291,12 @@ func (c Client) ResizeBlockStorageVolume(ctx context.Context, id UUID, req Resiz
 		return nil, fmt.Errorf("ResizeBlockStorageVolume: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ResizeBlockStorageVolume: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "resize-block-storage-volume")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1306,17 +1332,18 @@ func (c Client) GetDBAASCACertificate(ctx context.Context) (*GetDBAASCACertifica
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASCACertificate: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASCACertificate: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASCACertificate: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-ca-certificate")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1348,17 +1375,18 @@ func (c Client) DeleteDBAASServiceGrafana(ctx context.Context, name string) (*Op
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceGrafana: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceGrafana: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceGrafana: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-service-grafana")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1390,17 +1418,18 @@ func (c Client) GetDBAASServiceGrafana(ctx context.Context, name string) (*DBAAS
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceGrafana: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceGrafana: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceGrafana: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-service-grafana")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1472,6 +1501,7 @@ func (c Client) CreateDBAASServiceGrafana(ctx context.Context, name string, req 
 	if err != nil {
 		return nil, fmt.Errorf("CreateDBAASServiceGrafana: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -1479,12 +1509,12 @@ func (c Client) CreateDBAASServiceGrafana(ctx context.Context, name string, req 
 		return nil, fmt.Errorf("CreateDBAASServiceGrafana: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDBAASServiceGrafana: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-service-grafana")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1555,6 +1585,7 @@ func (c Client) UpdateDBAASServiceGrafana(ctx context.Context, name string, req 
 	if err != nil {
 		return nil, fmt.Errorf("UpdateDBAASServiceGrafana: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -1562,12 +1593,12 @@ func (c Client) UpdateDBAASServiceGrafana(ctx context.Context, name string, req 
 		return nil, fmt.Errorf("UpdateDBAASServiceGrafana: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASServiceGrafana: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-dbaas-service-grafana")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1599,17 +1630,18 @@ func (c Client) StartDBAASGrafanaMaintenance(ctx context.Context, name string) (
 	if err != nil {
 		return nil, fmt.Errorf("StartDBAASGrafanaMaintenance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("StartDBAASGrafanaMaintenance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("StartDBAASGrafanaMaintenance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "start-dbaas-grafana-maintenance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1654,6 +1686,7 @@ func (c Client) CreateDBAASIntegration(ctx context.Context, req CreateDBAASInteg
 	if err != nil {
 		return nil, fmt.Errorf("CreateDBAASIntegration: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -1661,12 +1694,12 @@ func (c Client) CreateDBAASIntegration(ctx context.Context, req CreateDBAASInteg
 		return nil, fmt.Errorf("CreateDBAASIntegration: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDBAASIntegration: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-integration")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1711,17 +1744,18 @@ func (c Client) ListDBAASIntegrationSettings(ctx context.Context, integrationTyp
 	if err != nil {
 		return nil, fmt.Errorf("ListDBAASIntegrationSettings: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListDBAASIntegrationSettings: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListDBAASIntegrationSettings: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-dbaas-integration-settings")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1757,17 +1791,18 @@ func (c Client) ListDBAASIntegrationTypes(ctx context.Context) (*ListDBAASIntegr
 	if err != nil {
 		return nil, fmt.Errorf("ListDBAASIntegrationTypes: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListDBAASIntegrationTypes: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListDBAASIntegrationTypes: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-dbaas-integration-types")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1799,17 +1834,18 @@ func (c Client) DeleteDBAASIntegration(ctx context.Context, id UUID) (*Operation
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDBAASIntegration: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASIntegration: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASIntegration: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-integration")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1841,17 +1877,18 @@ func (c Client) GetDBAASIntegration(ctx context.Context, id UUID) (*DBAASIntegra
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASIntegration: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASIntegration: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASIntegration: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-integration")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1893,6 +1930,7 @@ func (c Client) UpdateDBAASIntegration(ctx context.Context, id UUID, req UpdateD
 	if err != nil {
 		return nil, fmt.Errorf("UpdateDBAASIntegration: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -1900,12 +1938,12 @@ func (c Client) UpdateDBAASIntegration(ctx context.Context, id UUID, req UpdateD
 		return nil, fmt.Errorf("UpdateDBAASIntegration: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASIntegration: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-dbaas-integration")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1937,17 +1975,18 @@ func (c Client) DeleteDBAASServiceKafka(ctx context.Context, name string) (*Oper
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceKafka: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceKafka: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceKafka: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-service-kafka")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -1979,17 +2018,18 @@ func (c Client) GetDBAASServiceKafka(ctx context.Context, name string) (*DBAASSe
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceKafka: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceKafka: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceKafka: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-service-kafka")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -2084,6 +2124,7 @@ func (c Client) CreateDBAASServiceKafka(ctx context.Context, name string, req Cr
 	if err != nil {
 		return nil, fmt.Errorf("CreateDBAASServiceKafka: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -2091,12 +2132,12 @@ func (c Client) CreateDBAASServiceKafka(ctx context.Context, name string, req Cr
 		return nil, fmt.Errorf("CreateDBAASServiceKafka: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDBAASServiceKafka: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-service-kafka")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -2191,6 +2232,7 @@ func (c Client) UpdateDBAASServiceKafka(ctx context.Context, name string, req Up
 	if err != nil {
 		return nil, fmt.Errorf("UpdateDBAASServiceKafka: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -2198,12 +2240,12 @@ func (c Client) UpdateDBAASServiceKafka(ctx context.Context, name string, req Up
 		return nil, fmt.Errorf("UpdateDBAASServiceKafka: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASServiceKafka: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-dbaas-service-kafka")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -2235,17 +2277,18 @@ func (c Client) GetDBAASKafkaAclConfig(ctx context.Context, name string) (*DBAAS
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASKafkaAclConfig: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASKafkaAclConfig: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASKafkaAclConfig: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-kafka-acl-config")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -2277,17 +2320,18 @@ func (c Client) StartDBAASKafkaMaintenance(ctx context.Context, name string) (*O
 	if err != nil {
 		return nil, fmt.Errorf("StartDBAASKafkaMaintenance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("StartDBAASKafkaMaintenance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("StartDBAASKafkaMaintenance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "start-dbaas-kafka-maintenance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -2324,6 +2368,7 @@ func (c Client) CreateDBAASKafkaSchemaRegistryAclConfig(ctx context.Context, nam
 	if err != nil {
 		return nil, fmt.Errorf("CreateDBAASKafkaSchemaRegistryAclConfig: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -2331,12 +2376,12 @@ func (c Client) CreateDBAASKafkaSchemaRegistryAclConfig(ctx context.Context, nam
 		return nil, fmt.Errorf("CreateDBAASKafkaSchemaRegistryAclConfig: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDBAASKafkaSchemaRegistryAclConfig: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-kafka-schema-registry-acl-config")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -2368,17 +2413,18 @@ func (c Client) DeleteDBAASKafkaSchemaRegistryAclConfig(ctx context.Context, nam
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDBAASKafkaSchemaRegistryAclConfig: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASKafkaSchemaRegistryAclConfig: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASKafkaSchemaRegistryAclConfig: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-kafka-schema-registry-acl-config")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -2415,6 +2461,7 @@ func (c Client) CreateDBAASKafkaTopicAclConfig(ctx context.Context, name string,
 	if err != nil {
 		return nil, fmt.Errorf("CreateDBAASKafkaTopicAclConfig: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -2422,12 +2469,12 @@ func (c Client) CreateDBAASKafkaTopicAclConfig(ctx context.Context, name string,
 		return nil, fmt.Errorf("CreateDBAASKafkaTopicAclConfig: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDBAASKafkaTopicAclConfig: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-kafka-topic-acl-config")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -2459,17 +2506,18 @@ func (c Client) DeleteDBAASKafkaTopicAclConfig(ctx context.Context, name string,
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDBAASKafkaTopicAclConfig: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASKafkaTopicAclConfig: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASKafkaTopicAclConfig: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-kafka-topic-acl-config")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -2510,6 +2558,7 @@ func (c Client) CreateDBAASKafkaUser(ctx context.Context, serviceName string, re
 	if err != nil {
 		return nil, fmt.Errorf("CreateDBAASKafkaUser: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -2517,12 +2566,12 @@ func (c Client) CreateDBAASKafkaUser(ctx context.Context, serviceName string, re
 		return nil, fmt.Errorf("CreateDBAASKafkaUser: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDBAASKafkaUser: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-kafka-user")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -2554,17 +2603,18 @@ func (c Client) DeleteDBAASKafkaUser(ctx context.Context, serviceName string, us
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDBAASKafkaUser: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASKafkaUser: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASKafkaUser: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-kafka-user")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -2605,6 +2655,7 @@ func (c Client) ResetDBAASKafkaUserPassword(ctx context.Context, serviceName str
 	if err != nil {
 		return nil, fmt.Errorf("ResetDBAASKafkaUserPassword: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -2612,12 +2663,12 @@ func (c Client) ResetDBAASKafkaUserPassword(ctx context.Context, serviceName str
 		return nil, fmt.Errorf("ResetDBAASKafkaUserPassword: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ResetDBAASKafkaUserPassword: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reset-dbaas-kafka-user-password")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -2641,6 +2692,49 @@ func (c Client) ResetDBAASKafkaUserPassword(ctx context.Context, serviceName str
 	return bodyresp, nil
 }
 
+// Reveal the secrets of a DBaaS Kafka user
+func (c Client) RevealDBAASKafkaUserPassword(ctx context.Context, serviceName string, username string) (*DBAASUserKafkaSecrets, error) {
+	path := fmt.Sprintf("/dbaas-kafka/%v/user/%v/password/reveal", serviceName, username)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("RevealDBAASKafkaUserPassword: new request: %w", err)
+	}
+	request.Header.Add("User-Agent", UserAgent)
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("RevealDBAASKafkaUserPassword: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("RevealDBAASKafkaUserPassword: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reveal-dbaas-kafka-user-password")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("RevealDBAASKafkaUserPassword: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("RevealDBAASKafkaUserPassword: http response: %w", err)
+	}
+
+	bodyresp := &DBAASUserKafkaSecrets{}
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("RevealDBAASKafkaUserPassword: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
 // Get a DBaaS migration status
 func (c Client) GetDBAASMigrationStatus(ctx context.Context, name string) (*DBAASMigrationStatus, error) {
 	path := fmt.Sprintf("/dbaas-migration-status/%v", name)
@@ -2649,17 +2743,18 @@ func (c Client) GetDBAASMigrationStatus(ctx context.Context, name string) (*DBAA
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASMigrationStatus: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASMigrationStatus: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASMigrationStatus: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-migration-status")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -2691,17 +2786,18 @@ func (c Client) DeleteDBAASServiceMysql(ctx context.Context, name string) (*Oper
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceMysql: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceMysql: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceMysql: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-service-mysql")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -2733,17 +2829,18 @@ func (c Client) GetDBAASServiceMysql(ctx context.Context, name string) (*DBAASSe
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceMysql: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceMysql: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceMysql: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-service-mysql")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -2871,6 +2968,7 @@ func (c Client) CreateDBAASServiceMysql(ctx context.Context, name string, req Cr
 	if err != nil {
 		return nil, fmt.Errorf("CreateDBAASServiceMysql: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -2878,12 +2976,12 @@ func (c Client) CreateDBAASServiceMysql(ctx context.Context, name string, req Cr
 		return nil, fmt.Errorf("CreateDBAASServiceMysql: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDBAASServiceMysql: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-service-mysql")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -2985,6 +3083,7 @@ func (c Client) UpdateDBAASServiceMysql(ctx context.Context, name string, req Up
 	if err != nil {
 		return nil, fmt.Errorf("UpdateDBAASServiceMysql: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -2992,12 +3091,12 @@ func (c Client) UpdateDBAASServiceMysql(ctx context.Context, name string, req Up
 		return nil, fmt.Errorf("UpdateDBAASServiceMysql: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASServiceMysql: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-dbaas-service-mysql")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -3029,17 +3128,18 @@ func (c Client) StartDBAASMysqlMaintenance(ctx context.Context, name string) (*O
 	if err != nil {
 		return nil, fmt.Errorf("StartDBAASMysqlMaintenance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("StartDBAASMysqlMaintenance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("StartDBAASMysqlMaintenance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "start-dbaas-mysql-maintenance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -3071,17 +3171,18 @@ func (c Client) StopDBAASMysqlMigration(ctx context.Context, name string) (*Oper
 	if err != nil {
 		return nil, fmt.Errorf("StopDBAASMysqlMigration: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("StopDBAASMysqlMigration: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("StopDBAASMysqlMigration: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "stop-dbaas-mysql-migration")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -3122,6 +3223,7 @@ func (c Client) CreateDBAASMysqlDatabase(ctx context.Context, serviceName string
 	if err != nil {
 		return nil, fmt.Errorf("CreateDBAASMysqlDatabase: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -3129,12 +3231,12 @@ func (c Client) CreateDBAASMysqlDatabase(ctx context.Context, serviceName string
 		return nil, fmt.Errorf("CreateDBAASMysqlDatabase: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDBAASMysqlDatabase: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-mysql-database")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -3166,17 +3268,18 @@ func (c Client) DeleteDBAASMysqlDatabase(ctx context.Context, serviceName string
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDBAASMysqlDatabase: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASMysqlDatabase: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASMysqlDatabase: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-mysql-database")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -3218,6 +3321,7 @@ func (c Client) CreateDBAASMysqlUser(ctx context.Context, serviceName string, re
 	if err != nil {
 		return nil, fmt.Errorf("CreateDBAASMysqlUser: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -3225,12 +3329,12 @@ func (c Client) CreateDBAASMysqlUser(ctx context.Context, serviceName string, re
 		return nil, fmt.Errorf("CreateDBAASMysqlUser: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDBAASMysqlUser: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-mysql-user")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -3262,17 +3366,18 @@ func (c Client) DeleteDBAASMysqlUser(ctx context.Context, serviceName string, us
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDBAASMysqlUser: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASMysqlUser: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASMysqlUser: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-mysql-user")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -3314,6 +3419,7 @@ func (c Client) ResetDBAASMysqlUserPassword(ctx context.Context, serviceName str
 	if err != nil {
 		return nil, fmt.Errorf("ResetDBAASMysqlUserPassword: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -3321,12 +3427,12 @@ func (c Client) ResetDBAASMysqlUserPassword(ctx context.Context, serviceName str
 		return nil, fmt.Errorf("ResetDBAASMysqlUserPassword: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ResetDBAASMysqlUserPassword: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reset-dbaas-mysql-user-password")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -3350,6 +3456,49 @@ func (c Client) ResetDBAASMysqlUserPassword(ctx context.Context, serviceName str
 	return bodyresp, nil
 }
 
+// Reveal the secrets of a DBaaS MySQL user
+func (c Client) RevealDBAASMysqlUserPassword(ctx context.Context, serviceName string, username string) (*DBAASUserMysqlSecrets, error) {
+	path := fmt.Sprintf("/dbaas-mysql/%v/user/%v/password/reveal", serviceName, username)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("RevealDBAASMysqlUserPassword: new request: %w", err)
+	}
+	request.Header.Add("User-Agent", UserAgent)
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("RevealDBAASMysqlUserPassword: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("RevealDBAASMysqlUserPassword: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reveal-dbaas-mysql-user-password")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("RevealDBAASMysqlUserPassword: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("RevealDBAASMysqlUserPassword: http response: %w", err)
+	}
+
+	bodyresp := &DBAASUserMysqlSecrets{}
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("RevealDBAASMysqlUserPassword: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
 // Delete a OpenSearch service
 func (c Client) DeleteDBAASServiceOpensearch(ctx context.Context, name string) (*Operation, error) {
 	path := fmt.Sprintf("/dbaas-opensearch/%v", name)
@@ -3358,17 +3507,18 @@ func (c Client) DeleteDBAASServiceOpensearch(ctx context.Context, name string) (
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceOpensearch: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceOpensearch: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceOpensearch: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-service-opensearch")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -3400,17 +3550,18 @@ func (c Client) GetDBAASServiceOpensearch(ctx context.Context, name string) (*DB
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceOpensearch: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceOpensearch: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceOpensearch: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-service-opensearch")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -3532,6 +3683,7 @@ func (c Client) CreateDBAASServiceOpensearch(ctx context.Context, name string, r
 	if err != nil {
 		return nil, fmt.Errorf("CreateDBAASServiceOpensearch: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -3539,12 +3691,12 @@ func (c Client) CreateDBAASServiceOpensearch(ctx context.Context, name string, r
 		return nil, fmt.Errorf("CreateDBAASServiceOpensearch: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDBAASServiceOpensearch: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-service-opensearch")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -3663,6 +3815,7 @@ func (c Client) UpdateDBAASServiceOpensearch(ctx context.Context, name string, r
 	if err != nil {
 		return nil, fmt.Errorf("UpdateDBAASServiceOpensearch: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -3670,12 +3823,12 @@ func (c Client) UpdateDBAASServiceOpensearch(ctx context.Context, name string, r
 		return nil, fmt.Errorf("UpdateDBAASServiceOpensearch: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASServiceOpensearch: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-dbaas-service-opensearch")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -3707,17 +3860,18 @@ func (c Client) GetDBAASOpensearchAclConfig(ctx context.Context, name string) (*
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASOpensearchAclConfig: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASOpensearchAclConfig: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASOpensearchAclConfig: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-opensearch-acl-config")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -3754,6 +3908,7 @@ func (c Client) UpdateDBAASOpensearchAclConfig(ctx context.Context, name string,
 	if err != nil {
 		return nil, fmt.Errorf("UpdateDBAASOpensearchAclConfig: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -3761,12 +3916,12 @@ func (c Client) UpdateDBAASOpensearchAclConfig(ctx context.Context, name string,
 		return nil, fmt.Errorf("UpdateDBAASOpensearchAclConfig: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASOpensearchAclConfig: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-dbaas-opensearch-acl-config")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -3798,17 +3953,18 @@ func (c Client) StartDBAASOpensearchMaintenance(ctx context.Context, name string
 	if err != nil {
 		return nil, fmt.Errorf("StartDBAASOpensearchMaintenance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("StartDBAASOpensearchMaintenance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("StartDBAASOpensearchMaintenance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "start-dbaas-opensearch-maintenance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -3849,6 +4005,7 @@ func (c Client) CreateDBAASOpensearchUser(ctx context.Context, serviceName strin
 	if err != nil {
 		return nil, fmt.Errorf("CreateDBAASOpensearchUser: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -3856,12 +4013,12 @@ func (c Client) CreateDBAASOpensearchUser(ctx context.Context, serviceName strin
 		return nil, fmt.Errorf("CreateDBAASOpensearchUser: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDBAASOpensearchUser: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-opensearch-user")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -3893,17 +4050,18 @@ func (c Client) DeleteDBAASOpensearchUser(ctx context.Context, serviceName strin
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDBAASOpensearchUser: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASOpensearchUser: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASOpensearchUser: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-opensearch-user")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -3944,6 +4102,7 @@ func (c Client) ResetDBAASOpensearchUserPassword(ctx context.Context, serviceNam
 	if err != nil {
 		return nil, fmt.Errorf("ResetDBAASOpensearchUserPassword: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -3951,12 +4110,12 @@ func (c Client) ResetDBAASOpensearchUserPassword(ctx context.Context, serviceNam
 		return nil, fmt.Errorf("ResetDBAASOpensearchUserPassword: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ResetDBAASOpensearchUserPassword: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reset-dbaas-opensearch-user-password")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -3980,6 +4139,49 @@ func (c Client) ResetDBAASOpensearchUserPassword(ctx context.Context, serviceNam
 	return bodyresp, nil
 }
 
+// Reveal the secrets of a DBaaS OpenSearch user
+func (c Client) RevealDBAASOpensearchUserPassword(ctx context.Context, serviceName string, username string) (*DBAASUserOpensearchSecrets, error) {
+	path := fmt.Sprintf("/dbaas-opensearch/%v/user/%v/password/reveal", serviceName, username)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("RevealDBAASOpensearchUserPassword: new request: %w", err)
+	}
+	request.Header.Add("User-Agent", UserAgent)
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("RevealDBAASOpensearchUserPassword: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("RevealDBAASOpensearchUserPassword: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reveal-dbaas-opensearch-user-password")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("RevealDBAASOpensearchUserPassword: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("RevealDBAASOpensearchUserPassword: http response: %w", err)
+	}
+
+	bodyresp := &DBAASUserOpensearchSecrets{}
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("RevealDBAASOpensearchUserPassword: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
 // Delete a Postgres service
 func (c Client) DeleteDBAASServicePG(ctx context.Context, name string) (*Operation, error) {
 	path := fmt.Sprintf("/dbaas-postgres/%v", name)
@@ -3988,17 +4190,18 @@ func (c Client) DeleteDBAASServicePG(ctx context.Context, name string) (*Operati
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServicePG: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServicePG: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServicePG: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-service-pg")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -4030,17 +4233,18 @@ func (c Client) GetDBAASServicePG(ctx context.Context, name string) (*DBAASServi
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASServicePG: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASServicePG: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASServicePG: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-service-pg")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -4177,6 +4381,7 @@ func (c Client) CreateDBAASServicePG(ctx context.Context, name string, req Creat
 	if err != nil {
 		return nil, fmt.Errorf("CreateDBAASServicePG: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -4184,12 +4389,12 @@ func (c Client) CreateDBAASServicePG(ctx context.Context, name string, req Creat
 		return nil, fmt.Errorf("CreateDBAASServicePG: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDBAASServicePG: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-service-pg")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -4303,6 +4508,7 @@ func (c Client) UpdateDBAASServicePG(ctx context.Context, name string, req Updat
 	if err != nil {
 		return nil, fmt.Errorf("UpdateDBAASServicePG: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -4310,12 +4516,12 @@ func (c Client) UpdateDBAASServicePG(ctx context.Context, name string, req Updat
 		return nil, fmt.Errorf("UpdateDBAASServicePG: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASServicePG: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-dbaas-service-pg")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -4347,17 +4553,18 @@ func (c Client) StartDBAASPGMaintenance(ctx context.Context, name string) (*Oper
 	if err != nil {
 		return nil, fmt.Errorf("StartDBAASPGMaintenance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("StartDBAASPGMaintenance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("StartDBAASPGMaintenance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "start-dbaas-pg-maintenance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -4389,17 +4596,18 @@ func (c Client) StopDBAASPGMigration(ctx context.Context, name string) (*Operati
 	if err != nil {
 		return nil, fmt.Errorf("StopDBAASPGMigration: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("StopDBAASPGMigration: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("StopDBAASPGMigration: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "stop-dbaas-pg-migration")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -4444,6 +4652,7 @@ func (c Client) CreateDBAASPGConnectionPool(ctx context.Context, serviceName str
 	if err != nil {
 		return nil, fmt.Errorf("CreateDBAASPGConnectionPool: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -4451,12 +4660,12 @@ func (c Client) CreateDBAASPGConnectionPool(ctx context.Context, serviceName str
 		return nil, fmt.Errorf("CreateDBAASPGConnectionPool: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDBAASPGConnectionPool: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-pg-connection-pool")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -4488,17 +4697,18 @@ func (c Client) DeleteDBAASPGConnectionPool(ctx context.Context, serviceName str
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDBAASPGConnectionPool: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASPGConnectionPool: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASPGConnectionPool: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-pg-connection-pool")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -4542,6 +4752,7 @@ func (c Client) UpdateDBAASPGConnectionPool(ctx context.Context, serviceName str
 	if err != nil {
 		return nil, fmt.Errorf("UpdateDBAASPGConnectionPool: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -4549,12 +4760,12 @@ func (c Client) UpdateDBAASPGConnectionPool(ctx context.Context, serviceName str
 		return nil, fmt.Errorf("UpdateDBAASPGConnectionPool: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASPGConnectionPool: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-dbaas-pg-connection-pool")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -4599,6 +4810,7 @@ func (c Client) CreateDBAASPGDatabase(ctx context.Context, serviceName string, r
 	if err != nil {
 		return nil, fmt.Errorf("CreateDBAASPGDatabase: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -4606,12 +4818,12 @@ func (c Client) CreateDBAASPGDatabase(ctx context.Context, serviceName string, r
 		return nil, fmt.Errorf("CreateDBAASPGDatabase: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDBAASPGDatabase: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-pg-database")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -4643,17 +4855,18 @@ func (c Client) DeleteDBAASPGDatabase(ctx context.Context, serviceName string, d
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDBAASPGDatabase: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASPGDatabase: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASPGDatabase: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-pg-database")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -4695,6 +4908,7 @@ func (c Client) CreateDBAASPostgresUser(ctx context.Context, serviceName string,
 	if err != nil {
 		return nil, fmt.Errorf("CreateDBAASPostgresUser: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -4702,12 +4916,12 @@ func (c Client) CreateDBAASPostgresUser(ctx context.Context, serviceName string,
 		return nil, fmt.Errorf("CreateDBAASPostgresUser: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDBAASPostgresUser: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-postgres-user")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -4739,17 +4953,18 @@ func (c Client) DeleteDBAASPostgresUser(ctx context.Context, serviceName string,
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDBAASPostgresUser: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASPostgresUser: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASPostgresUser: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-postgres-user")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -4790,6 +5005,7 @@ func (c Client) UpdateDBAASPostgresAllowReplication(ctx context.Context, service
 	if err != nil {
 		return nil, fmt.Errorf("UpdateDBAASPostgresAllowReplication: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -4797,12 +5013,12 @@ func (c Client) UpdateDBAASPostgresAllowReplication(ctx context.Context, service
 		return nil, fmt.Errorf("UpdateDBAASPostgresAllowReplication: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASPostgresAllowReplication: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-dbaas-postgres-allow-replication")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -4843,6 +5059,7 @@ func (c Client) ResetDBAASPostgresUserPassword(ctx context.Context, serviceName 
 	if err != nil {
 		return nil, fmt.Errorf("ResetDBAASPostgresUserPassword: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -4850,12 +5067,12 @@ func (c Client) ResetDBAASPostgresUserPassword(ctx context.Context, serviceName 
 		return nil, fmt.Errorf("ResetDBAASPostgresUserPassword: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ResetDBAASPostgresUserPassword: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reset-dbaas-postgres-user-password")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -4879,6 +5096,49 @@ func (c Client) ResetDBAASPostgresUserPassword(ctx context.Context, serviceName 
 	return bodyresp, nil
 }
 
+// Reveal the secrets of a DBaaS Postgres user
+func (c Client) RevealDBAASPostgresUserPassword(ctx context.Context, serviceName string, username string) (*DBAASUserPostgresSecrets, error) {
+	path := fmt.Sprintf("/dbaas-postgres/%v/user/%v/password/reveal", serviceName, username)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("RevealDBAASPostgresUserPassword: new request: %w", err)
+	}
+	request.Header.Add("User-Agent", UserAgent)
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("RevealDBAASPostgresUserPassword: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("RevealDBAASPostgresUserPassword: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reveal-dbaas-postgres-user-password")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("RevealDBAASPostgresUserPassword: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("RevealDBAASPostgresUserPassword: http response: %w", err)
+	}
+
+	bodyresp := &DBAASUserPostgresSecrets{}
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("RevealDBAASPostgresUserPassword: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
 type CreateDBAASPGUpgradeCheckRequest struct {
 	TargetVersion DBAASPGTargetVersions `json:"target-version" validate:"required"`
 }
@@ -4896,6 +5156,7 @@ func (c Client) CreateDBAASPGUpgradeCheck(ctx context.Context, service string, r
 	if err != nil {
 		return nil, fmt.Errorf("CreateDBAASPGUpgradeCheck: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -4903,12 +5164,12 @@ func (c Client) CreateDBAASPGUpgradeCheck(ctx context.Context, service string, r
 		return nil, fmt.Errorf("CreateDBAASPGUpgradeCheck: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDBAASPGUpgradeCheck: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-pg-upgrade-check")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -4940,17 +5201,18 @@ func (c Client) DeleteDBAASServiceRedis(ctx context.Context, name string) (*Oper
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceRedis: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceRedis: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASServiceRedis: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-service-redis")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -4982,17 +5244,18 @@ func (c Client) GetDBAASServiceRedis(ctx context.Context, name string) (*DBAASSe
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceRedis: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceRedis: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceRedis: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-service-redis")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -5087,6 +5350,7 @@ func (c Client) CreateDBAASServiceRedis(ctx context.Context, name string, req Cr
 	if err != nil {
 		return nil, fmt.Errorf("CreateDBAASServiceRedis: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -5094,12 +5358,12 @@ func (c Client) CreateDBAASServiceRedis(ctx context.Context, name string, req Cr
 		return nil, fmt.Errorf("CreateDBAASServiceRedis: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDBAASServiceRedis: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-service-redis")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -5191,6 +5455,7 @@ func (c Client) UpdateDBAASServiceRedis(ctx context.Context, name string, req Up
 	if err != nil {
 		return nil, fmt.Errorf("UpdateDBAASServiceRedis: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -5198,12 +5463,12 @@ func (c Client) UpdateDBAASServiceRedis(ctx context.Context, name string, req Up
 		return nil, fmt.Errorf("UpdateDBAASServiceRedis: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateDBAASServiceRedis: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-dbaas-service-redis")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -5235,17 +5500,18 @@ func (c Client) StartDBAASRedisMaintenance(ctx context.Context, name string) (*O
 	if err != nil {
 		return nil, fmt.Errorf("StartDBAASRedisMaintenance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("StartDBAASRedisMaintenance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("StartDBAASRedisMaintenance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "start-dbaas-redis-maintenance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -5277,17 +5543,18 @@ func (c Client) StopDBAASRedisMigration(ctx context.Context, name string) (*Oper
 	if err != nil {
 		return nil, fmt.Errorf("StopDBAASRedisMigration: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("StopDBAASRedisMigration: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("StopDBAASRedisMigration: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "stop-dbaas-redis-migration")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -5311,6 +5578,200 @@ func (c Client) StopDBAASRedisMigration(ctx context.Context, name string) (*Oper
 	return bodyresp, nil
 }
 
+type CreateDBAASRedisUserRequest struct {
+	Username DBAASUserUsername `json:"username" validate:"required,gte=1,lte=64"`
+}
+
+// Create a DBaaS Redis user
+func (c Client) CreateDBAASRedisUser(ctx context.Context, serviceName string, req CreateDBAASRedisUserRequest) (*Operation, error) {
+	path := fmt.Sprintf("/dbaas-redis/%v/user", serviceName)
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("CreateDBAASRedisUser: prepare Json body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("CreateDBAASRedisUser: new request: %w", err)
+	}
+	request.Header.Add("User-Agent", UserAgent)
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("CreateDBAASRedisUser: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("CreateDBAASRedisUser: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-redis-user")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("CreateDBAASRedisUser: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("CreateDBAASRedisUser: http response: %w", err)
+	}
+
+	bodyresp := &Operation{}
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("CreateDBAASRedisUser: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// Delete a DBaaS Redis user
+func (c Client) DeleteDBAASRedisUser(ctx context.Context, serviceName string, username string) (*Operation, error) {
+	path := fmt.Sprintf("/dbaas-redis/%v/user/%v", serviceName, username)
+
+	request, err := http.NewRequestWithContext(ctx, "DELETE", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteDBAASRedisUser: new request: %w", err)
+	}
+	request.Header.Add("User-Agent", UserAgent)
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("DeleteDBAASRedisUser: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("DeleteDBAASRedisUser: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-redis-user")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteDBAASRedisUser: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("DeleteDBAASRedisUser: http response: %w", err)
+	}
+
+	bodyresp := &Operation{}
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("DeleteDBAASRedisUser: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type ResetDBAASRedisUserPasswordRequest struct {
+	Password DBAASUserPassword `json:"password,omitempty" validate:"omitempty,gte=8,lte=256"`
+}
+
+// If no password is provided one will be generated automatically.
+func (c Client) ResetDBAASRedisUserPassword(ctx context.Context, serviceName string, username string, req ResetDBAASRedisUserPasswordRequest) (*Operation, error) {
+	path := fmt.Sprintf("/dbaas-redis/%v/user/%v/password/reset", serviceName, username)
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("ResetDBAASRedisUserPassword: prepare Json body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("ResetDBAASRedisUserPassword: new request: %w", err)
+	}
+	request.Header.Add("User-Agent", UserAgent)
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("ResetDBAASRedisUserPassword: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("ResetDBAASRedisUserPassword: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reset-dbaas-redis-user-password")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("ResetDBAASRedisUserPassword: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("ResetDBAASRedisUserPassword: http response: %w", err)
+	}
+
+	bodyresp := &Operation{}
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("ResetDBAASRedisUserPassword: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// Reveal the secrets of a DBaaS Redis user
+func (c Client) RevealDBAASRedisUserPassword(ctx context.Context, serviceName string, username string) (*DBAASUserRedisSecrets, error) {
+	path := fmt.Sprintf("/dbaas-redis/%v/user/%v/password/reveal", serviceName, username)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("RevealDBAASRedisUserPassword: new request: %w", err)
+	}
+	request.Header.Add("User-Agent", UserAgent)
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("RevealDBAASRedisUserPassword: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("RevealDBAASRedisUserPassword: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reveal-dbaas-redis-user-password")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("RevealDBAASRedisUserPassword: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("RevealDBAASRedisUserPassword: http response: %w", err)
+	}
+
+	bodyresp := &DBAASUserRedisSecrets{}
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("RevealDBAASRedisUserPassword: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
 type ListDBAASServicesResponse struct {
 	DBAASServices []DBAASServiceCommon `json:"dbaas-services,omitempty"`
 }
@@ -5323,17 +5784,18 @@ func (c Client) ListDBAASServices(ctx context.Context) (*ListDBAASServicesRespon
 	if err != nil {
 		return nil, fmt.Errorf("ListDBAASServices: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListDBAASServices: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListDBAASServices: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-dbaas-services")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -5378,6 +5840,7 @@ func (c Client) GetDBAASServiceLogs(ctx context.Context, serviceName string, req
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceLogs: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -5385,12 +5848,12 @@ func (c Client) GetDBAASServiceLogs(ctx context.Context, serviceName string, req
 		return nil, fmt.Errorf("GetDBAASServiceLogs: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceLogs: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-service-logs")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -5446,6 +5909,7 @@ func (c Client) GetDBAASServiceMetrics(ctx context.Context, serviceName string, 
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceMetrics: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -5453,12 +5917,12 @@ func (c Client) GetDBAASServiceMetrics(ctx context.Context, serviceName string, 
 		return nil, fmt.Errorf("GetDBAASServiceMetrics: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceMetrics: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-service-metrics")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -5494,17 +5958,18 @@ func (c Client) ListDBAASServiceTypes(ctx context.Context) (*ListDBAASServiceTyp
 	if err != nil {
 		return nil, fmt.Errorf("ListDBAASServiceTypes: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListDBAASServiceTypes: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListDBAASServiceTypes: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-dbaas-service-types")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -5536,17 +6001,18 @@ func (c Client) GetDBAASServiceType(ctx context.Context, serviceTypeName string)
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceType: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceType: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASServiceType: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-service-type")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -5578,17 +6044,18 @@ func (c Client) DeleteDBAASService(ctx context.Context, name string) (*Operation
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDBAASService: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASService: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDBAASService: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dbaas-service")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -5637,17 +6104,18 @@ func (c Client) GetDBAASSettingsGrafana(ctx context.Context) (*GetDBAASSettingsG
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsGrafana: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsGrafana: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsGrafana: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-settings-grafana")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -5726,17 +6194,18 @@ func (c Client) GetDBAASSettingsKafka(ctx context.Context) (*GetDBAASSettingsKaf
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsKafka: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsKafka: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsKafka: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-settings-kafka")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -5785,17 +6254,18 @@ func (c Client) GetDBAASSettingsMysql(ctx context.Context) (*GetDBAASSettingsMys
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsMysql: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsMysql: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsMysql: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-settings-mysql")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -5844,17 +6314,18 @@ func (c Client) GetDBAASSettingsOpensearch(ctx context.Context) (*GetDBAASSettin
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsOpensearch: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsOpensearch: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsOpensearch: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-settings-opensearch")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -5933,17 +6404,18 @@ func (c Client) GetDBAASSettingsPG(ctx context.Context) (*GetDBAASSettingsPGResp
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsPG: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsPG: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsPG: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-settings-pg")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -5992,17 +6464,18 @@ func (c Client) GetDBAASSettingsRedis(ctx context.Context) (*GetDBAASSettingsRed
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsRedis: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsRedis: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASSettingsRedis: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-settings-redis")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6047,6 +6520,7 @@ func (c Client) CreateDBAASTaskMigrationCheck(ctx context.Context, service strin
 	if err != nil {
 		return nil, fmt.Errorf("CreateDBAASTaskMigrationCheck: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -6054,12 +6528,12 @@ func (c Client) CreateDBAASTaskMigrationCheck(ctx context.Context, service strin
 		return nil, fmt.Errorf("CreateDBAASTaskMigrationCheck: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDBAASTaskMigrationCheck: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dbaas-task-migration-check")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6091,17 +6565,18 @@ func (c Client) GetDBAASTask(ctx context.Context, service string, id UUID) (*DBA
 	if err != nil {
 		return nil, fmt.Errorf("GetDBAASTask: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDBAASTask: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDBAASTask: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dbaas-task")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6148,17 +6623,18 @@ func (c Client) ListDeployTargets(ctx context.Context) (*ListDeployTargetsRespon
 	if err != nil {
 		return nil, fmt.Errorf("ListDeployTargets: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListDeployTargets: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListDeployTargets: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-deploy-targets")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6190,17 +6666,18 @@ func (c Client) GetDeployTarget(ctx context.Context, id UUID) (*DeployTarget, er
 	if err != nil {
 		return nil, fmt.Errorf("GetDeployTarget: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDeployTarget: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDeployTarget: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-deploy-target")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6236,17 +6713,18 @@ func (c Client) ListDNSDomains(ctx context.Context) (*ListDNSDomainsResponse, er
 	if err != nil {
 		return nil, fmt.Errorf("ListDNSDomains: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListDNSDomains: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListDNSDomains: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-dns-domains")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6289,6 +6767,7 @@ func (c Client) CreateDNSDomain(ctx context.Context, req CreateDNSDomainRequest)
 	if err != nil {
 		return nil, fmt.Errorf("CreateDNSDomain: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -6296,12 +6775,12 @@ func (c Client) CreateDNSDomain(ctx context.Context, req CreateDNSDomainRequest)
 		return nil, fmt.Errorf("CreateDNSDomain: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDNSDomain: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dns-domain")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6348,17 +6827,18 @@ func (c Client) ListDNSDomainRecords(ctx context.Context, domainID UUID) (*ListD
 	if err != nil {
 		return nil, fmt.Errorf("ListDNSDomainRecords: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListDNSDomainRecords: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListDNSDomainRecords: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-dns-domain-records")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6428,6 +6908,7 @@ func (c Client) CreateDNSDomainRecord(ctx context.Context, domainID UUID, req Cr
 	if err != nil {
 		return nil, fmt.Errorf("CreateDNSDomainRecord: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -6435,12 +6916,12 @@ func (c Client) CreateDNSDomainRecord(ctx context.Context, domainID UUID, req Cr
 		return nil, fmt.Errorf("CreateDNSDomainRecord: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateDNSDomainRecord: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-dns-domain-record")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6472,17 +6953,18 @@ func (c Client) DeleteDNSDomainRecord(ctx context.Context, domainID UUID, record
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDNSDomainRecord: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDNSDomainRecord: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDNSDomainRecord: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dns-domain-record")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6514,17 +6996,18 @@ func (c Client) GetDNSDomainRecord(ctx context.Context, domainID UUID, recordID 
 	if err != nil {
 		return nil, fmt.Errorf("GetDNSDomainRecord: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDNSDomainRecord: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDNSDomainRecord: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dns-domain-record")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6572,6 +7055,7 @@ func (c Client) UpdateDNSDomainRecord(ctx context.Context, domainID UUID, record
 	if err != nil {
 		return nil, fmt.Errorf("UpdateDNSDomainRecord: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -6579,12 +7063,12 @@ func (c Client) UpdateDNSDomainRecord(ctx context.Context, domainID UUID, record
 		return nil, fmt.Errorf("UpdateDNSDomainRecord: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateDNSDomainRecord: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-dns-domain-record")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6616,17 +7100,18 @@ func (c Client) DeleteDNSDomain(ctx context.Context, id UUID) (*Operation, error
 	if err != nil {
 		return nil, fmt.Errorf("DeleteDNSDomain: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteDNSDomain: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteDNSDomain: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-dns-domain")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6658,17 +7143,18 @@ func (c Client) GetDNSDomain(ctx context.Context, id UUID) (*DNSDomain, error) {
 	if err != nil {
 		return nil, fmt.Errorf("GetDNSDomain: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDNSDomain: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDNSDomain: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dns-domain")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6704,17 +7190,18 @@ func (c Client) GetDNSDomainZoneFile(ctx context.Context, id UUID) (*GetDNSDomai
 	if err != nil {
 		return nil, fmt.Errorf("GetDNSDomainZoneFile: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetDNSDomainZoneFile: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetDNSDomainZoneFile: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-dns-domain-zone-file")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6750,17 +7237,18 @@ func (c Client) ListElasticIPS(ctx context.Context) (*ListElasticIPSResponse, er
 	if err != nil {
 		return nil, fmt.Errorf("ListElasticIPS: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListElasticIPS: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListElasticIPS: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-elastic-ips")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6814,6 +7302,7 @@ func (c Client) CreateElasticIP(ctx context.Context, req CreateElasticIPRequest)
 	if err != nil {
 		return nil, fmt.Errorf("CreateElasticIP: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -6821,12 +7310,12 @@ func (c Client) CreateElasticIP(ctx context.Context, req CreateElasticIPRequest)
 		return nil, fmt.Errorf("CreateElasticIP: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateElasticIP: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-elastic-ip")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6858,17 +7347,18 @@ func (c Client) DeleteElasticIP(ctx context.Context, id UUID) (*Operation, error
 	if err != nil {
 		return nil, fmt.Errorf("DeleteElasticIP: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteElasticIP: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteElasticIP: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-elastic-ip")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6900,17 +7390,18 @@ func (c Client) GetElasticIP(ctx context.Context, id UUID) (*ElasticIP, error) {
 	if err != nil {
 		return nil, fmt.Errorf("GetElasticIP: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetElasticIP: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetElasticIP: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-elastic-ip")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -6955,6 +7446,7 @@ func (c Client) UpdateElasticIP(ctx context.Context, id UUID, req UpdateElasticI
 	if err != nil {
 		return nil, fmt.Errorf("UpdateElasticIP: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -6962,12 +7454,12 @@ func (c Client) UpdateElasticIP(ctx context.Context, id UUID, req UpdateElasticI
 		return nil, fmt.Errorf("UpdateElasticIP: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateElasticIP: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-elastic-ip")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -7005,17 +7497,18 @@ func (c Client) ResetElasticIPField(ctx context.Context, id UUID, field ResetEla
 	if err != nil {
 		return nil, fmt.Errorf("ResetElasticIPField: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ResetElasticIPField: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ResetElasticIPField: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reset-elastic-ip-field")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -7057,6 +7550,7 @@ func (c Client) AttachInstanceToElasticIP(ctx context.Context, id UUID, req Atta
 	if err != nil {
 		return nil, fmt.Errorf("AttachInstanceToElasticIP: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -7064,12 +7558,12 @@ func (c Client) AttachInstanceToElasticIP(ctx context.Context, id UUID, req Atta
 		return nil, fmt.Errorf("AttachInstanceToElasticIP: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("AttachInstanceToElasticIP: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "attach-instance-to-elastic-ip")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -7111,6 +7605,7 @@ func (c Client) DetachInstanceFromElasticIP(ctx context.Context, id UUID, req De
 	if err != nil {
 		return nil, fmt.Errorf("DetachInstanceFromElasticIP: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -7118,12 +7613,12 @@ func (c Client) DetachInstanceFromElasticIP(ctx context.Context, id UUID, req De
 		return nil, fmt.Errorf("DetachInstanceFromElasticIP: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DetachInstanceFromElasticIP: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "detach-instance-from-elastic-ip")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -7171,6 +7666,7 @@ func (c Client) ListEvents(ctx context.Context, opts ...ListEventsOpt) ([]Event,
 	if err != nil {
 		return nil, fmt.Errorf("ListEvents: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if len(opts) > 0 {
 		q := request.URL.Query()
@@ -7184,12 +7680,12 @@ func (c Client) ListEvents(ctx context.Context, opts ...ListEventsOpt) ([]Event,
 		return nil, fmt.Errorf("ListEvents: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListEvents: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-events")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -7221,17 +7717,18 @@ func (c Client) GetIAMOrganizationPolicy(ctx context.Context) (*IAMPolicy, error
 	if err != nil {
 		return nil, fmt.Errorf("GetIAMOrganizationPolicy: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetIAMOrganizationPolicy: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetIAMOrganizationPolicy: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-iam-organization-policy")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -7268,6 +7765,7 @@ func (c Client) UpdateIAMOrganizationPolicy(ctx context.Context, req IAMPolicy) 
 	if err != nil {
 		return nil, fmt.Errorf("UpdateIAMOrganizationPolicy: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -7275,12 +7773,12 @@ func (c Client) UpdateIAMOrganizationPolicy(ctx context.Context, req IAMPolicy) 
 		return nil, fmt.Errorf("UpdateIAMOrganizationPolicy: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateIAMOrganizationPolicy: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-iam-organization-policy")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -7327,17 +7825,18 @@ func (c Client) ListIAMRoles(ctx context.Context) (*ListIAMRolesResponse, error)
 	if err != nil {
 		return nil, fmt.Errorf("ListIAMRoles: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListIAMRoles: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListIAMRoles: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-iam-roles")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -7388,6 +7887,7 @@ func (c Client) CreateIAMRole(ctx context.Context, req CreateIAMRoleRequest) (*O
 	if err != nil {
 		return nil, fmt.Errorf("CreateIAMRole: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -7395,12 +7895,12 @@ func (c Client) CreateIAMRole(ctx context.Context, req CreateIAMRoleRequest) (*O
 		return nil, fmt.Errorf("CreateIAMRole: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateIAMRole: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-iam-role")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -7432,17 +7932,18 @@ func (c Client) DeleteIAMRole(ctx context.Context, id UUID) (*Operation, error) 
 	if err != nil {
 		return nil, fmt.Errorf("DeleteIAMRole: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteIAMRole: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteIAMRole: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-iam-role")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -7474,17 +7975,18 @@ func (c Client) GetIAMRole(ctx context.Context, id UUID) (*IAMRole, error) {
 	if err != nil {
 		return nil, fmt.Errorf("GetIAMRole: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetIAMRole: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetIAMRole: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-iam-role")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -7529,6 +8031,7 @@ func (c Client) UpdateIAMRole(ctx context.Context, id UUID, req UpdateIAMRoleReq
 	if err != nil {
 		return nil, fmt.Errorf("UpdateIAMRole: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -7536,12 +8039,12 @@ func (c Client) UpdateIAMRole(ctx context.Context, id UUID, req UpdateIAMRoleReq
 		return nil, fmt.Errorf("UpdateIAMRole: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateIAMRole: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-iam-role")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -7578,6 +8081,7 @@ func (c Client) UpdateIAMRolePolicy(ctx context.Context, id UUID, req IAMPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("UpdateIAMRolePolicy: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -7585,12 +8089,12 @@ func (c Client) UpdateIAMRolePolicy(ctx context.Context, id UUID, req IAMPolicy)
 		return nil, fmt.Errorf("UpdateIAMRolePolicy: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateIAMRolePolicy: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-iam-role-policy")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -7614,6 +8118,14 @@ func (c Client) UpdateIAMRolePolicy(ctx context.Context, id UUID, req IAMPolicy)
 	return bodyresp, nil
 }
 
+// Private Network
+type ListInstancesResponseInstancesPrivateNetworks struct {
+	// Private Network ID
+	ID UUID `json:"id,omitempty"`
+	// Private Network MAC address
+	MACAddress string `json:"mac-address,omitempty"`
+}
+
 // Instance
 type ListInstancesResponseInstances struct {
 	// Instance creation date
@@ -7625,12 +8137,14 @@ type ListInstancesResponseInstances struct {
 	// Instance IPv6 address
 	Ipv6Address string `json:"ipv6-address,omitempty"`
 	Labels      Labels `json:"labels,omitempty"`
+	// Instance MAC address
+	MACAddress string `json:"mac-address,omitempty"`
 	// Resource manager
 	Manager *Manager `json:"manager,omitempty"`
 	// Instance name
 	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
 	// Instance Private Networks
-	PrivateNetworks []PrivateNetwork `json:"private-networks,omitempty"`
+	PrivateNetworks []ListInstancesResponseInstancesPrivateNetworks `json:"private-networks,omitempty"`
 	// Instance public IPv4 address
 	PublicIP           net.IP             `json:"public-ip,omitempty"`
 	PublicIPAssignment PublicIPAssignment `json:"public-ip-assignment,omitempty"`
@@ -7694,6 +8208,7 @@ func (c Client) ListInstances(ctx context.Context, opts ...ListInstancesOpt) (*L
 	if err != nil {
 		return nil, fmt.Errorf("ListInstances: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if len(opts) > 0 {
 		q := request.URL.Query()
@@ -7707,12 +8222,12 @@ func (c Client) ListInstances(ctx context.Context, opts ...ListInstancesOpt) (*L
 		return nil, fmt.Errorf("ListInstances: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListInstances: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-instances")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -7778,6 +8293,7 @@ func (c Client) CreateInstance(ctx context.Context, req CreateInstanceRequest) (
 	if err != nil {
 		return nil, fmt.Errorf("CreateInstance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -7785,12 +8301,12 @@ func (c Client) CreateInstance(ctx context.Context, req CreateInstanceRequest) (
 		return nil, fmt.Errorf("CreateInstance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateInstance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-instance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -7837,17 +8353,18 @@ func (c Client) ListInstancePools(ctx context.Context) (*ListInstancePoolsRespon
 	if err != nil {
 		return nil, fmt.Errorf("ListInstancePools: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListInstancePools: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListInstancePools: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-instance-pools")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -7923,6 +8440,7 @@ func (c Client) CreateInstancePool(ctx context.Context, req CreateInstancePoolRe
 	if err != nil {
 		return nil, fmt.Errorf("CreateInstancePool: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -7930,12 +8448,12 @@ func (c Client) CreateInstancePool(ctx context.Context, req CreateInstancePoolRe
 		return nil, fmt.Errorf("CreateInstancePool: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateInstancePool: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-instance-pool")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -7967,17 +8485,18 @@ func (c Client) DeleteInstancePool(ctx context.Context, id UUID) (*Operation, er
 	if err != nil {
 		return nil, fmt.Errorf("DeleteInstancePool: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteInstancePool: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteInstancePool: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-instance-pool")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8009,17 +8528,18 @@ func (c Client) GetInstancePool(ctx context.Context, id UUID) (*InstancePool, er
 	if err != nil {
 		return nil, fmt.Errorf("GetInstancePool: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetInstancePool: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetInstancePool: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-instance-pool")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8093,6 +8613,7 @@ func (c Client) UpdateInstancePool(ctx context.Context, id UUID, req UpdateInsta
 	if err != nil {
 		return nil, fmt.Errorf("UpdateInstancePool: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -8100,12 +8621,12 @@ func (c Client) UpdateInstancePool(ctx context.Context, id UUID, req UpdateInsta
 		return nil, fmt.Errorf("UpdateInstancePool: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateInstancePool: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-instance-pool")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8152,17 +8673,18 @@ func (c Client) ResetInstancePoolField(ctx context.Context, id UUID, field Reset
 	if err != nil {
 		return nil, fmt.Errorf("ResetInstancePoolField: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ResetInstancePoolField: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ResetInstancePoolField: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reset-instance-pool-field")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8203,6 +8725,7 @@ func (c Client) EvictInstancePoolMembers(ctx context.Context, id UUID, req Evict
 	if err != nil {
 		return nil, fmt.Errorf("EvictInstancePoolMembers: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -8210,12 +8733,12 @@ func (c Client) EvictInstancePoolMembers(ctx context.Context, id UUID, req Evict
 		return nil, fmt.Errorf("EvictInstancePoolMembers: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("EvictInstancePoolMembers: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "evict-instance-pool-members")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8257,6 +8780,7 @@ func (c Client) ScaleInstancePool(ctx context.Context, id UUID, req ScaleInstanc
 	if err != nil {
 		return nil, fmt.Errorf("ScaleInstancePool: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -8264,12 +8788,12 @@ func (c Client) ScaleInstancePool(ctx context.Context, id UUID, req ScaleInstanc
 		return nil, fmt.Errorf("ScaleInstancePool: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ScaleInstancePool: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "scale-instance-pool")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8305,17 +8829,18 @@ func (c Client) ListInstanceTypes(ctx context.Context) (*ListInstanceTypesRespon
 	if err != nil {
 		return nil, fmt.Errorf("ListInstanceTypes: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListInstanceTypes: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListInstanceTypes: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-instance-types")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8347,17 +8872,18 @@ func (c Client) GetInstanceType(ctx context.Context, id UUID) (*InstanceType, er
 	if err != nil {
 		return nil, fmt.Errorf("GetInstanceType: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetInstanceType: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetInstanceType: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-instance-type")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8389,17 +8915,18 @@ func (c Client) DeleteInstance(ctx context.Context, id UUID) (*Operation, error)
 	if err != nil {
 		return nil, fmt.Errorf("DeleteInstance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteInstance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteInstance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-instance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8431,17 +8958,18 @@ func (c Client) GetInstance(ctx context.Context, id UUID) (*Instance, error) {
 	if err != nil {
 		return nil, fmt.Errorf("GetInstance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetInstance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetInstance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-instance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8487,6 +9015,7 @@ func (c Client) UpdateInstance(ctx context.Context, id UUID, req UpdateInstanceR
 	if err != nil {
 		return nil, fmt.Errorf("UpdateInstance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -8494,12 +9023,12 @@ func (c Client) UpdateInstance(ctx context.Context, id UUID, req UpdateInstanceR
 		return nil, fmt.Errorf("UpdateInstance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateInstance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-instance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8537,17 +9066,18 @@ func (c Client) ResetInstanceField(ctx context.Context, id UUID, field ResetInst
 	if err != nil {
 		return nil, fmt.Errorf("ResetInstanceField: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ResetInstanceField: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ResetInstanceField: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reset-instance-field")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8571,28 +9101,26 @@ func (c Client) ResetInstanceField(ctx context.Context, id UUID, field ResetInst
 	return bodyresp, nil
 }
 
-type AddInstanceProtectionResponse struct {
-}
-
 // Set instance destruction protection
-func (c Client) AddInstanceProtection(ctx context.Context, id UUID) (*AddInstanceProtectionResponse, error) {
+func (c Client) AddInstanceProtection(ctx context.Context, id UUID) (*Operation, error) {
 	path := fmt.Sprintf("/instance/%v:add-protection", id)
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("AddInstanceProtection: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("AddInstanceProtection: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("AddInstanceProtection: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "add-instance-protection")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8608,7 +9136,7 @@ func (c Client) AddInstanceProtection(ctx context.Context, id UUID) (*AddInstanc
 		return nil, fmt.Errorf("AddInstanceProtection: http response: %w", err)
 	}
 
-	bodyresp := &AddInstanceProtectionResponse{}
+	bodyresp := &Operation{}
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("AddInstanceProtection: prepare Json response: %w", err)
 	}
@@ -8624,17 +9152,18 @@ func (c Client) CreateSnapshot(ctx context.Context, id UUID) (*Operation, error)
 	if err != nil {
 		return nil, fmt.Errorf("CreateSnapshot: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("CreateSnapshot: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateSnapshot: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-snapshot")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8670,17 +9199,18 @@ func (c Client) RevealInstancePassword(ctx context.Context, id UUID) (*InstanceP
 	if err != nil {
 		return nil, fmt.Errorf("RevealInstancePassword: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("RevealInstancePassword: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("RevealInstancePassword: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reveal-instance-password")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8712,17 +9242,18 @@ func (c Client) RebootInstance(ctx context.Context, id UUID) (*Operation, error)
 	if err != nil {
 		return nil, fmt.Errorf("RebootInstance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("RebootInstance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("RebootInstance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reboot-instance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8746,28 +9277,26 @@ func (c Client) RebootInstance(ctx context.Context, id UUID) (*Operation, error)
 	return bodyresp, nil
 }
 
-type RemoveInstanceProtectionResponse struct {
-}
-
 // Remove instance destruction protection
-func (c Client) RemoveInstanceProtection(ctx context.Context, id UUID) (*RemoveInstanceProtectionResponse, error) {
+func (c Client) RemoveInstanceProtection(ctx context.Context, id UUID) (*Operation, error) {
 	path := fmt.Sprintf("/instance/%v:remove-protection", id)
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("RemoveInstanceProtection: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("RemoveInstanceProtection: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("RemoveInstanceProtection: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "remove-instance-protection")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8783,7 +9312,7 @@ func (c Client) RemoveInstanceProtection(ctx context.Context, id UUID) (*RemoveI
 		return nil, fmt.Errorf("RemoveInstanceProtection: http response: %w", err)
 	}
 
-	bodyresp := &RemoveInstanceProtectionResponse{}
+	bodyresp := &Operation{}
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RemoveInstanceProtection: prepare Json response: %w", err)
 	}
@@ -8811,6 +9340,7 @@ func (c Client) ResetInstance(ctx context.Context, id UUID, req ResetInstanceReq
 	if err != nil {
 		return nil, fmt.Errorf("ResetInstance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -8818,12 +9348,12 @@ func (c Client) ResetInstance(ctx context.Context, id UUID, req ResetInstanceReq
 		return nil, fmt.Errorf("ResetInstance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ResetInstance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reset-instance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8855,17 +9385,18 @@ func (c Client) ResetInstancePassword(ctx context.Context, id UUID) (*Operation,
 	if err != nil {
 		return nil, fmt.Errorf("ResetInstancePassword: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ResetInstancePassword: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ResetInstancePassword: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reset-instance-password")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8907,6 +9438,7 @@ func (c Client) ResizeInstanceDisk(ctx context.Context, id UUID, req ResizeInsta
 	if err != nil {
 		return nil, fmt.Errorf("ResizeInstanceDisk: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -8914,12 +9446,12 @@ func (c Client) ResizeInstanceDisk(ctx context.Context, id UUID, req ResizeInsta
 		return nil, fmt.Errorf("ResizeInstanceDisk: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ResizeInstanceDisk: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "resize-instance-disk")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -8961,6 +9493,7 @@ func (c Client) ScaleInstance(ctx context.Context, id UUID, req ScaleInstanceReq
 	if err != nil {
 		return nil, fmt.Errorf("ScaleInstance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -8968,12 +9501,12 @@ func (c Client) ScaleInstance(ctx context.Context, id UUID, req ScaleInstanceReq
 		return nil, fmt.Errorf("ScaleInstance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ScaleInstance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "scale-instance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9022,6 +9555,7 @@ func (c Client) StartInstance(ctx context.Context, id UUID, req StartInstanceReq
 	if err != nil {
 		return nil, fmt.Errorf("StartInstance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -9029,12 +9563,12 @@ func (c Client) StartInstance(ctx context.Context, id UUID, req StartInstanceReq
 		return nil, fmt.Errorf("StartInstance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("StartInstance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "start-instance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9066,17 +9600,18 @@ func (c Client) StopInstance(ctx context.Context, id UUID) (*Operation, error) {
 	if err != nil {
 		return nil, fmt.Errorf("StopInstance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("StopInstance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("StopInstance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "stop-instance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9119,6 +9654,7 @@ func (c Client) RevertInstanceToSnapshot(ctx context.Context, instanceID UUID, r
 	if err != nil {
 		return nil, fmt.Errorf("RevertInstanceToSnapshot: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -9126,12 +9662,12 @@ func (c Client) RevertInstanceToSnapshot(ctx context.Context, instanceID UUID, r
 		return nil, fmt.Errorf("RevertInstanceToSnapshot: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("RevertInstanceToSnapshot: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "revert-instance-to-snapshot")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9178,17 +9714,18 @@ func (c Client) ListLoadBalancers(ctx context.Context) (*ListLoadBalancersRespon
 	if err != nil {
 		return nil, fmt.Errorf("ListLoadBalancers: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListLoadBalancers: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListLoadBalancers: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-load-balancers")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9233,6 +9770,7 @@ func (c Client) CreateLoadBalancer(ctx context.Context, req CreateLoadBalancerRe
 	if err != nil {
 		return nil, fmt.Errorf("CreateLoadBalancer: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -9240,12 +9778,12 @@ func (c Client) CreateLoadBalancer(ctx context.Context, req CreateLoadBalancerRe
 		return nil, fmt.Errorf("CreateLoadBalancer: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateLoadBalancer: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-load-balancer")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9277,17 +9815,18 @@ func (c Client) DeleteLoadBalancer(ctx context.Context, id UUID) (*Operation, er
 	if err != nil {
 		return nil, fmt.Errorf("DeleteLoadBalancer: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteLoadBalancer: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteLoadBalancer: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-load-balancer")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9319,17 +9858,18 @@ func (c Client) GetLoadBalancer(ctx context.Context, id UUID) (*LoadBalancer, er
 	if err != nil {
 		return nil, fmt.Errorf("GetLoadBalancer: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetLoadBalancer: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetLoadBalancer: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-load-balancer")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9374,6 +9914,7 @@ func (c Client) UpdateLoadBalancer(ctx context.Context, id UUID, req UpdateLoadB
 	if err != nil {
 		return nil, fmt.Errorf("UpdateLoadBalancer: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -9381,12 +9922,12 @@ func (c Client) UpdateLoadBalancer(ctx context.Context, id UUID, req UpdateLoadB
 		return nil, fmt.Errorf("UpdateLoadBalancer: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateLoadBalancer: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-load-balancer")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9456,6 +9997,7 @@ func (c Client) AddServiceToLoadBalancer(ctx context.Context, id UUID, req AddSe
 	if err != nil {
 		return nil, fmt.Errorf("AddServiceToLoadBalancer: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -9463,12 +10005,12 @@ func (c Client) AddServiceToLoadBalancer(ctx context.Context, id UUID, req AddSe
 		return nil, fmt.Errorf("AddServiceToLoadBalancer: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("AddServiceToLoadBalancer: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "add-service-to-load-balancer")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9500,17 +10042,18 @@ func (c Client) DeleteLoadBalancerService(ctx context.Context, id UUID, serviceI
 	if err != nil {
 		return nil, fmt.Errorf("DeleteLoadBalancerService: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteLoadBalancerService: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteLoadBalancerService: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-load-balancer-service")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9542,17 +10085,18 @@ func (c Client) GetLoadBalancerService(ctx context.Context, id UUID, serviceID U
 	if err != nil {
 		return nil, fmt.Errorf("GetLoadBalancerService: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetLoadBalancerService: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetLoadBalancerService: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-load-balancer-service")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9620,6 +10164,7 @@ func (c Client) UpdateLoadBalancerService(ctx context.Context, id UUID, serviceI
 	if err != nil {
 		return nil, fmt.Errorf("UpdateLoadBalancerService: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -9627,12 +10172,12 @@ func (c Client) UpdateLoadBalancerService(ctx context.Context, id UUID, serviceI
 		return nil, fmt.Errorf("UpdateLoadBalancerService: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateLoadBalancerService: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-load-balancer-service")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9670,17 +10215,18 @@ func (c Client) ResetLoadBalancerServiceField(ctx context.Context, id UUID, serv
 	if err != nil {
 		return nil, fmt.Errorf("ResetLoadBalancerServiceField: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ResetLoadBalancerServiceField: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ResetLoadBalancerServiceField: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reset-load-balancer-service-field")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9719,17 +10265,18 @@ func (c Client) ResetLoadBalancerField(ctx context.Context, id UUID, field Reset
 	if err != nil {
 		return nil, fmt.Errorf("ResetLoadBalancerField: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ResetLoadBalancerField: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ResetLoadBalancerField: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reset-load-balancer-field")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9761,17 +10308,18 @@ func (c Client) GetOperation(ctx context.Context, id UUID) (*Operation, error) {
 	if err != nil {
 		return nil, fmt.Errorf("GetOperation: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetOperation: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetOperation: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-operation")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9818,17 +10366,18 @@ func (c Client) ListPrivateNetworks(ctx context.Context) (*ListPrivateNetworksRe
 	if err != nil {
 		return nil, fmt.Errorf("ListPrivateNetworks: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListPrivateNetworks: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListPrivateNetworks: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-private-networks")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9879,6 +10428,7 @@ func (c Client) CreatePrivateNetwork(ctx context.Context, req CreatePrivateNetwo
 	if err != nil {
 		return nil, fmt.Errorf("CreatePrivateNetwork: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -9886,12 +10436,12 @@ func (c Client) CreatePrivateNetwork(ctx context.Context, req CreatePrivateNetwo
 		return nil, fmt.Errorf("CreatePrivateNetwork: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreatePrivateNetwork: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-private-network")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9923,17 +10473,18 @@ func (c Client) DeletePrivateNetwork(ctx context.Context, id UUID) (*Operation, 
 	if err != nil {
 		return nil, fmt.Errorf("DeletePrivateNetwork: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeletePrivateNetwork: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeletePrivateNetwork: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-private-network")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -9965,17 +10516,18 @@ func (c Client) GetPrivateNetwork(ctx context.Context, id UUID) (*PrivateNetwork
 	if err != nil {
 		return nil, fmt.Errorf("GetPrivateNetwork: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetPrivateNetwork: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetPrivateNetwork: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-private-network")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10026,6 +10578,7 @@ func (c Client) UpdatePrivateNetwork(ctx context.Context, id UUID, req UpdatePri
 	if err != nil {
 		return nil, fmt.Errorf("UpdatePrivateNetwork: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -10033,12 +10586,12 @@ func (c Client) UpdatePrivateNetwork(ctx context.Context, id UUID, req UpdatePri
 		return nil, fmt.Errorf("UpdatePrivateNetwork: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdatePrivateNetwork: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-private-network")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10076,17 +10629,18 @@ func (c Client) ResetPrivateNetworkField(ctx context.Context, id UUID, field Res
 	if err != nil {
 		return nil, fmt.Errorf("ResetPrivateNetworkField: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ResetPrivateNetworkField: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ResetPrivateNetworkField: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reset-private-network-field")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10136,6 +10690,7 @@ func (c Client) AttachInstanceToPrivateNetwork(ctx context.Context, id UUID, req
 	if err != nil {
 		return nil, fmt.Errorf("AttachInstanceToPrivateNetwork: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -10143,12 +10698,12 @@ func (c Client) AttachInstanceToPrivateNetwork(ctx context.Context, id UUID, req
 		return nil, fmt.Errorf("AttachInstanceToPrivateNetwork: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("AttachInstanceToPrivateNetwork: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "attach-instance-to-private-network")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10190,6 +10745,7 @@ func (c Client) DetachInstanceFromPrivateNetwork(ctx context.Context, id UUID, r
 	if err != nil {
 		return nil, fmt.Errorf("DetachInstanceFromPrivateNetwork: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -10197,12 +10753,12 @@ func (c Client) DetachInstanceFromPrivateNetwork(ctx context.Context, id UUID, r
 		return nil, fmt.Errorf("DetachInstanceFromPrivateNetwork: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DetachInstanceFromPrivateNetwork: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "detach-instance-from-private-network")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10250,6 +10806,7 @@ func (c Client) UpdatePrivateNetworkInstanceIP(ctx context.Context, id UUID, req
 	if err != nil {
 		return nil, fmt.Errorf("UpdatePrivateNetworkInstanceIP: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -10257,12 +10814,12 @@ func (c Client) UpdatePrivateNetworkInstanceIP(ctx context.Context, id UUID, req
 		return nil, fmt.Errorf("UpdatePrivateNetworkInstanceIP: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdatePrivateNetworkInstanceIP: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-private-network-instance-ip")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10298,17 +10855,18 @@ func (c Client) ListQuotas(ctx context.Context) (*ListQuotasResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("ListQuotas: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListQuotas: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListQuotas: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-quotas")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10340,17 +10898,18 @@ func (c Client) GetQuota(ctx context.Context, entity string) (*Quota, error) {
 	if err != nil {
 		return nil, fmt.Errorf("GetQuota: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetQuota: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetQuota: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-quota")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10382,17 +10941,18 @@ func (c Client) DeleteReverseDNSElasticIP(ctx context.Context, id UUID) (*Operat
 	if err != nil {
 		return nil, fmt.Errorf("DeleteReverseDNSElasticIP: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteReverseDNSElasticIP: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteReverseDNSElasticIP: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-reverse-dns-elastic-ip")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10424,17 +10984,18 @@ func (c Client) GetReverseDNSElasticIP(ctx context.Context, id UUID) (*ReverseDN
 	if err != nil {
 		return nil, fmt.Errorf("GetReverseDNSElasticIP: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetReverseDNSElasticIP: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetReverseDNSElasticIP: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-reverse-dns-elastic-ip")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10475,6 +11036,7 @@ func (c Client) UpdateReverseDNSElasticIP(ctx context.Context, id UUID, req Upda
 	if err != nil {
 		return nil, fmt.Errorf("UpdateReverseDNSElasticIP: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -10482,12 +11044,12 @@ func (c Client) UpdateReverseDNSElasticIP(ctx context.Context, id UUID, req Upda
 		return nil, fmt.Errorf("UpdateReverseDNSElasticIP: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateReverseDNSElasticIP: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-reverse-dns-elastic-ip")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10519,17 +11081,18 @@ func (c Client) DeleteReverseDNSInstance(ctx context.Context, id UUID) (*Operati
 	if err != nil {
 		return nil, fmt.Errorf("DeleteReverseDNSInstance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteReverseDNSInstance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteReverseDNSInstance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-reverse-dns-instance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10561,17 +11124,18 @@ func (c Client) GetReverseDNSInstance(ctx context.Context, id UUID) (*ReverseDNS
 	if err != nil {
 		return nil, fmt.Errorf("GetReverseDNSInstance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetReverseDNSInstance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetReverseDNSInstance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-reverse-dns-instance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10612,6 +11176,7 @@ func (c Client) UpdateReverseDNSInstance(ctx context.Context, id UUID, req Updat
 	if err != nil {
 		return nil, fmt.Errorf("UpdateReverseDNSInstance: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -10619,12 +11184,12 @@ func (c Client) UpdateReverseDNSInstance(ctx context.Context, id UUID, req Updat
 		return nil, fmt.Errorf("UpdateReverseDNSInstance: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateReverseDNSInstance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-reverse-dns-instance")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10689,6 +11254,7 @@ func (c Client) ListSecurityGroups(ctx context.Context, opts ...ListSecurityGrou
 	if err != nil {
 		return nil, fmt.Errorf("ListSecurityGroups: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if len(opts) > 0 {
 		q := request.URL.Query()
@@ -10702,12 +11268,12 @@ func (c Client) ListSecurityGroups(ctx context.Context, opts ...ListSecurityGrou
 		return nil, fmt.Errorf("ListSecurityGroups: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListSecurityGroups: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-security-groups")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10751,6 +11317,7 @@ func (c Client) CreateSecurityGroup(ctx context.Context, req CreateSecurityGroup
 	if err != nil {
 		return nil, fmt.Errorf("CreateSecurityGroup: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -10758,12 +11325,12 @@ func (c Client) CreateSecurityGroup(ctx context.Context, req CreateSecurityGroup
 		return nil, fmt.Errorf("CreateSecurityGroup: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateSecurityGroup: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-security-group")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10795,17 +11362,18 @@ func (c Client) DeleteSecurityGroup(ctx context.Context, id UUID) (*Operation, e
 	if err != nil {
 		return nil, fmt.Errorf("DeleteSecurityGroup: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteSecurityGroup: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteSecurityGroup: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-security-group")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10837,17 +11405,18 @@ func (c Client) GetSecurityGroup(ctx context.Context, id UUID) (*SecurityGroup, 
 	if err != nil {
 		return nil, fmt.Errorf("GetSecurityGroup: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetSecurityGroup: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetSecurityGroup: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-security-group")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10929,6 +11498,7 @@ func (c Client) AddRuleToSecurityGroup(ctx context.Context, id UUID, req AddRule
 	if err != nil {
 		return nil, fmt.Errorf("AddRuleToSecurityGroup: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -10936,12 +11506,12 @@ func (c Client) AddRuleToSecurityGroup(ctx context.Context, id UUID, req AddRule
 		return nil, fmt.Errorf("AddRuleToSecurityGroup: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("AddRuleToSecurityGroup: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "add-rule-to-security-group")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -10973,17 +11543,18 @@ func (c Client) DeleteRuleFromSecurityGroup(ctx context.Context, id UUID, ruleID
 	if err != nil {
 		return nil, fmt.Errorf("DeleteRuleFromSecurityGroup: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteRuleFromSecurityGroup: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteRuleFromSecurityGroup: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-rule-from-security-group")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -11025,6 +11596,7 @@ func (c Client) AddExternalSourceToSecurityGroup(ctx context.Context, id UUID, r
 	if err != nil {
 		return nil, fmt.Errorf("AddExternalSourceToSecurityGroup: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -11032,12 +11604,12 @@ func (c Client) AddExternalSourceToSecurityGroup(ctx context.Context, id UUID, r
 		return nil, fmt.Errorf("AddExternalSourceToSecurityGroup: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("AddExternalSourceToSecurityGroup: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "add-external-source-to-security-group")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -11079,6 +11651,7 @@ func (c Client) AttachInstanceToSecurityGroup(ctx context.Context, id UUID, req 
 	if err != nil {
 		return nil, fmt.Errorf("AttachInstanceToSecurityGroup: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -11086,12 +11659,12 @@ func (c Client) AttachInstanceToSecurityGroup(ctx context.Context, id UUID, req 
 		return nil, fmt.Errorf("AttachInstanceToSecurityGroup: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("AttachInstanceToSecurityGroup: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "attach-instance-to-security-group")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -11133,6 +11706,7 @@ func (c Client) DetachInstanceFromSecurityGroup(ctx context.Context, id UUID, re
 	if err != nil {
 		return nil, fmt.Errorf("DetachInstanceFromSecurityGroup: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -11140,12 +11714,12 @@ func (c Client) DetachInstanceFromSecurityGroup(ctx context.Context, id UUID, re
 		return nil, fmt.Errorf("DetachInstanceFromSecurityGroup: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DetachInstanceFromSecurityGroup: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "detach-instance-from-security-group")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -11187,6 +11761,7 @@ func (c Client) RemoveExternalSourceFromSecurityGroup(ctx context.Context, id UU
 	if err != nil {
 		return nil, fmt.Errorf("RemoveExternalSourceFromSecurityGroup: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -11194,12 +11769,12 @@ func (c Client) RemoveExternalSourceFromSecurityGroup(ctx context.Context, id UU
 		return nil, fmt.Errorf("RemoveExternalSourceFromSecurityGroup: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("RemoveExternalSourceFromSecurityGroup: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "remove-external-source-from-security-group")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -11246,17 +11821,18 @@ func (c Client) ListSKSClusters(ctx context.Context) (*ListSKSClustersResponse, 
 	if err != nil {
 		return nil, fmt.Errorf("ListSKSClusters: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListSKSClusters: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListSKSClusters: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-sks-clusters")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -11327,6 +11903,7 @@ func (c Client) CreateSKSCluster(ctx context.Context, req CreateSKSClusterReques
 	if err != nil {
 		return nil, fmt.Errorf("CreateSKSCluster: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -11334,12 +11911,12 @@ func (c Client) CreateSKSCluster(ctx context.Context, req CreateSKSClusterReques
 		return nil, fmt.Errorf("CreateSKSCluster: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateSKSCluster: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-sks-cluster")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -11371,17 +11948,18 @@ func (c Client) ListSKSClusterDeprecatedResources(ctx context.Context, id UUID) 
 	if err != nil {
 		return nil, fmt.Errorf("ListSKSClusterDeprecatedResources: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListSKSClusterDeprecatedResources: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListSKSClusterDeprecatedResources: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-sks-cluster-deprecated-resources")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -11422,6 +12000,7 @@ func (c Client) GenerateSKSClusterKubeconfig(ctx context.Context, id UUID, req S
 	if err != nil {
 		return nil, fmt.Errorf("GenerateSKSClusterKubeconfig: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -11429,12 +12008,12 @@ func (c Client) GenerateSKSClusterKubeconfig(ctx context.Context, id UUID, req S
 		return nil, fmt.Errorf("GenerateSKSClusterKubeconfig: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GenerateSKSClusterKubeconfig: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "generate-sks-cluster-kubeconfig")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -11478,6 +12057,7 @@ func (c Client) ListSKSClusterVersions(ctx context.Context, opts ...ListSKSClust
 	if err != nil {
 		return nil, fmt.Errorf("ListSKSClusterVersions: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if len(opts) > 0 {
 		q := request.URL.Query()
@@ -11491,12 +12071,12 @@ func (c Client) ListSKSClusterVersions(ctx context.Context, opts ...ListSKSClust
 		return nil, fmt.Errorf("ListSKSClusterVersions: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListSKSClusterVersions: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-sks-cluster-versions")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -11528,17 +12108,18 @@ func (c Client) DeleteSKSCluster(ctx context.Context, id UUID) (*Operation, erro
 	if err != nil {
 		return nil, fmt.Errorf("DeleteSKSCluster: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteSKSCluster: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteSKSCluster: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-sks-cluster")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -11570,17 +12151,18 @@ func (c Client) GetSKSCluster(ctx context.Context, id UUID) (*SKSCluster, error)
 	if err != nil {
 		return nil, fmt.Errorf("GetSKSCluster: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetSKSCluster: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetSKSCluster: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-sks-cluster")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -11631,6 +12213,7 @@ func (c Client) UpdateSKSCluster(ctx context.Context, id UUID, req UpdateSKSClus
 	if err != nil {
 		return nil, fmt.Errorf("UpdateSKSCluster: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -11638,12 +12221,12 @@ func (c Client) UpdateSKSCluster(ctx context.Context, id UUID, req UpdateSKSClus
 		return nil, fmt.Errorf("UpdateSKSCluster: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateSKSCluster: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-sks-cluster")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -11687,17 +12270,18 @@ func (c Client) GetSKSClusterAuthorityCert(ctx context.Context, id UUID, authori
 	if err != nil {
 		return nil, fmt.Errorf("GetSKSClusterAuthorityCert: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetSKSClusterAuthorityCert: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetSKSClusterAuthorityCert: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-sks-cluster-authority-cert")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -11731,17 +12315,18 @@ func (c Client) GetSKSClusterInspection(ctx context.Context, id UUID) (*GetSKSCl
 	if err != nil {
 		return nil, fmt.Errorf("GetSKSClusterInspection: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetSKSClusterInspection: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetSKSClusterInspection: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-sks-cluster-inspection")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -11807,6 +12392,7 @@ func (c Client) CreateSKSNodepool(ctx context.Context, id UUID, req CreateSKSNod
 	if err != nil {
 		return nil, fmt.Errorf("CreateSKSNodepool: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -11814,12 +12400,12 @@ func (c Client) CreateSKSNodepool(ctx context.Context, id UUID, req CreateSKSNod
 		return nil, fmt.Errorf("CreateSKSNodepool: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CreateSKSNodepool: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-sks-nodepool")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -11851,17 +12437,18 @@ func (c Client) DeleteSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UU
 	if err != nil {
 		return nil, fmt.Errorf("DeleteSKSNodepool: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteSKSNodepool: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteSKSNodepool: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-sks-nodepool")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -11893,17 +12480,18 @@ func (c Client) GetSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UUID)
 	if err != nil {
 		return nil, fmt.Errorf("GetSKSNodepool: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetSKSNodepool: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetSKSNodepool: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-sks-nodepool")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -11963,6 +12551,7 @@ func (c Client) UpdateSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UU
 	if err != nil {
 		return nil, fmt.Errorf("UpdateSKSNodepool: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -11970,12 +12559,12 @@ func (c Client) UpdateSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UU
 		return nil, fmt.Errorf("UpdateSKSNodepool: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateSKSNodepool: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-sks-nodepool")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12018,17 +12607,18 @@ func (c Client) ResetSKSNodepoolField(ctx context.Context, id UUID, sksNodepoolI
 	if err != nil {
 		return nil, fmt.Errorf("ResetSKSNodepoolField: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ResetSKSNodepoolField: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ResetSKSNodepoolField: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reset-sks-nodepool-field")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12069,6 +12659,7 @@ func (c Client) EvictSKSNodepoolMembers(ctx context.Context, id UUID, sksNodepoo
 	if err != nil {
 		return nil, fmt.Errorf("EvictSKSNodepoolMembers: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -12076,12 +12667,12 @@ func (c Client) EvictSKSNodepoolMembers(ctx context.Context, id UUID, sksNodepoo
 		return nil, fmt.Errorf("EvictSKSNodepoolMembers: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("EvictSKSNodepoolMembers: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "evict-sks-nodepool-members")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12123,6 +12714,7 @@ func (c Client) ScaleSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UUI
 	if err != nil {
 		return nil, fmt.Errorf("ScaleSKSNodepool: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -12130,12 +12722,12 @@ func (c Client) ScaleSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UUI
 		return nil, fmt.Errorf("ScaleSKSNodepool: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ScaleSKSNodepool: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "scale-sks-nodepool")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12167,17 +12759,18 @@ func (c Client) RotateSKSCcmCredentials(ctx context.Context, id UUID) (*Operatio
 	if err != nil {
 		return nil, fmt.Errorf("RotateSKSCcmCredentials: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("RotateSKSCcmCredentials: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("RotateSKSCcmCredentials: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "rotate-sks-ccm-credentials")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12209,17 +12802,18 @@ func (c Client) RotateSKSOperatorsCA(ctx context.Context, id UUID) (*Operation, 
 	if err != nil {
 		return nil, fmt.Errorf("RotateSKSOperatorsCA: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("RotateSKSOperatorsCA: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("RotateSKSOperatorsCA: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "rotate-sks-operators-ca")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12261,6 +12855,7 @@ func (c Client) UpgradeSKSCluster(ctx context.Context, id UUID, req UpgradeSKSCl
 	if err != nil {
 		return nil, fmt.Errorf("UpgradeSKSCluster: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -12268,12 +12863,12 @@ func (c Client) UpgradeSKSCluster(ctx context.Context, id UUID, req UpgradeSKSCl
 		return nil, fmt.Errorf("UpgradeSKSCluster: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpgradeSKSCluster: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "upgrade-sks-cluster")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12305,17 +12900,18 @@ func (c Client) UpgradeSKSClusterServiceLevel(ctx context.Context, id UUID) (*Op
 	if err != nil {
 		return nil, fmt.Errorf("UpgradeSKSClusterServiceLevel: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("UpgradeSKSClusterServiceLevel: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpgradeSKSClusterServiceLevel: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "upgrade-sks-cluster-service-level")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12354,17 +12950,18 @@ func (c Client) ResetSKSClusterField(ctx context.Context, id UUID, field ResetSK
 	if err != nil {
 		return nil, fmt.Errorf("ResetSKSClusterField: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ResetSKSClusterField: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ResetSKSClusterField: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reset-sks-cluster-field")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12411,17 +13008,18 @@ func (c Client) ListSnapshots(ctx context.Context) (*ListSnapshotsResponse, erro
 	if err != nil {
 		return nil, fmt.Errorf("ListSnapshots: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListSnapshots: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListSnapshots: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-snapshots")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12453,17 +13051,18 @@ func (c Client) DeleteSnapshot(ctx context.Context, id UUID) (*Operation, error)
 	if err != nil {
 		return nil, fmt.Errorf("DeleteSnapshot: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteSnapshot: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteSnapshot: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-snapshot")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12495,17 +13094,18 @@ func (c Client) GetSnapshot(ctx context.Context, id UUID) (*Snapshot, error) {
 	if err != nil {
 		return nil, fmt.Errorf("GetSnapshot: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetSnapshot: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetSnapshot: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-snapshot")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12537,17 +13137,18 @@ func (c Client) ExportSnapshot(ctx context.Context, id UUID) (*Operation, error)
 	if err != nil {
 		return nil, fmt.Errorf("ExportSnapshot: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ExportSnapshot: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ExportSnapshot: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "export-snapshot")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12597,6 +13198,7 @@ func (c Client) PromoteSnapshotToTemplate(ctx context.Context, id UUID, req Prom
 	if err != nil {
 		return nil, fmt.Errorf("PromoteSnapshotToTemplate: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -12604,12 +13206,12 @@ func (c Client) PromoteSnapshotToTemplate(ctx context.Context, id UUID, req Prom
 		return nil, fmt.Errorf("PromoteSnapshotToTemplate: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("PromoteSnapshotToTemplate: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "promote-snapshot-to-template")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12645,17 +13247,18 @@ func (c Client) ListSOSBucketsUsage(ctx context.Context) (*ListSOSBucketsUsageRe
 	if err != nil {
 		return nil, fmt.Errorf("ListSOSBucketsUsage: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListSOSBucketsUsage: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListSOSBucketsUsage: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-sos-buckets-usage")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12699,6 +13302,7 @@ func (c Client) GetSOSPresignedURL(ctx context.Context, bucket string, opts ...G
 	if err != nil {
 		return nil, fmt.Errorf("GetSOSPresignedURL: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if len(opts) > 0 {
 		q := request.URL.Query()
@@ -12712,12 +13316,12 @@ func (c Client) GetSOSPresignedURL(ctx context.Context, bucket string, opts ...G
 		return nil, fmt.Errorf("GetSOSPresignedURL: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetSOSPresignedURL: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-sos-presigned-url")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12753,17 +13357,18 @@ func (c Client) ListSSHKeys(ctx context.Context) (*ListSSHKeysResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("ListSSHKeys: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListSSHKeys: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListSSHKeys: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-ssh-keys")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12807,6 +13412,7 @@ func (c Client) RegisterSSHKey(ctx context.Context, req RegisterSSHKeyRequest) (
 	if err != nil {
 		return nil, fmt.Errorf("RegisterSSHKey: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -12814,12 +13420,12 @@ func (c Client) RegisterSSHKey(ctx context.Context, req RegisterSSHKeyRequest) (
 		return nil, fmt.Errorf("RegisterSSHKey: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("RegisterSSHKey: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "register-ssh-key")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12851,17 +13457,18 @@ func (c Client) DeleteSSHKey(ctx context.Context, name string) (*Operation, erro
 	if err != nil {
 		return nil, fmt.Errorf("DeleteSSHKey: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteSSHKey: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteSSHKey: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-ssh-key")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12893,17 +13500,18 @@ func (c Client) GetSSHKey(ctx context.Context, name string) (*SSHKey, error) {
 	if err != nil {
 		return nil, fmt.Errorf("GetSSHKey: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetSSHKey: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetSSHKey: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-ssh-key")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -12971,6 +13579,7 @@ func (c Client) ListTemplates(ctx context.Context, opts ...ListTemplatesOpt) (*L
 	if err != nil {
 		return nil, fmt.Errorf("ListTemplates: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if len(opts) > 0 {
 		q := request.URL.Query()
@@ -12984,12 +13593,12 @@ func (c Client) ListTemplates(ctx context.Context, opts ...ListTemplatesOpt) (*L
 		return nil, fmt.Errorf("ListTemplates: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListTemplates: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-templates")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -13060,6 +13669,7 @@ func (c Client) RegisterTemplate(ctx context.Context, req RegisterTemplateReques
 	if err != nil {
 		return nil, fmt.Errorf("RegisterTemplate: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -13067,12 +13677,12 @@ func (c Client) RegisterTemplate(ctx context.Context, req RegisterTemplateReques
 		return nil, fmt.Errorf("RegisterTemplate: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("RegisterTemplate: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "register-template")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -13104,17 +13714,18 @@ func (c Client) DeleteTemplate(ctx context.Context, id UUID) (*Operation, error)
 	if err != nil {
 		return nil, fmt.Errorf("DeleteTemplate: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("DeleteTemplate: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("DeleteTemplate: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-template")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -13146,17 +13757,18 @@ func (c Client) GetTemplate(ctx context.Context, id UUID) (*Template, error) {
 	if err != nil {
 		return nil, fmt.Errorf("GetTemplate: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("GetTemplate: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("GetTemplate: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-template")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -13198,6 +13810,7 @@ func (c Client) CopyTemplate(ctx context.Context, id UUID, req CopyTemplateReque
 	if err != nil {
 		return nil, fmt.Errorf("CopyTemplate: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -13205,12 +13818,12 @@ func (c Client) CopyTemplate(ctx context.Context, id UUID, req CopyTemplateReque
 		return nil, fmt.Errorf("CopyTemplate: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("CopyTemplate: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "copy-template")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -13254,6 +13867,7 @@ func (c Client) UpdateTemplate(ctx context.Context, id UUID, req UpdateTemplateR
 	if err != nil {
 		return nil, fmt.Errorf("UpdateTemplate: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	request.Header.Add("Content-Type", "application/json")
 
@@ -13261,12 +13875,12 @@ func (c Client) UpdateTemplate(ctx context.Context, id UUID, req UpdateTemplateR
 		return nil, fmt.Errorf("UpdateTemplate: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("UpdateTemplate: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-template")
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -13302,17 +13916,18 @@ func (c Client) ListZones(ctx context.Context) (*ListZonesResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("ListZones: new request: %w", err)
 	}
+	request.Header.Add("User-Agent", UserAgent)
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListZones: execute request editors: %w", err)
 	}
 
-	if c.trace {
-		dumpRequest(request)
-	}
-
 	if err := c.signRequest(request); err != nil {
 		return nil, fmt.Errorf("ListZones: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-zones")
 	}
 
 	response, err := c.httpClient.Do(request)

--- a/vendor/github.com/exoscale/egoscale/v3/schemas.go
+++ b/vendor/github.com/exoscale/egoscale/v3/schemas.go
@@ -111,7 +111,7 @@ type BlockStorageSnapshot struct {
 	// Snapshot name
 	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
 	// Snapshot size
-	Size int64 `json:"size,omitempty" validate:"omitempty,gte=10,lte=10240"`
+	Size int64 `json:"size,omitempty" validate:"omitempty,gte=10"`
 	// Snapshot state
 	State BlockStorageSnapshotState `json:"state,omitempty"`
 }
@@ -152,7 +152,7 @@ type BlockStorageVolume struct {
 	// Volume name
 	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
 	// Volume size
-	Size int64 `json:"size,omitempty" validate:"omitempty,gte=10,lte=10240"`
+	Size int64 `json:"size,omitempty" validate:"omitempty,gte=10"`
 	// Volume state
 	State BlockStorageVolumeState `json:"state,omitempty"`
 }
@@ -1247,7 +1247,52 @@ type DBAASTask struct {
 	TaskType    string                 `json:"task-type,omitempty"`
 }
 
+// Kafka User secrets
+type DBAASUserKafkaSecrets struct {
+	// Kafka certificate
+	AccessCert       string    `json:"access-cert,omitempty"`
+	AccessCertExpiry time.Time `json:"access-cert-expiry,omitempty"`
+	// Kafka access key
+	AccessKey string `json:"access-key,omitempty"`
+	// Kafka password
+	Password string `json:"password,omitempty"`
+	// Kafka username
+	Username string `json:"username,omitempty"`
+}
+
+// MySQL User secrets
+type DBAASUserMysqlSecrets struct {
+	// MySQL password
+	Password string `json:"password,omitempty"`
+	// MySQL username
+	Username string `json:"username,omitempty"`
+}
+
+// Opensearch User secrets
+type DBAASUserOpensearchSecrets struct {
+	// Opensearch password
+	Password string `json:"password,omitempty"`
+	// Opensearch username
+	Username string `json:"username,omitempty"`
+}
+
 type DBAASUserPassword string
+
+// Postgres User secrets
+type DBAASUserPostgresSecrets struct {
+	// Postgres password
+	Password string `json:"password,omitempty"`
+	// Postgres username
+	Username string `json:"username,omitempty"`
+}
+
+// Redis User secrets
+type DBAASUserRedisSecrets struct {
+	// Redis password
+	Password string `json:"password,omitempty"`
+	// Redis username
+	Username string `json:"username,omitempty"`
+}
 
 type DBAASUserUsername string
 
@@ -1496,14 +1541,18 @@ type Event struct {
 	GetParams map[string]any `json:"get-params,omitempty"`
 	// Operation handler name
 	Handler string `json:"handler,omitempty"`
+	// IAM API Key
+	IAMAPIKey *IAMAPIKey `json:"iam-api-key,omitempty"`
+	// IAM Role
+	IAMRole *IAMRole `json:"iam-role,omitempty"`
 	// Operation message
 	Message string `json:"message,omitempty"`
 	// URI path parameters (free form map)
 	PathParams map[string]any `json:"path-params,omitempty"`
-	// Client IP address
-	RemoteAddr string `json:"remote-addr,omitempty"`
 	// Operation unique identifier
 	RequestID string `json:"request-id,omitempty"`
+	// Client IP address
+	SourceIP string `json:"source-ip,omitempty"`
 	// Operation HTTP status
 	Status int64 `json:"status,omitempty" validate:"omitempty,gt=0"`
 	// Time at which the event happened, millisecond resolution
@@ -1594,6 +1643,14 @@ type IAMServicePolicyRule struct {
 	Resources  []string                   `json:"resources,omitempty"`
 }
 
+// Private Network
+type InstancePrivateNetworks struct {
+	// Private Network ID
+	ID UUID `json:"id,omitempty"`
+	// Private Network MAC address
+	MACAddress string `json:"mac-address,omitempty"`
+}
+
 // Instance
 type Instance struct {
 	// Instance Anti-affinity Groups
@@ -1613,12 +1670,14 @@ type Instance struct {
 	// Instance IPv6 address
 	Ipv6Address string `json:"ipv6-address,omitempty"`
 	Labels      Labels `json:"labels,omitempty"`
+	// Instance MAC address
+	MACAddress string `json:"mac-address,omitempty"`
 	// Resource manager
 	Manager *Manager `json:"manager,omitempty"`
 	// Instance name
 	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
 	// Instance Private Networks
-	PrivateNetworks []PrivateNetwork `json:"private-networks,omitempty"`
+	PrivateNetworks []InstancePrivateNetworks `json:"private-networks,omitempty"`
 	// Instance public IPv4 address
 	PublicIP           net.IP             `json:"public-ip,omitempty"`
 	PublicIPAssignment PublicIPAssignment `json:"public-ip-assignment,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.1
 ## explicit; go 1.16
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.102.4-0.20240327105104-a8a8cb197ac6
+# github.com/exoscale/egoscale v0.102.4-0.20240411151757-e59fc2d046ea
 ## explicit; go 1.20
 github.com/exoscale/egoscale/v2
 github.com/exoscale/egoscale/v2/api

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.1
 ## explicit; go 1.16
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.102.4-0.20240223092311-76285ea0504f
+# github.com/exoscale/egoscale v0.102.4-0.20240411151757-e59fc2d046ea
 ## explicit; go 1.20
 github.com/exoscale/egoscale/v2
 github.com/exoscale/egoscale/v2/api


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

```BASH
EXOSCALE_TRACE=true go run main.go c bs get XXXXX
>>> Operation: list-zones
GET /v2/zone HTTP/1.1
Host: api-ch-gva-2.exoscale.com
Authorization: EXO2-HMAC-SHA256 credential=XXXXXXXX
User-Agent: egoscale/0.102.3 (go1.21.3; linux/amd64)


<<< HTTP/2.0 200 OK
Connection: close
Content-Type: application/json; charset=utf-8
Date: Fri, 12 Apr 2024 13:16:59 GMT
Exo-Cm-Hash: XXXXXXX
Referrer-Policy: no-referrer-when-downgrade
Strict-Transport-Security: max-age=31557600; includeSubDomains; preload
X-Content-Type-Options: nosniff always
X-Xss-Protection: 1; mode=block always

{"zones":[{"id":"1128bd56-b4d9-4ac6-a7b9-c715b187ce11","name":"ch-gva-2","api-endpoint":"https://api-ch-gva-2.exoscale.com/v2","sos-endpoint":"https://sos-ch-gva-2.exo.io"},{"id":"91e5e9e4-c9ed-4b76-bee4-427004b3baf9","name":"ch-dk-2","api-endpoint":"https://api-ch-dk-2.exoscale.com/v2","sos-endpoint":"https://sos-ch-dk-2.exo.io"},{"id":"4da1b188-dcd6-4ff5-b7fd-bde984055548","name":"at-vie-1","api-endpoint":"https://api-at-vie-1.exoscale.com/v2","sos-endpoint":"https://sos-at-vie-1.exo.io"},{"id":"35eb7739-d19e-45f7-a581-4687c54d6d02","name":"de-fra-1","api-endpoint":"https://api-de-fra-1.exoscale.com/v2","sos-endpoint":"https://sos-de-fra-1.exo.io"},{"id":"70e5f8b1-0b2c-4457-a5e0-88bcf1f3db68","name":"bg-sof-1","api-endpoint":"https://api-bg-sof-1.exoscale.com/v2","sos-endpoint":"https://sos-bg-sof-1.exo.io"},{"id":"85664334-0fd5-47bd-94a1-b4f40b1d2eb7","name":"de-muc-1","api-endpoint":"https://api-de-muc-1.exoscale.com/v2","sos-endpoint":"https://sos-de-muc-1.exo.io"},{"id":"97e5df2d-0da5-4914-a9a2-97af3fc7180d","name":"at-vie-2","api-endpoint":"https://api-at-vie-2.exoscale.com/v2","sos-endpoint":"https://sos-at-vie-2.exo.io"}]}
----------------------------------------------------------------------
>>> Operation: list-block-storage-volumes
GET /v2/block-storage HTTP/1.1
Host: api-ch-gva-2.exoscale.com
Authorization: EXO2-HMAC-SHA256 credential=XXXXX
User-Agent: egoscale/0.102.3 (go1.21.3; linux/amd64)


<<< HTTP/2.0 200 OK
Connection: close
Content-Type: application/json; charset=utf-8
Date: Fri, 12 Apr 2024 13:16:59 GMT
Exo-Cm-Hash: XXXXX
Referrer-Policy: no-referrer-when-downgrade
Strict-Transport-Security: max-age=31557600; includeSubDomains; preload
X-Content-Type-Options: nosniff always
X-Xss-Protection: 1; mode=block always

JSON XXXXXXX
----------------------------------------------------------------------
┼─────────────────────────┼──────────────────────────────────────────┼
│  BLOCK STORAGE VOLUME   │                                          │
┼─────────────────────────┼──────────────────────────────────────────┼
│ Block Storage Snapshots │ n/a                                      │
│ Blocksize               │ 4096                                     │
│ Created AT              │ 2024-04-08 08:28:08 +0000 UTC            │
│ ID                      │ XXXXX     │
│ Instance                │ n/a                                      │
│ Name                    │ XXXXX │
│ Size                    │ 10 GiB                                   │
│ State                   │ detached                                 │
┼─────────────────────────┼──────────────────────────────────────────┼
```

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

<!--
Describe the tests you did
-->
