### PR TITLE
Fix list of dependencies for archlinux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
         shell: bash
 
       - name: install tools
-        run: pacman --noconfirm -Sy git openssh glibc sudo binutils make gcc pkg-config fakeroot go which
+        run: pacman --noconfirm -Sy base-devel git openssh glibc go
         shell: bash
 
       - name: release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+-  Fix list of dependencies for archlinux builds #628
+
 ## 1.78.6
 
 ### Bug Fixes


### PR DESCRIPTION
# Description

For archlinux builds install `base-devel` metapackage instead of individual tools. This fixes the build error triggered by missing `debugedit` tool:

```
==> ERROR: Cannot find the debugedit binary required for including source files in debug packages.
```

`base-devel` metapackage contains following packages (as the time of writing):
```
$ pacman -Qi base-devel | grep Depends
Depends On      : archlinux-keyring  autoconf  automake  binutils  bison  debugedit  fakeroot  file  findutils  flex  gawk  gcc  gettext  grep  groff  gzip  libtool  m4  make  pacman  patch  pkgconf  sed  sudo  texinfo  which
```

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

<!--
Describe the tests you did
-->
