### PR TITLE
instance: add a protection flag to exo compute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ contrib
 *.xdelta3
 go.work
 .aptlydata
+.idea/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## 1.79.0
 
+### Features
+
+- instance: add a protection flag to exo compute #608
+
 ### Improvements
 
 - DBaaS: external endpoints and integrations commands #631

--- a/cmd/instance_create.go
+++ b/cmd/instance_create.go
@@ -263,8 +263,10 @@ func (c *instanceCreateCmd) cmdRun(_ *cobra.Command, _ []string) error { //nolin
 				return
 			}
 		}
+		fmt.Printf("Protection flag value: %v\n", c.Protection)
 
 		if c.Protection {
+			fmt.Println("Protection flag is set, adding protection...")
 			var value egoscale3.UUID
 			var op *egoscale3.Operation
 			value, err = egoscale3.ParseUUID(*instance.ID)
@@ -275,7 +277,7 @@ func (c *instanceCreateCmd) cmdRun(_ *cobra.Command, _ []string) error { //nolin
 			if err != nil {
 				return
 			}
-			op, err = globalstate.EgoscaleV3Client.Wait(ctx, op, egoscale3.OperationStateSuccess)
+			_, err = globalstate.EgoscaleV3Client.Wait(ctx, op, egoscale3.OperationStateSuccess)
 
 		}
 	})

--- a/cmd/instance_create.go
+++ b/cmd/instance_create.go
@@ -41,6 +41,7 @@ type instanceCreateCmd struct {
 	PrivateNetworks    []string          `cli-flag:"private-network" cli-usage:"instance Private Network NAME|ID (can be specified multiple times)"`
 	PrivateInstance    bool              `cli-flag:"private-instance" cli-usage:"enable private instance to be created"`
 	SSHKeys            []string          `cli-flag:"ssh-key" cli-usage:"SSH key to deploy on the instance (can be specified multiple times)"`
+	Protection         bool              `cli-flag:"protection" cli-usage:"enable delete protection"`
 	SecurityGroups     []string          `cli-flag:"security-group" cli-usage:"instance Security Group NAME|ID (can be specified multiple times)"`
 	Template           string            `cli-usage:"instance template NAME|ID"`
 	TemplateVisibility string            `cli-usage:"instance template visibility (public|private)"`
@@ -261,6 +262,21 @@ func (c *instanceCreateCmd) cmdRun(_ *cobra.Command, _ []string) error { //nolin
 			if err != nil {
 				return
 			}
+		}
+
+		if c.Protection {
+			var value egoscale3.UUID
+			var op *egoscale3.Operation
+			value, err = egoscale3.ParseUUID(*instance.ID)
+			if err != nil {
+				return
+			}
+			op, err = globalstate.EgoscaleV3Client.AddInstanceProtection(ctx, value)
+			if err != nil {
+				return
+			}
+			op, err = globalstate.EgoscaleV3Client.Wait(ctx, op, egoscale3.OperationStateSuccess)
+
 		}
 	})
 	if err != nil {

--- a/cmd/instance_create.go
+++ b/cmd/instance_create.go
@@ -20,6 +20,7 @@ import (
 	exossh "github.com/exoscale/cli/pkg/ssh"
 	"github.com/exoscale/cli/pkg/userdata"
 	"github.com/exoscale/cli/utils"
+	egoscale3 "github.com/exoscale/egoscale/v3"
 	v3 "github.com/exoscale/egoscale/v3"
 )
 

--- a/cmd/instance_create.go
+++ b/cmd/instance_create.go
@@ -268,7 +268,7 @@ func (c *instanceCreateCmd) cmdRun(_ *cobra.Command, _ []string) error { //nolin
 		if c.Protection {
 			var value egoscale3.UUID
 			var op *egoscale3.Operation
-			value, err = egoscale3.ParseUUID(*instance.ID)
+			value, err = egoscale3.ParseUUID(instanceID.String())
 			if err != nil {
 				return
 			}

--- a/cmd/instance_create.go
+++ b/cmd/instance_create.go
@@ -20,7 +20,6 @@ import (
 	exossh "github.com/exoscale/cli/pkg/ssh"
 	"github.com/exoscale/cli/pkg/userdata"
 	"github.com/exoscale/cli/utils"
-	egoscale3 "github.com/exoscale/egoscale/v3"
 	v3 "github.com/exoscale/egoscale/v3"
 )
 
@@ -266,9 +265,9 @@ func (c *instanceCreateCmd) cmdRun(_ *cobra.Command, _ []string) error { //nolin
 		}
 
 		if c.Protection {
-			var value egoscale3.UUID
-			var op *egoscale3.Operation
-			value, err = egoscale3.ParseUUID(instanceID.String())
+			var value v3.UUID
+			var op *v3.Operation
+			value, err = v3.ParseUUID(instanceID.String())
 			if err != nil {
 				return
 			}
@@ -276,7 +275,7 @@ func (c *instanceCreateCmd) cmdRun(_ *cobra.Command, _ []string) error { //nolin
 			if err != nil {
 				return
 			}
-			_, err = globalstate.EgoscaleV3Client.Wait(ctx, op, egoscale3.OperationStateSuccess)
+			_, err = globalstate.EgoscaleV3Client.Wait(ctx, op, v3.OperationStateSuccess)
 
 		}
 	})

--- a/cmd/instance_create.go
+++ b/cmd/instance_create.go
@@ -263,10 +263,8 @@ func (c *instanceCreateCmd) cmdRun(_ *cobra.Command, _ []string) error { //nolin
 				return
 			}
 		}
-		fmt.Printf("Protection flag value: %v\n", c.Protection)
 
 		if c.Protection {
-			fmt.Println("Protection flag is set, adding protection...")
 			var value egoscale3.UUID
 			var op *egoscale3.Operation
 			value, err = egoscale3.ParseUUID(*instance.ID)

--- a/cmd/instance_update.go
+++ b/cmd/instance_update.go
@@ -101,7 +101,6 @@ func (c *instanceUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 			}
 
 			if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.Protection)) {
-				fmt.Println("Protection flag is set, adding protection...")
 				var value egoscale3.UUID
 				var op *egoscale3.Operation
 				value, err = egoscale3.ParseUUID(*instance.ID)

--- a/cmd/instance_update.go
+++ b/cmd/instance_update.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	egoscale3 "github.com/exoscale/egoscale/v3"
 	"strings"
+
+	egoscale3 "github.com/exoscale/egoscale/v3"
 
 	"github.com/spf13/cobra"
 

--- a/cmd/instance_update.go
+++ b/cmd/instance_update.go
@@ -99,21 +99,25 @@ func (c *instanceUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 					err = globalstate.EgoscaleClient.UpdateInstanceReverseDNS(ctx, c.Zone, *instance.ID, c.ReverseDNS)
 				}
 			}
-			var value egoscale3.UUID
-			var op *egoscale3.Operation
-			value, err = egoscale3.ParseUUID(*instance.ID)
-			if err != nil {
-				return
+
+			if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.Protection)) {
+				fmt.Println("Protection flag is set, adding protection...")
+				var value egoscale3.UUID
+				var op *egoscale3.Operation
+				value, err = egoscale3.ParseUUID(*instance.ID)
+				if err != nil {
+					return
+				}
+				if c.Protection {
+					op, err = globalstate.EgoscaleV3Client.AddInstanceProtection(ctx, value)
+				} else {
+					op, err = globalstate.EgoscaleV3Client.RemoveInstanceProtection(ctx, value)
+				}
+				if err != nil {
+					return
+				}
+				_, err = globalstate.EgoscaleV3Client.Wait(ctx, op, egoscale3.OperationStateSuccess)
 			}
-			if c.Protection {
-				op, err = globalstate.EgoscaleV3Client.AddInstanceProtection(ctx, value)
-			} else {
-				op, err = globalstate.EgoscaleV3Client.RemoveInstanceProtection(ctx, value)
-			}
-			if err != nil {
-				return
-			}
-			op, err = globalstate.EgoscaleV3Client.Wait(ctx, op, egoscale3.OperationStateSuccess)
 
 		})
 

--- a/cmd/instance_update.go
+++ b/cmd/instance_update.go
@@ -84,7 +84,7 @@ func (c *instanceUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 		updatedRDNS = true
 	}
 
-	if updatedInstance || updatedRDNS {
+	if updatedInstance || updatedRDNS || cmd.Flags().Changed(mustCLICommandFlagName(c, &c.Protection)) {
 		decorateAsyncOperation(fmt.Sprintf("Updating instance %q...", c.Instance), func() {
 			if updatedInstance {
 				if err = globalstate.EgoscaleClient.UpdateInstance(ctx, c.Zone, instance); err != nil {


### PR DESCRIPTION
# Description
added add/remove a protection flag to exo compute, however it did not work as expected

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

I tested the cli after the changes locally but the protection flag does not work.


```bash
❯ ./exo compute instance update --help
This command updates an Instance .

Supported output template annotations: .ID, .Name, .CreationDate, .InstanceType, .Template, .Zone, .AntiAffinityGroups, .DeployTarget, .SecurityGroups, .PrivateInstance, .PrivateNetworks, .ElasticIPs, .IPAddress, .IPv6Address, .SSHKey, .DiskSize, .State, .Labels, .ReverseDNS

Usage:
  exo compute instance update NAME|ID [flags]

Flags:
  -c, --cloud-init string      instance cloud-init user data configuration file path
      --cloud-init-compress    compress instance cloud-init user data
  -h, --help                   help for update
      --label stringToString   instance label (format: key=value) (default [])
  -n, --name string            instance name
      --protection             enable delete protection
      --reverse-dns string     Reverse DNS Domain
  -z, --zone string            instance zone

Global Flags:
  -C, --config string            Specify an alternate config file [env EXOSCALE_CONFIG]
  -O, --output-format string     Output format (table|json|text), see "exo output --help" for more information
      --output-template string   Template to use if output format is "text"
  -Q, --quiet                    Quiet mode (disable non-essential command output)
  -A, --use-account string       Account to use in config file [env EXOSCALE_ACCOUNT]
❯ ./exo compute instance update 4ed629e1-9a63-4d74-b8c9-165d83292f9d --protection
┼──────────────────────┼──────────────────────────────────────┼
│   COMPUTE INSTANCE   │                                      │
┼──────────────────────┼──────────────────────────────────────┼
│ ID                   │ 4ed629e1-9a63-4d74-b8c9-165d83292f9d │
│ Name                 │ test                                 │
│ Creation Date        │ 2024-05-28 08:31:56 +0000 UTC        │
│ Instance Type        │ standard.medium                      │
│ Template             │ Linux Ubuntu 22.04 LTS 64-bit        │
│ Zone                 │ at-vie-1                             │
│ Anti-Affinity Groups │ n/a                                  │
│ Deploy Target        │ -                                    │
│ Security Groups      │ default                              │
│ Private Instance     │ No                                   │
│ Private Networks     │ n/a                                  │
│ Elastic IPs          │ n/a                                  │
│ IP Address           │ 194.182.184.154                      │
│ IPv6 Address         │ -                                    │
│ SSH Key              │ -                                    │
│ Disk Size            │ 50 GiB                               │
│ State                │ running                              │
│ Labels               │ n/a                                  │
│ Reverse DNS          │                                      │
┼──────────────────────┼──────────────────────────────────────┼
❯ ./exo compute instance delete 4ed629e1-9a63-4d74-b8c9-165d83292f9d
[+] Are you sure you want to delete instance "4ed629e1-9a63-4d74-b8c9-165d83292f9d"? [yN]: y
 ✔ Deleting instance "4ed629e1-9a63-4d74-b8c9-165d83292f9d"... 6s
```