### PR TITLE
Compute Instance delete: Remove multiple entities by their IDs/Names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improvements
+
+- Compute Instance delete: Remove multiple entities by their IDs/Names #619
+
 ### Bug Fixes
 
 - output template: use text/template #617

--- a/cmd/instance_delete.go
+++ b/cmd/instance_delete.go
@@ -54,10 +54,10 @@ func (c *instanceDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	for _, i := range c.Instances {
 		instance, err := instances.FindListInstancesResponseInstances(i)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "warning: %s not found.\n", i)
 			if !c.Force {
 				return err
 			}
+			fmt.Fprintf(os.Stderr, "warning: %s not found.\n", i)
 
 			continue
 		}
@@ -88,6 +88,8 @@ func (c *instanceDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// Cleaning up resources created in create instance
+	// https://github.com/exoscale/cli/blob/master/cmd/instance_create.go#L220
 	for _, i := range instanceToDelete {
 		instanceDir := path.Join(globalstate.ConfigFolder, "instances", i.String())
 		if _, err := os.Stat(instanceDir); !os.IsNotExist(err) {

--- a/cmd/instance_delete.go
+++ b/cmd/instance_delete.go
@@ -54,6 +54,7 @@ func (c *instanceDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
 	for _, i := range c.Instances {
 		instance, err := instances.FindListInstancesResponseInstances(i)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: %s not found.\n", i)
 			if !c.Force {
 				return err
 			}


### PR DESCRIPTION
# Description
Compute Instance delete, remove multiple entities by their IDs/Names

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

Deleting a list of instance
```BASH
go run main.go c i delete test1 test2 test3
[+] Are you sure you want to delete instance "test1"? [yN]: y
[+] Are you sure you want to delete instance "test2"? [yN]: y
[+] Are you sure you want to delete instance "test3"? [yN]: y
 ✔ Deleting instance "test1, test2, test3"... 9s
```

Not existing instance in list
```
go run main.go c i delete test1 test2 test404 test3
[+] Are you sure you want to delete instance "test1"? [yN]: y
[+] Are you sure you want to delete instance "test2"? [yN]: y
error: "test404" not found in ListInstancesResponse: resource not found
exit status 1
```

Force deletion like rm cmd even if not exist
```
go run main.go c i delete test1 test2 test404 test3 testNotexist -f
 ✔ Deleting instance "test1, test2, test404, test3, testNotexist"... 9s
```

Nothing happen here
```
go run main.go c i delete 404 dummy notfound -f
```