### PR TITLE
Fix panic in dbaas migration show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 - Block Storage: Show all quotas #591
 - Block Storage: Fix volume show with snapshot #589
-- storage presign: fix panic when parsing arg[0] #590 
-- config: remind user that no default account was set #593 
+- storage presign: fix panic when parsing arg[0] #590
+- config: remind user that no default account was set #593
+- dbaas migration show: fix panic #597
 
 ## 1.77.1
 
@@ -22,7 +23,7 @@
 
 ### Features
 - compute: Add Block Storage #574
-- sks: flag for CSI addon #572 
+- sks: flag for CSI addon #572
 
 ### Improvements
 - Instance reset password: remove wrong "rm" alias #583
@@ -44,7 +45,7 @@
 ## 1.76.1
 
 ### Improvements
-- go.mk: use as a plain repo instead of a submodule #575 
+- go.mk: use as a plain repo instead of a submodule #575
 
 ## 1.76.0
 

--- a/pkg/output/outputter.go
+++ b/pkg/output/outputter.go
@@ -284,7 +284,7 @@ func Table(o interface{}) {
 			} else {
 				// Most of our openAPI resource reference has {ID: "UUID"}
 				// That facilitate the outputers struct.
-				if v.Field(i).Elem().FieldByName("ID").String() != "" {
+				if v.Field(i).Elem().Kind() == reflect.Struct && v.Field(i).Elem().FieldByName("ID").String() != "" {
 					tab.Append([]string{label, fmt.Sprint(v.Field(i).Elem().FieldByName("ID").String())})
 					continue
 				}


### PR DESCRIPTION
# Description

Fixes panic in `dbaas migration show`.
Bug was in the shared table format code that makes assumption about our API that don't apply to dbaas API (due to originating from Aiven).

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

Before:
```bash
$ exo dbaas migration status mydb2
panic: reflect: call of reflect.Value.FieldByName on string Value

goroutine 1 [running]:
reflect.flag.mustBe(...)
        reflect/value.go:233
reflect.Value.FieldByName({0x14d1fe0?, 0xc0002947c0?, 0x170a2ea?}, {0x16e1b46?, 0x1f12c78?})
        reflect/value.go:1361 +0x1c8
github.com/exoscale/cli/pkg/output.Table({0x1594560, 0xc000a9a040})
        github.com/exoscale/cli/pkg/output/outputter.go:287 +0xc56
github.com/exoscale/cli/cmd.(*databaseMigrationStatus).ToTable(0xc000d12420?)
        github.com/exoscale/cli/cmd/dbaas_migration_status.go:44 +0x1d
github.com/exoscale/cli/cmd.printOutput({0x1efd420?, 0xc000a9a040?}, {0x0?, 0x0?})
        github.com/exoscale/cli/cmd/output.go:40 +0x7a
github.com/exoscale/cli/cmd.(*dbaasMigrationStatusCmd).cmdRun(0xc00083c480, 0xc0008422c8?, {0xc000774500?, 0x5c68c0?, 0xc000139c80?})
        github.com/exoscale/cli/cmd/dbaas_migration_status.go:57 +0x21b
github.com/spf13/cobra.(*Command).execute(0xc0008422c8, {0xc000774480, 0x1, 0x1})
        github.com/spf13/cobra@v1.3.0/command.go:856 +0x69d
github.com/spf13/cobra.(*Command).ExecuteC(0x29640a0)
        github.com/spf13/cobra@v1.3.0/command.go:974 +0x38d
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.3.0/command.go:902
github.com/exoscale/cli/cmd.Execute({0x1eed860?, 0x2885900?}, {0x1eee090?, 0xc0000061c0?})
        github.com/exoscale/cli/cmd/root.go:81 +0x1ed
main.main()
        github.com/exoscale/cli/main.go:34 +0x3c
```

After this fix:
```bash
$ go run . dbaas migration status mydb2
┼────────────────────────────┼───────────────────────────┼
│ Details                    │ n/a                       │
│ Error                      │ Endpoint is not available │
│ Master Last IO Seconds Ago │ n/a                       │
│ Master Link Status         │ n/a                       │
│ Method                     │                           │
│ Status                     │ failed                    │
┼────────────────────────────┼───────────────────────────┼
```