### PR TITLE
config: remind user that no default account was set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Block Storage: Show all quotas #591
 - Block Storage: Fix volume show with snapshot #589
 - storage presign: fix panic when parsing arg[0] #590 
+- config: remind user that no default account was set #593 
 
 ## 1.77.1
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -170,6 +170,10 @@ func saveConfig(filePath string, newAccounts *account.Config) error {
 	}
 
 	conf.DefaultAccount = gConfig.Get("defaultAccount").(string)
+	if conf.DefaultAccount == "" {
+		fmt.Println("no default account set")
+	}
+
 	account.GAllAccount = conf
 
 	return nil


### PR DESCRIPTION
# Description
```shell
❯ exo config add
[+] API Key [none]: asdf
[+] Secret Key [none]: asdf
[+] Name [none]: asdf
✔ at-vie-1
[+] Set [asdf] as default account? [yN]: N
no default account set
```

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing
