### PR TITLE
Fix instance/ipool key naming in json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 
 - dbaas opensearch: remove top-level max-index-count flag #611
+- Fix instance/ipool key naming in json output #612
 
 ## 1.78.2
 

--- a/cmd/instance_pool_show.go
+++ b/cmd/instance_pool_show.go
@@ -21,8 +21,8 @@ type instancePoolShowOutput struct {
 	Name               string            `json:"name"`
 	Description        string            `json:"description"`
 	InstanceType       string            `json:"instance_type"`
-	Template           string            `json:"template_id"`
-	Zone               string            `json:"zoneid"`
+	Template           string            `json:"template"`
+	Zone               string            `json:"zone"`
 	AntiAffinityGroups []string          `json:"anti_affinity_groups" outputLabel:"Anti-Affinity Groups"`
 	SecurityGroups     []string          `json:"security_groups"`
 	PrivateNetworks    []string          `json:"private_networks"`

--- a/cmd/instance_show.go
+++ b/cmd/instance_show.go
@@ -21,8 +21,8 @@ type instanceShowOutput struct {
 	Name               string            `json:"name"`
 	CreationDate       string            `json:"creation_date"`
 	InstanceType       string            `json:"instance_type"`
-	Template           string            `json:"template_id"`
-	Zone               string            `json:"zoneid"`
+	Template           string            `json:"template"`
+	Zone               string            `json:"zone"`
 	AntiAffinityGroups []string          `json:"anti_affinity_groups" outputLabel:"Anti-Affinity Groups"`
 	DeployTarget       string            `json:"deploy_target"`
 	SecurityGroups     []string          `json:"security_groups"`


### PR DESCRIPTION
# Description

Renames keys that did not match actual data:
- `template_id` -> `template`;
- `zoneid` -> `zone`.

These were present in both `c instance show` and `c instance-pool show` commands.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

```bash
$ go run . c i show 1d1b482c-adcf-4928-acd9-fdffbe2d7c98 --output-format json | jq                                                                                        
{                                                                                                                                                                                            
  "id": "1d1b482c-adcf-4928-acd9-fdffbe2d7c98",                                                                                                                                              
  "name": "my-instance",                                                                                                                                                                
  "creation_date": "2024-06-14 15:09:06 +0000 UTC",                                                                                                                                          
  "instance_type": "standard.medium",                                                                                                                                                        
  "template": "sks-node-1.30.jammy",                                                                                                                                                         
  "zone": "ch-gva-2",                                                                                                                                                                        
  "anti_affinity_groups": [                                                                                                                                                                  
    "my-sks-anti-affinity-group"                                                                                                                                                             
  ],                                                                                                                                                                                         
  "deploy_target": "-",                                                                                                                                                                      
  "security_groups": [                                                                                                                                                                       
    "default",                                                                                                                                                                               
    "my-sks-security-group"                                                                                                                                                                  
  ],                                                                                                                                                                                         
  "private-instance": "No",                                                                                                                                                                  
  "private_networks": [],                                                                                                                                                                    
  "elastic_ips": [],
  "ip_address": "x.x.x.x",
  "ipv6_address": "-",
  "ssh_key": "-",
  "disk_size": "50 GiB",
  "state": "running",
  "labels": null,
  "reverse_dns": ""
}
```