### PR TITLE
sks: enable CSI addon on existing clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Block Storage: Fix volume show with snapshot #589
 - storage presign: fix panic when parsing arg[0] #590
 - dbaas migration show: fix panic #597
+- sks: enable CSI addon on existing clusters #596 
 
 ## 1.77.1
 

--- a/cmd/sks_update.go
+++ b/cmd/sks_update.go
@@ -1,17 +1,16 @@
 package cmd
 
 import (
-	"errors"
+	"context"
 	"fmt"
 	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
 
-	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
-	exoapi "github.com/exoscale/egoscale/v2/api"
+	v3 "github.com/exoscale/egoscale/v3"
 )
 
 type sksUpdateCmd struct {
@@ -49,48 +48,55 @@ func (c *sksUpdateCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
 func (c *sksUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 	var updated bool
 
-	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, c.Zone))
+	ctx := context.Background()
 
-	cluster, err := globalstate.EgoscaleClient.FindSKSCluster(ctx, c.Zone, c.Cluster)
+	clusters, err := globalstate.EgoscaleV3Client.ListSKSClusters(ctx)
 	if err != nil {
-		if errors.Is(err, exoapi.ErrNotFound) {
-			return fmt.Errorf("resource not found in zone %q", c.Zone)
-		}
 		return err
 	}
 
+	cluster, err := clusters.FindSKSCluster(c.Cluster)
+	if err != nil {
+		return err
+	}
+
+	updateReq := v3.UpdateSKSClusterRequest{}
+
 	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.AutoUpgrade)) {
-		cluster.AutoUpgrade = &c.AutoUpgrade
+		updateReq.AutoUpgrade = &c.AutoUpgrade
 		updated = true
 	}
 
 	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.Labels)) {
-		cluster.Labels = &c.Labels
+		updateReq.Labels = c.Labels
 		updated = true
 	}
 
 	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.Name)) {
-		cluster.Name = &c.Name
+		updateReq.Name = c.Name
 		updated = true
 	}
 
 	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.Description)) {
-		cluster.Description = &c.Description
+		updateReq.Description = c.Description
 		updated = true
 	}
 
-	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.EnableCSIAddon)) && !slices.Contains(*cluster.AddOns, sksClusterAddonExoscaleCSI) {
-		addons := *cluster.AddOns
-		addons = append(addons, sksClusterAddonExoscaleCSI)
-		fmt.Printf("addons: %v\n", addons)
-		cluster.AddOns = &addons
+	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.EnableCSIAddon)) && !slices.Contains(cluster.Addons, sksClusterAddonExoscaleCSI) {
+		updateReq.Addons = append(cluster.Addons, sksClusterAddonExoscaleCSI)
 		updated = true
 	}
 
 	if updated {
+		op, err := globalstate.EgoscaleV3Client.UpdateSKSCluster(ctx, cluster.ID, updateReq)
+		if err != nil {
+			return err
+		}
+
 		decorateAsyncOperation(fmt.Sprintf("Updating SKS cluster %q...", c.Cluster), func() {
-			err = globalstate.EgoscaleClient.UpdateSKSCluster(ctx, c.Zone, cluster)
+			_, err = globalstate.EgoscaleV3Client.Wait(ctx, op, v3.OperationStateSuccess)
 		})
+
 		if err != nil {
 			return err
 		}
@@ -99,7 +105,7 @@ func (c *sksUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 	if !globalstate.Quiet {
 		return (&sksShowCmd{
 			cliCommandSettings: c.cliCommandSettings,
-			Cluster:            *cluster.ID,
+			Cluster:            string(cluster.ID),
 			Zone:               c.Zone,
 		}).cmdRun(nil, nil)
 	}

--- a/cmd/sks_update.go
+++ b/cmd/sks_update.go
@@ -82,7 +82,7 @@ func (c *sksUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 	}
 
 	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.EnableCSIAddon)) && !slices.Contains(cluster.Addons, sksClusterAddonExoscaleCSI) {
-		updateReq.Addons = append(cluster.Addons, sksClusterAddonExoscaleCSI)
+		updateReq.Addons = append(cluster.Addons, sksClusterAddonExoscaleCSI) //nolint:gocritic
 		updated = true
 	}
 

--- a/cmd/sks_update.go
+++ b/cmd/sks_update.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -48,7 +47,7 @@ func (c *sksUpdateCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
 func (c *sksUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 	var updated bool
 
-	ctx := context.Background()
+	ctx := gContext
 
 	clusters, err := globalstate.EgoscaleV3Client.ListSKSClusters(ctx)
 	if err != nil {

--- a/cmd/sks_update.go
+++ b/cmd/sks_update.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -20,11 +21,12 @@ type sksUpdateCmd struct {
 
 	Cluster string `cli-arg:"#" cli-usage:"NAME|ID"`
 
-	AutoUpgrade bool              `cli-usage:"enable automatic upgrading of the SKS cluster control plane Kubernetes version(--auto-upgrade=false to disable again)"`
-	Description string            `cli-usage:"SKS cluster description"`
-	Labels      map[string]string `cli-flag:"label" cli-usage:"SKS cluster label (format: key=value)"`
-	Name        string            `cli-usage:"SKS cluster name"`
-	Zone        string            `cli-short:"z" cli-usage:"SKS cluster zone"`
+	AutoUpgrade    bool              `cli-usage:"enable automatic upgrading of the SKS cluster control plane Kubernetes version(--auto-upgrade=false to disable again)"`
+	Description    string            `cli-usage:"SKS cluster description"`
+	Labels         map[string]string `cli-flag:"label" cli-usage:"SKS cluster label (format: key=value)"`
+	Name           string            `cli-usage:"SKS cluster name"`
+	EnableCSIAddon bool              `cli-usage:"enable the Exoscale CSI driver"`
+	Zone           string            `cli-short:"z" cli-usage:"SKS cluster zone"`
 }
 
 func (c *sksUpdateCmd) cmdAliases() []string { return nil }
@@ -74,6 +76,14 @@ func (c *sksUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 
 	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.Description)) {
 		cluster.Description = &c.Description
+		updated = true
+	}
+
+	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.EnableCSIAddon)) && !slices.Contains(*cluster.AddOns, sksClusterAddonExoscaleCSI) {
+		addons := *cluster.AddOns
+		addons = append(addons, sksClusterAddonExoscaleCSI)
+		fmt.Printf("addons: %v\n", addons)
+		cluster.AddOns = &addons
 		updated = true
 	}
 


### PR DESCRIPTION
# Description
We add the `--enable-csi-addon` flag to the `sks update` command.
egoscale v2 doesn't pass the AddOns field to the API and instead of updating v2 I refactored the update command to use v3.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

On a cluster that wasn't created with the CSI Addon:
```shell
> exo c sks update -z ch-gva-2 test-cluster --enable-csi-addon
 ✔ Updating SKS cluster "test-cluster"... 42s
┼───────────────┼──────────────────────────────────────────────────────────────────┼
│  SKS CLUSTER  │                                                                  │
┼───────────────┼──────────────────────────────────────────────────────────────────┼
│ ID            │ 746f5de4-ee31-4761-a7c6-9fc71f3e9bf4                             │
│ Name          │ test-cluster                                                     │
│ Description   │                                                                  │
│ Zone          │ ch-gva-2                                                         │
│ Creation Date │ 2024-04-25 07:44:03 +0000 UTC                                    │
│ Auto-upgrade  │ false                                                            │
│ Endpoint      │ https://746f5de4-ee31-4761-a7c6-9fc71f3e9bf4.sks-ch-gva-2.exo.io │
│ Version       │ 1.29.3                                                           │
│ Service Level │ pro                                                              │
│ CNI           │ calico                                                           │
│ Add-Ons       │ exoscale-cloud-controller                                        │
│               │ exoscale-container-storage-interface                             │
│               │ metrics-server                                                   │
│ State         │ running                                                          │
│ Labels        │ n/a                                                              │
│ Nodepools     │ 9d644be3-ceb7-4ba3-b84f-58851c890306 | test-cluster-nodepool     │
┼───────────────┼──────────────────────────────────────────────────────────────────┼

❯ kubectl get pods -A
NAMESPACE     NAME                                       READY   STATUS    RESTARTS   AGE
kube-system   exoscale-csi-controller-67c9d7ddb-4vss2    7/7     Running   0          4m10s
kube-system   exoscale-csi-controller-67c9d7ddb-zzz2x    7/7     Running   0          4m10s
kube-system   exoscale-csi-node-5tqsx                    3/3     Running   0          4m11s
kube-system   exoscale-csi-node-f9jxr                    3/3     Running   0          4m11s
kube-system   exoscale-csi-node-kpxgf                    3/3     Running   0          4m11s
...
```
