### PR TITLE
Fix installation script to support `aarch64`

### DIFF
--- a/install-latest.sh
+++ b/install-latest.sh
@@ -84,6 +84,9 @@ case "$(uname -m)" in
     x86_64)
         CPUARCHITECTURE="amd64"
         ;;
+    aarch64)
+        CPUARCHITECTURE="arm64"
+        ;;
     armv7l)
         CPUARCHITECTURE="armv7"
         ;;


### PR DESCRIPTION
# Description
The installation fails right now if `uname -m` reports `aarch64` which, according to wikipedia, is a synonym for `arm64` architecture (https://en.wikipedia.org/wiki/AArch64).

Therefore, this PR adds a rule for renaming `aarch64` to `arm64` in the installation script.

## Testing
Using `debian:stable-slim` Docker image on M1 chip reported `aarch64` as the architecture which is how I ran into this issue in the first place. This change made the installation work and running `exo` worked.