### PR TITLE
Pass the zone when listing result of blockstorage operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased
-
+### Bug fixes
+- Fix creation and update of blockstorage volumes/snapshots in non-default zones
 ## 1.79.0
 
 ### Features

--- a/cmd/blockstorage_create.go
+++ b/cmd/blockstorage_create.go
@@ -90,6 +90,7 @@ func (c *blockStorageCreateCmd) cmdRun(_ *cobra.Command, _ []string) error {
 		return (&blockStorageShowCmd{
 			cliCommandSettings: c.cliCommandSettings,
 			Name:               c.Name,
+			Zone:               c.Zone,
 		}).cmdRun(nil, nil)
 	}
 

--- a/cmd/blockstorage_snapshot_create.go
+++ b/cmd/blockstorage_snapshot_create.go
@@ -83,6 +83,7 @@ func (c *blockStorageSnapshotCreateCmd) cmdRun(_ *cobra.Command, _ []string) err
 		return (&blockStorageSnapshotShowCmd{
 			cliCommandSettings: c.cliCommandSettings,
 			Name:               name,
+			Zone:               c.Zone,
 		}).cmdRun(nil, nil)
 	}
 

--- a/cmd/blockstorage_snapshot_update.go
+++ b/cmd/blockstorage_snapshot_update.go
@@ -91,6 +91,7 @@ func (c *blockStorageSnapshotUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) e
 		return (&blockStorageSnapshotShowCmd{
 			cliCommandSettings: c.cliCommandSettings,
 			Name:               name,
+			Zone:               c.Zone,
 		}).cmdRun(nil, nil)
 	}
 

--- a/cmd/blockstorage_update.go
+++ b/cmd/blockstorage_update.go
@@ -109,6 +109,7 @@ func (c *blockStorageUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 		return (&blockStorageShowCmd{
 			cliCommandSettings: c.cliCommandSettings,
 			Name:               name,
+			Zone:               c.Zone,
 		}).cmdRun(nil, nil)
 	}
 


### PR DESCRIPTION
# Description
After doing mutations on blockstorage related entities, we do a list to display the change. However this listing was done on the default zone and not on the zone where the update occurred. And because public API only return blockstorage results that live in the same zone, this was causing issues 

Before (default zone is ch-gva-2)
```
❯ exo compute block create test-create -z at-vie-1 --size 100
 ✔ Creating block storage volume "test-create"... 3s
error: "test-create" not found in ListBlockStorageVolumesResponse: resource not found
```
(The volume was successfully created bu failed to be displayed) 

After
```
❯ go run . compute block create test-create -z at-vie-1 --size 100                 
 ✔ Creating block storage volume "test-create"... 3s
┼─────────────────────────┼──────────────────────────────────────┼
│  BLOCK STORAGE VOLUME   │                                      │
┼─────────────────────────┼──────────────────────────────────────┼
│ Block Storage Snapshots │ n/a                                  │
│ Blocksize               │ 4096                                 │
│ Created AT              │ 2024-08-23 09:54:03 +0000 UTC        │
│ ID                      │ 641e351c-81ee-41fd-8273-52965ccbf3ed │
│ Instance                │ n/a                                  │
│ Name                    │ test-create                          │
│ Size                    │ 100 GiB                              │
│ Labels                  │ n/a                                  │
│ State                   │ detached                             │
┼─────────────────────────┼──────────────────────────────────────┼
```


## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

<!--
Describe the tests you did
-->
