### PR TITLE
anti-affinity group: fix a bug in the "show" command to list all attached instances from different zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 - Storage: handle errors in batch objects delete action #627
 - Instance: Fix instance protection flag update zone context #648
-- Anti-affinity group: fix show command to print all the attached instances from different zones
+- Anti-affinity group: fix show command to print all the attached instances from different zones #649
 
 ## 1.80.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Storage: handle errors in batch objects delete action #627
 - Instance: Fix instance protection flag update zone context #648
+- Anti-affinity group: fix show command to print all the attached instances from different zones
 
 ## 1.80.0
 

--- a/cmd/anti_affinity_group_show.go
+++ b/cmd/anti_affinity_group_show.go
@@ -50,7 +50,7 @@ func (c *antiAffinityGroupShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	antiAffinityGroupsResp, err := globalstate.EgoscaleV3Client.ListAntiAffinityGroups(ctx)
 	if err != nil {
-		return fmt.Errorf("unable to retrieve list of anti-affinity %q: %w", err)
+		return fmt.Errorf("unable to retrieve list of anti-affinity %w", err)
 	}
 
 	antiAffinityGroup, err := antiAffinityGroupsResp.FindAntiAffinityGroup(c.AntiAffinityGroup)

--- a/cmd/anti_affinity_group_show.go
+++ b/cmd/anti_affinity_group_show.go
@@ -50,7 +50,7 @@ func (c *antiAffinityGroupShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	antiAffinityGroupsResp, err := globalstate.EgoscaleV3Client.ListAntiAffinityGroups(ctx)
 	if err != nil {
-		return fmt.Errorf("unable to retrieve list of anti-affinity %w", err)
+		return fmt.Errorf("unable to retrieve list of anti-affinity groups: %w", err)
 	}
 
 	antiAffinityGroup, err := antiAffinityGroupsResp.FindAntiAffinityGroup(c.AntiAffinityGroup)

--- a/cmd/anti_affinity_group_show.go
+++ b/cmd/anti_affinity_group_show.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
-
-	"github.com/spf13/cobra"
-
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
 	v3 "github.com/exoscale/egoscale/v3"
+	"github.com/spf13/cobra"
+	"strings"
 )
 
 type antiAffinityGroupShowOutput struct {
@@ -52,27 +50,29 @@ func (c *antiAffinityGroupShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 
 	antiAffinityGroupsResp, err := globalstate.EgoscaleV3Client.ListAntiAffinityGroups(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to retrieve list of anti-affinity %q: %w", err)
 	}
 
 	antiAffinityGroup, err := antiAffinityGroupsResp.FindAntiAffinityGroup(c.AntiAffinityGroup)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to find anti-affinity group %q: %w", c.AntiAffinityGroup, err)
 	}
-
 	out := antiAffinityGroupShowOutput{
 		ID:          antiAffinityGroup.ID,
 		Name:        antiAffinityGroup.Name,
 		Description: antiAffinityGroup.Description,
 	}
 
-	if antiAffinityGroup.Instances != nil {
-		out.Instances = make([]string, len(antiAffinityGroup.Instances))
-		for i, instance := range antiAffinityGroup.Instances {
-			out.Instances[i] = instance.Name
+	antiAffinityGroupWithInstanceDetails, err := globalstate.EgoscaleV3Client.GetAntiAffinityGroup(ctx, antiAffinityGroup.ID)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve anti-affinity group with instance details %q: %w", c.AntiAffinityGroup, err)
+	}
+	if antiAffinityGroupWithInstanceDetails.Instances != nil {
+		out.Instances = make([]string, len(antiAffinityGroupWithInstanceDetails.Instances))
+		for i, instance := range antiAffinityGroupWithInstanceDetails.Instances {
+			out.Instances[i] = instance.ID.String()
 		}
 	}
-
 	return c.outputFunc(&out, nil)
 }
 

--- a/cmd/iam_api_key_create.go
+++ b/cmd/iam_api_key_create.go
@@ -12,9 +12,9 @@ import (
 )
 
 type iamAPIKeyShowOutput struct {
-	Name   string `json:"name"`
-	Key    string `json:"key"`
-	Secret string `json:"secret"`
+	Name   string  `json:"name"`
+	Key    string  `json:"key"`
+	Secret string  `json:"secret"`
 	Role   v3.UUID `json:"role-id"`
 }
 


### PR DESCRIPTION
# Description
 Fix a bug in the "show" command to list all attached instances from different zones, while the user tries to printanti-affinity group, the attached instance list is printed empty.


## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing
### Before the fix

```
PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> go run .  compute instance create se-test-2 --anti-affinity-group=se-test-1 --zone=de-muc-1
 ✔ Creating instance "se-test-2"... 12s
┼──────────────────────┼──────────────────────────────────────┼
│   COMPUTE INSTANCE   │                                      │
┼──────────────────────┼──────────────────────────────────────┼
│ ID                   │ 583ee938-e5f8-4142-a3f4-f08dc77ce3a9 │
│ Name                 │ se-test-2                            │
│ Creation Date        │ 2024-11-07 17:55:25 +0000 UTC        │
│ Instance Type        │ standard.medium                      │
│ Template             │ Linux Ubuntu 22.04 LTS 64-bit        │
│ Zone                 │ de-muc-1                             │
│ Anti-Affinity Groups │ se-test-1                            │
│ Deploy Target        │ -                                    │
│ Security Groups      │ default                              │
│ Private Instance     │ No                                   │
│ Private Networks     │ n/a                                  │
│ Elastic IPs          │ n/a                                  │
│ IP Address           │ 194.182.180.240                      │
│ IPv6 Address         │ -                                    │
│ SSH Key              │ -                                    │
│ Disk Size            │ 50 GiB                               │
│ State                │ running                              │
│ Labels               │ n/a                                  │
│ Reverse DNS          │                                      │
┼──────────────────────┼──────────────────────────────────────┼

PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> go run .  compute anti-affinity-group show se-test-1                
┼─────────────┼──────────────────────────────────────┼
│ ID          │ a769d132-5baa-4a09-8a12-28437fd3f820 │
│ Name        │ se-test-1                            │
│ Description │                                      │
│ Instances   │                                      │
│             │                                      │
┼─────────────┼──────────────────────────────────────┼
```


### After the fix

```
PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> go run .  compute instance create se-af-test-3 --anti-affinity-group=se-test-1 -z=at-vie-2
 ✔ Creating instance "se-af-test-3"... 9s
┼──────────────────────┼──────────────────────────────────────┼
│   COMPUTE INSTANCE   │                                      │
┼──────────────────────┼──────────────────────────────────────┼
│ ID                   │ 371f94ba-1a1d-4fc0-a4be-9c3e60301b2a │
│ Name                 │ se-af-test-3                         │
│ Creation Date        │ 2024-11-11 11:08:09 +0000 UTC        │
│ Instance Type        │ standard.medium                      │
│ Template             │ Linux Ubuntu 22.04 LTS 64-bit        │
│ Zone                 │ at-vie-2                             │
│ Anti-Affinity Groups │ se-test-1                            │
│ Deploy Target        │ -                                    │
│ Security Groups      │ default                              │
│ Private Instance     │ No                                   │
│ Private Networks     │ n/a                                  │
│ Elastic IPs          │ n/a                                  │
│ IP Address           │ 138.124.210.60                       │
│ IPv6 Address         │ -                                    │
│ SSH Key              │ -                                    │
│ Disk Size            │ 50 GiB                               │
│ State                │ running                              │
│ Labels               │ n/a                                  │
│ Reverse DNS          │                                      │
┼──────────────────────┼──────────────────────────────────────┼
PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> go run .  compute anti-affinity-group show se-test-1
┼─────────────┼──────────────────────────────────────┼
│ ID          │ a769d132-5baa-4a09-8a12-28437fd3f820 │
│ Name        │ se-test-1                            │
│ Description │                                      │
│ Instances   │ 371f94ba-1a1d-4fc0-a4be-9c3e60301b2a │
┼─────────────┼──────────────────────────────────────┼
PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> go run .  compute instance create se-af-test-4 --anti-affinity-group=se-test-1 -z=de-muc-1
 ✔ Creating instance "se-af-test-4"... 12s
┼──────────────────────┼──────────────────────────────────────┼
│   COMPUTE INSTANCE   │                                      │
┼──────────────────────┼──────────────────────────────────────┼
│ ID                   │ fe9ef0e1-3133-48e1-b897-6b49199c2b7e │
│ Name                 │ se-af-test-4                         │
│ Creation Date        │ 2024-11-11 11:09:22 +0000 UTC        │
│ Instance Type        │ standard.medium                      │
│ Template             │ Linux Ubuntu 22.04 LTS 64-bit        │
│ Zone                 │ de-muc-1                             │
│ Anti-Affinity Groups │ se-test-1                            │
│ Deploy Target        │ -                                    │
│ Security Groups      │ default                              │
│ Private Instance     │ No                                   │
│ Private Networks     │ n/a                                  │
│ Elastic IPs          │ n/a                                  │
│ IP Address           │ 194.182.181.4                        │
│ IPv6 Address         │ -                                    │
│ SSH Key              │ -                                    │
│ Disk Size            │ 50 GiB                               │
│ State                │ running                              │
│ Labels               │ n/a                                  │
│ Reverse DNS          │                                      │
┼──────────────────────┼──────────────────────────────────────┼
PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> go run .  compute anti-affinity-group show se-test-1                                      
┼─────────────┼──────────────────────────────────────┼
│ ID          │ a769d132-5baa-4a09-8a12-28437fd3f820 │
│ Name        │ se-test-1                            │
│ Description │                                      │
│ Instances   │ 371f94ba-1a1d-4fc0-a4be-9c3e60301b2a │
│             │ fe9ef0e1-3133-48e1-b897-6b49199c2b7e │
┼─────────────┼──────────────────────────────────────┼


PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> go run .  compute instance delete se-af-test-3 -z=at-vie-2
[+] Are you sure you want to delete instance "se-af-test-3"? [yN]: y
 ✔ Deleting instance "se-af-test-3"... 6s
PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> go run .  compute instance delete se-af-test-4 -z=de-mus-1            
error: switch client zone v3: get zone api endpoint: find zone: "de-mus-1" not found in ListZonesResponse: Not Found
exit status 1
PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> go run .  compute instance delete se-af-test-4 -z=de-muc-1
[+] Are you sure you want to delete instance "se-af-test-4"? [yN]: y
 ✔ Deleting instance "se-af-test-4"... 12s
PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> go run .  compute anti-affinity-group show se-test-1
┼─────────────┼──────────────────────────────────────┼
│ ID          │ a769d132-5baa-4a09-8a12-28437fd3f820 │
│ Name        │ se-test-1                            │
│ Description │                                      │
│ Instances   │ n/a                                  │
┼─────────────┼──────────────────────────────────────┼

```

