### PR TITLE
go.mk: lint with staticcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- go.mk: lint with staticcheck #606 
+
 ## 1.78.2
 
 ### Bug Fixes

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO_MK_REF := v1.0.1
+GO_MK_REF := philippsauter/sc-95507/public-tooling-switch-golanci-lint-staticcheck
 
 # make go.mk a dependency for all targets
 .EXTRA_PREREQS = go.mk

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO_MK_REF := philippsauter/sc-95507/public-tooling-switch-golanci-lint-staticcheck
+GO_MK_REF := v2.0.0
 
 # make go.mk a dependency for all targets
 .EXTRA_PREREQS = go.mk

--- a/cmd/iam_role_show.go
+++ b/cmd/iam_role_show.go
@@ -57,7 +57,7 @@ func (c *iamRoleShowCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
 
 func (c *iamRoleShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	if c.Role == "" {
-		return errors.New("Role ID not provided") //nolint: stylecheck
+		return errors.New("role ID not provided")
 	}
 
 	zone := account.CurrentAccount.DefaultZone

--- a/cmd/iam_role_update.go
+++ b/cmd/iam_role_update.go
@@ -49,7 +49,7 @@ func (c *iamRoleUpdateCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
 
 func (c *iamRoleUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 	if c.Role == "" {
-		return errors.New("Role not provided") // nolint:stylecheck
+		return errors.New("role not provided")
 	}
 
 	zone := account.CurrentAccount.DefaultZone

--- a/cmd/icmp_code.go
+++ b/cmd/icmp_code.go
@@ -8,9 +8,10 @@ import (
 	"golang.org/x/text/language"
 )
 
+//lint:file-ignore U1000 unknown
+
 type icmpCode uint16
 
-// nolint
 const (
 	//destinationUnreachable
 	netUnreachable                                                 icmpCode = 0x0300

--- a/cmd/icmp_type.go
+++ b/cmd/icmp_type.go
@@ -8,6 +8,8 @@ import (
 
 //go:generate stringer -type=icmpType
 
+//lint:file-ignore U1000 unknown
+
 type icmpType uint8
 
 // nolint

--- a/cmd/instance_pool_delete.go
+++ b/cmd/instance_pool_delete.go
@@ -59,8 +59,8 @@ func (c *instancePoolDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	for _, nlb := range nlbs {
 		for _, svc := range nlb.Services {
 			if svc.InstancePoolID == instancePool.ID {
-				return fmt.Errorf( // nolint:stylecheck
-					"Instance Pool %q is still referenced by NLB service %s/%s",
+				return fmt.Errorf(
+					"instance Pool %q is still referenced by NLB service %s/%s",
 					*instancePool.Name,
 					*nlb.Name,
 					*svc.Name,

--- a/cmd/instance_snapshot_create.go
+++ b/cmd/instance_snapshot_create.go
@@ -54,7 +54,7 @@ func (c *instanceSnapshotCreateCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		snapshot, err = globalstate.EgoscaleClient.CreateInstanceSnapshot(ctx, c.Zone, instance)
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
-				err = fmt.Errorf("Request timeout reached. Snapshot creation is not canceled and might still be running, check the status with: exo c i snapshot list") // nolint:stylecheck
+				err = fmt.Errorf("request timeout reached. Snapshot creation is not canceled and might still be running, check the status with: exo c i snapshot list") // nolint:stylecheck
 			}
 			return
 		}

--- a/cmd/sks_nodepool_delete.go
+++ b/cmd/sks_nodepool_delete.go
@@ -65,7 +65,7 @@ func (c *sksNodepoolDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	return errors.New("Nodepool not found") // nolint:stylecheck
+	return errors.New("nodepool not found") // nolint:stylecheck
 }
 
 func init() {

--- a/cmd/sks_nodepool_evict.go
+++ b/cmd/sks_nodepool_evict.go
@@ -81,7 +81,7 @@ func (c *sksNodepoolEvictCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 		}
 	}
 	if nodepool == nil {
-		return errors.New("Nodepool not found") // nolint:stylecheck
+		return errors.New("nodepool not found")
 	}
 
 	nodes := make([]string, len(c.Nodes))

--- a/cmd/sks_nodepool_scale.go
+++ b/cmd/sks_nodepool_scale.go
@@ -78,7 +78,7 @@ func (c *sksNodepoolScaleCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		}
 	}
 	if nodepool == nil {
-		return errors.New("Nodepool not found") // nolint:stylecheck
+		return errors.New("nodepool not found")
 	}
 
 	decorateAsyncOperation(fmt.Sprintf("Scaling Nodepool %q...", c.Nodepool), func() {

--- a/cmd/sks_nodepool_show.go
+++ b/cmd/sks_nodepool_show.go
@@ -91,7 +91,7 @@ func (c *sksNodepoolShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		}
 	}
 	if nodepool == nil {
-		return errors.New("Nodepool not found") // nolint:stylecheck
+		return errors.New("nodepool not found")
 	}
 
 	out := sksNodepoolShowOutput{

--- a/cmd/sks_nodepool_update.go
+++ b/cmd/sks_nodepool_update.go
@@ -77,7 +77,7 @@ func (c *sksNodepoolUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error { //
 		}
 	}
 	if nodepool == nil {
-		return errors.New("Nodepool not found") // nolint:stylecheck
+		return errors.New("nodepool not found")
 	}
 
 	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.AntiAffinityGroups)) {


### PR DESCRIPTION
# Description

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing
```shell
❯ make lint
remote: Enumerating objects: 9, done.
remote: Counting objects: 100% (9/9), done.
remote: Compressing objects: 100% (7/7), done.
remote: Total 9 (delta 3), reused 6 (delta 2), pack-reused 0
Unpacking objects: 100% (9/9), 5.47 KiB | 2.74 MiB/s, done.
From github.com:exoscale/go.mk
   529be42..c320e5b  master     -> origin/master
 * [new tag]         v2.0.0     -> v2.0.0
'/home/sauterp/bin/go' install honnef.co/go/tools/cmd/staticcheck@2023.1.7
'/home/sauterp/go/bin/staticcheck' \
   \
  ./...
```