### PR TITLE
Set API timeout from ENV when credentials are specified in ENV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- Set API timeout from ENV when credentials are specified in ENV #625
+
 ## 1.78.5
 
 ### Improvements

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -172,6 +172,13 @@ func initConfig() { //nolint:gocyclo
 			account.CurrentAccount.SosEndpoint = sosEndpointFromEnv
 		}
 
+		clientTimeoutFromEnv := readFromEnv("EXOSCALE_API_TIMEOUT")
+		if clientTimeoutFromEnv != "" {
+			if t, err := strconv.Atoi(clientTimeoutFromEnv); err == nil {
+				account.CurrentAccount.ClientTimeout = t
+			}
+		}
+
 		account.GAllAccount = &account.Config{
 			DefaultAccount: account.CurrentAccount.Name,
 			Accounts:       []account.Account{*account.CurrentAccount},


### PR DESCRIPTION
# Description

Fixes bug with  EXOSCALE_API_TIMEOUT being ignored when credentials are specified in ENV.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

Before change:
```bash
$ EXOSCALE_API_KEY=xxx EXOSCALE_API_SECRET=xxx EXOSCALE_API_TIMEOUT=1 exo c i snapshot create myinstance -z ch-gva-2
 ✔ Creating snapshot of instance "myinstance"... 3m18s
┼───────────────┼────────────────────────────────────────┼
│   SNAPSHOT    │                                        │
┼───────────────┼────────────────────────────────────────┼
│ ID            │ b41413b9-58bc-4ccf-a498-7391bb603b91   │
│ Name          │ myinstance_ROOT-7380078_20240805161855 │
│ Creation Date │ 2024-08-05 16:18:55 +0000 UTC          │
│ State         │ exported                               │
│ Size (GB)     │ 50                                     │
│ Instance      │ myinstance                             │
│ Zone          │ ch-gva-2                               │
┼───────────────┼────────────────────────────────────────┼
```
After change:
```bash
$ EXOSCALE_API_KEY=xxx EXOSCALE_API_SECRET=xxx EXOSCALE_API_TIMEOUT=1 go run . c i snapshot create myinstance -z ch-gva-2
 ✔ Creating snapshot of instance "myinstance"... 1m0s
error: request timeout reached. Snapshot creation is not canceled and might still be running, check the status with: exo c i snapshot list
exit status 1
```
