### PR TITLE
refactor(ssh-keys-list): Update ssh-keys list to egoscale v3

### DIFF
--- a/cmd/ssh_key_list.go
+++ b/cmd/ssh_key_list.go
@@ -6,10 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
-	exoapi "github.com/exoscale/egoscale/v2/api"
 )
 
 type computeSSHKeyListItemOutput struct {
@@ -45,22 +43,21 @@ func (c *computeSSHKeyListCmd) cmdPreRun(cmd *cobra.Command, args []string) erro
 }
 
 func (c *computeSSHKeyListCmd) cmdRun(_ *cobra.Command, _ []string) error {
-	ctx := exoapi.WithEndpoint(
-		gContext,
-		exoapi.NewReqEndpoint(account.CurrentAccount.Environment, account.CurrentAccount.DefaultZone),
-	)
 
-	sshKeys, err := globalstate.EgoscaleClient.ListSSHKeys(ctx, account.CurrentAccount.DefaultZone)
+	ctx := gContext
+	client := globalstate.EgoscaleV3Client
+
+	sshKeysResponse, err := client.ListSSHKeys(ctx)
 	if err != nil {
 		return err
 	}
 
 	out := make(computeSSHKeyListOutput, 0)
 
-	for _, k := range sshKeys {
+	for _, k := range sshKeysResponse.SSHKeys {
 		out = append(out, computeSSHKeyListItemOutput{
-			Name:        *k.Name,
-			Fingerprint: *k.Fingerprint,
+			Name:        k.Name,
+			Fingerprint: k.Fingerprint,
 		})
 	}
 


### PR DESCRIPTION
# Description
Update ssh-keys list to egoscale v3

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

```
root@65df3c390733:/cli# go run . compute ssh-key list
┼──────────────────────┼─────────────────────────────────────────────────┼
│         NAME         │                   FINGERPRINT                   │
┼──────────────────────┼─────────────────────────────────────────────────┼
│ key1                 │ 5d:49:0a:8a:f2:17:9f:ef:9e:06:e0:46:ad:42:ef:91 │
│ key2                 │ 19:59:d8:58:ce:be:4c:8b:fa:5b:c2:3c:0b:27:a1:12 │
│ key3                 │ 93:d5:1a:55:36:ba:e9:6b:16:b8:17:9a:39:a4:31:1a │
│ key4                 │ 7e:08:64:f5:95:bb:b9:69:37:1d:ab:4e:3c:cc:19:43 │
│ key5                 │ 1c:d8:19:38:a3:c4:bf:87:f8:78:80:c4:71:46:c6:34 │
│ key6                 │ ea:ab:c5:7f:dc:44:31:b9:6a:ad:21:19:7c:7b:3e:0c │
│ key7                 │ 93:b2:67:e1:fd:f8:80:5b:23:59:e5:3f:25:52:e2:38 │
┼──────────────────────┼─────────────────────────────────────────────────┼

```