### PR TITLE
sks nodepool: show instance family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - go.mk: lint with staticcheck #606 
 - Update deprecated goreleaser directives #607
+- sks nodepool: show instance family #615 
 
 ### Bug Fixes
 

--- a/cmd/sks_nodepool_show.go
+++ b/cmd/sks_nodepool_show.go
@@ -23,7 +23,6 @@ type sksNodepoolShowOutput struct {
 	InstancePoolID       string            `json:"instance_pool_id"`
 	InstancePrefix       string            `json:"instance_prefix"`
 	InstanceType         string            `json:"instance_type"`
-	InstanceFamily       string            `json:"instance_family"`
 	Template             string            `json:"template"`
 	DiskSize             int64             `json:"disk_size"`
 	AntiAffinityGroups   []string          `json:"anti_affinity_groups"`
@@ -180,12 +179,11 @@ func (c *sksNodepoolShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	serviceOffering, err := globalstate.EgoscaleClient.GetInstanceType(ctx, c.Zone, *nodepool.InstanceTypeID)
+	instanceType, err := globalstate.EgoscaleClient.GetInstanceType(ctx, c.Zone, *nodepool.InstanceTypeID)
 	if err != nil {
 		return fmt.Errorf("error retrieving service offering: %w", err)
 	}
-	out.InstanceType = *serviceOffering.Size
-	out.InstanceFamily = *serviceOffering.Family
+	out.InstanceType = fmt.Sprintf("%s.%s", *instanceType.Family, *instanceType.Size)
 
 	template, err := globalstate.EgoscaleClient.GetTemplate(ctx, c.Zone, *nodepool.TemplateID)
 	if err != nil {

--- a/cmd/sks_nodepool_show.go
+++ b/cmd/sks_nodepool_show.go
@@ -23,6 +23,7 @@ type sksNodepoolShowOutput struct {
 	InstancePoolID       string            `json:"instance_pool_id"`
 	InstancePrefix       string            `json:"instance_prefix"`
 	InstanceType         string            `json:"instance_type"`
+	InstanceFamily       string            `json:"instance_family"`
 	Template             string            `json:"template"`
 	DiskSize             int64             `json:"disk_size"`
 	AntiAffinityGroups   []string          `json:"anti_affinity_groups"`
@@ -184,6 +185,7 @@ func (c *sksNodepoolShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("error retrieving service offering: %w", err)
 	}
 	out.InstanceType = *serviceOffering.Size
+	out.InstanceFamily = *serviceOffering.Family
 
 	template, err := globalstate.EgoscaleClient.GetTemplate(ctx, c.Zone, *nodepool.TemplateID)
 	if err != nil {


### PR DESCRIPTION
## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

```shell
❯ ./bin/exo -A exosauterp compute sks nodepool show abc def -z ch-gva-2
┼─────────────────────────┼──────────────────────────────────────┼
│      SKS NODEPOOL       │                                      │
┼─────────────────────────┼──────────────────────────────────────┼
│ Instance Type           │ standard.medium                      │
┼─────────────────────────┼──────────────────────────────────────┼
```
