### PR TITLE
output template: use text/template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- output template: use text/template #617
+
 ## 1.78.3
 
 ### Improvements

--- a/pkg/output/outputter.go
+++ b/pkg/output/outputter.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"os"
 	"reflect"
 	"strings"
+	"text/template"
 
 	"github.com/exoscale/cli/table"
 	v3 "github.com/exoscale/egoscale/v3"


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Previously we were using `html/template` which would result in strings being rendered as escaped html

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

<!--
Describe the tests you did
-->

Before:

```
➜ exo dbaas show test --output-template '{{.Kafka.ConnectionInfo.AccessCert}}'                                                  24-07-04 16:08 
-----BEGIN CERTIFICATE-----
MIIEVzCCAr&#43;gAwIBAgIUCoWog7/IGKm3ts&#43;xO6kSfkk/UHwwDQYJKoZIhvcNAQEM
...
```


W/ this PR:

```
➜ go run . dbaas show test --output-template '{{.Kafka.ConnectionInfo.AccessCert}}'                                                                                        24-07-04 16:57 
-----BEGIN CERTIFICATE-----
MIIEVzCCAr+gAwIBAgIUCoWog7/IGKm3ts+xO6kSfkk/UHwwDQYJKoZIhvcNAQEM
```