### PR TITLE
feat(ci): Trigger regeneration of community docs on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,12 @@ on:
       - 'v[0-9]+\.[0-9]+\.[0-9]+'
 
 jobs:
+  community-docs:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.EXOSCALE_BUILD_GH_TOKEN }}
+    steps:
+      - run: gh workflow run gen-cli.yaml -R exoscale/community-ng -f version=${{ github.ref_name }}
   goreleaser:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
# Description
Triggers a rebuild of the community docs when we release a new CLI version.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

`GH_TOKEN` was set the value in the secret.
```console
$ export GH_TOKEN=<redacted>
$ gh workflow run gen-cli.yaml -R exoscale/community-ng -f version=master
✓ Created workflow_dispatch event for gen-cli.yaml at main

To see runs for this workflow, try: gh run list --workflow=gen-cli.yaml
```
