### PR TITLE
storage presign: fix panic when parsing arg[0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## Unrelease
+## Unreleased
 
 - Block Storage: Fix volume show with snapshot #589
+- storage presign: fix panic when parsing arg[0] #590 
 
 ## 1.77.1
 

--- a/cmd/storage_presign.go
+++ b/cmd/storage_presign.go
@@ -41,6 +41,9 @@ var storagePresignCmd = &cobra.Command{
 		}
 
 		parts := strings.SplitN(args[0], "/", 2)
+		if len(parts) < 2 {
+			return fmt.Errorf("invalid object URL: %q", args[0])
+		}
 		bucket, key = parts[0], parts[1]
 
 		storage, err := sos.NewStorageClient(


### PR DESCRIPTION
# Description
Fixes https://github.com/exoscale/cli/issues/588

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing
Instead of
```shell
> exo storage presign 2dsofijc02q9jd
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/exoscale/cli/cmd.init.func65(0x29651a0, {0xc0009466f0, 0x1, 0x16e0fff?})
	github.com/exoscale/cli/cmd/storage_presign.go:44 +0x425
github.com/spf13/cobra.(*Command).execute(0x29651a0, {0xc000932480, 0x3, 0x4})
	github.com/spf13/cobra@v1.3.0/command.go:856 +0x69d
github.com/spf13/cobra.(*Command).ExecuteC(0x29610a0)
	github.com/spf13/cobra@v1.3.0/command.go:974 +0x38d
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.3.0/command.go:902
github.com/exoscale/cli/cmd.Execute({0x1eeae38?, 0x2882900?}, {0x1eeb668?, 0xc0000061c0?})
	github.com/exoscale/cli/cmd/root.go:81 +0x1ed
main.main()
	github.com/exoscale/cli/main.go:34 +0x3c
```
we now get
```shell
> exo storage presign 2dsofijc02q9jd
error: invalid object URL: "2dsofijc02q9jd"
```
