### PR TITLE
config: fixing bug sosEndpoint lost after user switch account

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -139,6 +139,9 @@ func saveConfig(filePath string, newAccounts *account.Config) error {
 		if acc.Account != "" {
 			accounts[i]["account"] = acc.Account
 		}
+		if acc.SosEndpoint != "" {
+			accounts[i]["sosendpoint"] = acc.SosEndpoint
+		}
 		if len(acc.SecretCommand) != 0 {
 			accounts[i]["secretCommand"] = acc.SecretCommand
 		} else {


### PR DESCRIPTION
Fixing bug `sosEnpoint` lost in the `.toml` file,  in case the user added `sosEndpoint`, it gets lost after switching the account.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

### Before the fix

This is how the `toml` file looks like

```
defaultZone = 'at-vie-1'
key = 'test'
name = 'Test'
secret = 'test2348198test'
sosendpoint = 'https://sos-{zone}.exo.io'

[[accounts]]
defaultZone = 'at-vie-1'
key = 'test2'
name = 'test-2'
secret = 'test3'
sosendpoint = 'https://ppsos-{zone}.exo.io'
```
After the user switch the account 
```
go run . config
Use the arrow keys to navigate: j k l h 
? Configured accounts (* = default account):
  >Test*
    test-2
    <Configure a new account>

defaultZone = 'at-vie-1'
key = 'test'
name = 'Test'
secret = 'testkey'

[[accounts]]
defaultZone = 'at-vie-1'
key = 'test2'
name = 'test-2'
secret = 'testKey'

```

### After the fix
```
defaultZone = 'at-vie-1'
key = 'test'
name = 'Test'
secret = 'test2348198test'
sosendpoint = 'https://sos-{zone}.exo.io'

[[accounts]]
defaultZone = 'at-vie-1'
key = 'test2'
name = 'test-2'
secret = 'test3'
sosendpoint = 'https://ppsos-{zone}.exo.io'
```
After the user switch the account 
```
go run . config
Use the arrow keys to navigate: j k l h 
? Configured accounts (* = default account):
  >Test*
    test-2
    <Configure a new account>

defaultZone = 'at-vie-1'
key = 'test'
name = 'Test'
secret = 'testkey'
sosendpoint = 'https://ppsos-{zone}.exo.io'

[[accounts]]
defaultZone = 'at-vie-1'
key = 'test2'
name = 'test-2'
secret = 'testKey'
sosendpoint = 'https://ppsos-{zone}.exo.io'

```
