### PR TITLE
storage: handle errors in batch objects delete action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- storage: handle errors in batch objects delete action #627
+
 ## 1.80.0
 
 ### Features

--- a/cmd/storage_delete.go
+++ b/cmd/storage_delete.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -86,6 +88,18 @@ argument with "/":
 
 		deleted, err := storage.DeleteObjects(gContext, bucket, prefix, recursive)
 		if err != nil {
+			e := sos.NewBatchErrorList()
+			if errors.As(err, e) {
+				if verbose {
+					for _, o := range deleted {
+						fmt.Println(aws.ToString(o.Key))
+					}
+				}
+
+				for _, e := range e.List {
+					fmt.Fprintln(os.Stderr, e)
+				}
+			}
 			return fmt.Errorf("unable to delete objects: %w", err)
 		}
 

--- a/cmd/storage_delete.go
+++ b/cmd/storage_delete.go
@@ -100,6 +100,7 @@ argument with "/":
 					fmt.Fprintln(os.Stderr, e)
 				}
 			}
+
 			return fmt.Errorf("unable to delete objects: %w", err)
 		}
 

--- a/pkg/storage/sos/object.go
+++ b/pkg/storage/sos/object.go
@@ -49,7 +49,7 @@ func (l BatchErrorList) Error() string {
 
 func (l *BatchErrorList) AddErrors(errs []types.Error) {
 	for _, err := range errs {
-		l.List = append(l.List, fmt.Errorf("%s", err.Message))
+		l.List = append(l.List, fmt.Errorf("%v", err.Message))
 	}
 }
 


### PR DESCRIPTION
# Description

Batch objects delete API method from `aws-sdk-go-v2` will not return error as second argument if individual objects failed to be deleted. Instead it will return both list of deleted objects and list of errors in result structure.

This prints errors (if any) after the list of successfully deleted files.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

<!--
Describe the tests you did
-->
