### PR TITLE
dbaas: use dedicated reveal-password endpoint to fetch password and build URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Instance Create: Migrate to egoscale v3 and add multiple sshkeys #620
+- dbaas: use dedicated reveal-password endpoint to fetch password and build URI #618
 
 ## 1.78.4
 

--- a/cmd/dbaas_show_redis.go
+++ b/cmd/dbaas_show_redis.go
@@ -17,6 +17,7 @@ import (
 	"github.com/exoscale/cli/utils"
 	exoapi "github.com/exoscale/egoscale/v2/api"
 	"github.com/exoscale/egoscale/v2/oapi"
+	v3 "github.com/exoscale/egoscale/v3"
 )
 
 type dbServiceRedisComponentShowOutput struct {
@@ -143,7 +144,37 @@ func (c *dbaasServiceShowCmd) showDatabaseServiceRedis(ctx context.Context) (out
 		return nil, nil
 
 	case c.ShowURI:
-		fmt.Println(utils.DefaultString(databaseService.Uri, ""))
+		// Read password from dedicated endpoint
+		client, err := switchClientZoneV3(
+			ctx,
+			globalstate.EgoscaleV3Client,
+			v3.ZoneName(c.Zone),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		uriParams := *databaseService.UriParams
+
+		creds, err := client.RevealDBAASRedisUserPassword(
+			ctx,
+			string(databaseService.Name),
+			uriParams["user"].(string),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		// Build URI
+		uri := fmt.Sprintf(
+			"rediss://%s:%s@%s:%s",
+			uriParams["user"],
+			creds.Password,
+			uriParams["host"],
+			uriParams["port"],
+		)
+
+		fmt.Println(uri)
 		return nil, nil
 	}
 


### PR DESCRIPTION
# Description

This PR rebuilds the connection URI by fetching password from a dedicated database service endpoint (for services that support credentials in URI).

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

<!--
Describe the tests you did
-->
