### PR TITLE
Update deprecated goreleaser directives

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,10 +80,10 @@ nfpms:
         dst: "/usr/share/zsh/vendor-completions/_exo"
 
 brews:
-  - tap:
+  - repository:
       owner: exoscale
       name: homebrew-tap
-    folder: Formula
+    directory: Formula
     homepage: "https://exoscale.github.io/cli/"
     description: Manage easily your Exoscale infrastructure from the command-line.
     install: |
@@ -112,7 +112,6 @@ source:
   enabled: true
   prefix_template: "{{ .ProjectName }}_{{ .Version }}/"
   name_template: "{{ .ProjectName }}_{{ .Version }}"
-  rlcp: true
   files:
     - go.mk/*
 
@@ -123,7 +122,7 @@ signs:
 
 scoops:
   - description: "Command-line tool for everything at Exoscale: compute, storage, dns."
-    folder: "bucket"
+    directory: "bucket"
     commit_author:
       name: "Exoscale Tooling"
       email: "tooling@exoscale.ch"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - go.mk: lint with staticcheck #606 
+- Update deprecated goreleaser directives #607
 
 ## 1.78.2
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO_MK_REF := v2.0.0
+GO_MK_REF := v2.0.1
 
 # make go.mk a dependency for all targets
 .EXTRA_PREREQS = go.mk


### PR DESCRIPTION
# Description

Newer goreleaser versions deprecated few directives we use. Most are just renamed now, one become enforced and is not needed. No breaking changes expected.

Requires https://github.com/exoscale/go.mk/pull/43

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

Before:
```bash
$ goreleaser check                                                                                                                                                        
  • checking                                 path=
  • DEPRECATED:  source.rlcp  should not be used anymore, check https://goreleaser.com/deprecations#sourcerlcp for more info
  • DEPRECATED:  brews.folder  should not be used anymore, check https://goreleaser.com/deprecations#brewsfolder for more info
  • DEPRECATED:  brews.tap  should not be used anymore, check https://goreleaser.com/deprecations#brewstap for more info
  • DEPRECATED:  scoops.folder  should not be used anymore, check https://goreleaser.com/deprecations#scoopsfolder for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
```
After change:
```bash
$ goreleaser check 
  • checking                                 path=
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```