### PR TITLE
fix: Remove ineffective replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/exoscale/cli
 
-replace gopkg.ini/ini.v1 => github.com/go-ini/ini v1.42.0
-
 require (
 	github.com/aws/aws-sdk-go-v2 v1.2.0
 	github.com/aws/aws-sdk-go-v2/config v1.1.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -788,4 +788,3 @@ gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
-# gopkg.ini/ini.v1 => github.com/go-ini/ini v1.42.0


### PR DESCRIPTION
# Description
`replace` directives prevent usage of `go install` or `go run` against this package.

Furthermore, the `replace` directive had a typo in it, so it was not doing anything anyway.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

Removed replace directive.
Ran `go mod tidy`
Ran `go mod vendor`
Checked that no dependencies were changed
Ran `go test ./...` for good measure
