### PR TITLE
Display the two new blockstorage quotas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Block Storage: Show all quotas #591
 - Block Storage: Fix volume show with snapshot #589
 - storage presign: fix panic when parsing arg[0] #590 
 

--- a/cmd/limits.go
+++ b/cmd/limits.go
@@ -25,6 +25,8 @@ const (
 	limitSKSClusters         = "sks-cluster"
 	limitSOSBuckets          = "bucket"
 	limitBlockStorageVolumes = "block-storage-volume"
+	limitBlockStorage        = "block-storage"
+	limitBlockStorageMaxSize = "block-storage-max-size"
 )
 
 type LimitsItemOutput struct {
@@ -60,6 +62,8 @@ Supported output template annotations: %s`,
 			limitSKSClusters:         "SKS clusters",
 			limitSOSBuckets:          "SOS buckets",
 			limitBlockStorageVolumes: "Block Storage Volumes",
+			limitBlockStorage:        "Block Storage cumulative size",
+			limitBlockStorageMaxSize: "Max Size of Block Storage Volumes",
 		}
 
 		out := LimitsOutput{}


### PR DESCRIPTION
# Description
We introduced two new quotas for block storage:
- One for the cumulative size of all block storage volumes of an org
- One for the maximum size of a block storage volume 

Before
```
❯ go run . limits    
┼────────────────────────────┼──────┼──────┼
│          RESOURCE          │ USED │ MAX  │
┼────────────────────────────┼──────┼──────┼
│ Elastic IP addresses       │ 0    │ 10   │
│ IAM API keys               │ 4    │ 100  │
│ Compute instance GPUs      │ 0    │ 1    │
│ Private networks           │ 0    │ 32   │
│ Compute instances          │ 33   │ 50   │
│ Compute instance templates │ 0    │ 30   │
│ Network Load Balancers     │ 0    │ 5    │
│ Compute instance snapshots │ 0    │ 30   │
│ SKS clusters               │ 0    │ 3    │
│ SOS buckets                │ 1    │ 100  │
│ Block Storage Volumes      │ 33   │ 2000 │
┼────────────────────────────┼──────┼──────┼
```

After:
```
❯ go run . limits 
┼───────────────────────────────────┼──────┼───────┼
│             RESOURCE              │ USED │  MAX  │
┼───────────────────────────────────┼──────┼───────┼
│ Max Size of Block Storage Volumes │ 0    │ 10240 │
│ Elastic IP addresses              │ 0    │ 10    │
│ IAM API keys                      │ 4    │ 100   │
│ Compute instance GPUs             │ 0    │ 1     │
│ Private networks                  │ 0    │ 32    │
│ Compute instances                 │ 33   │ 50    │
│ Compute instance templates        │ 0    │ 30    │
│ Network Load Balancers            │ 0    │ 5     │
│ Compute instance snapshots        │ 0    │ 30    │
│ Block Storage cummulative size    │ 900  │ 20480 │
│ SKS clusters                      │ 0    │ 3     │
│ SOS buckets                       │ 1    │ 100   │
│ Block Storage Volumes             │ 33   │ 2000  │
┼───────────────────────────────────┼──────┼───────┼
```
## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

<!--
Describe the tests you did
-->
