### PR TITLE
storage: Adding recursive feature to the storage command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Features
+
+- storage: Adding recursive feature to the storage command #653
 
 ## 1.81.0
 

--- a/pkg/storage/sos/object.go
+++ b/pkg/storage/sos/object.go
@@ -184,7 +184,8 @@ func (c *Client) DownloadFiles(ctx context.Context, config *DownloadConfig) erro
 		}
 
 		if _, err := os.Stat(dst); err == nil && !config.Overwrite {
-			return fmt.Errorf("file %q already exists, use flag `-f` to overwrite", dst)
+			fmt.Printf("error: file %q already exists, use flag `-f` to overwrite\n", dst)
+			continue
 		}
 
 		if err := c.DownloadFile(ctx, config.Bucket, object, dst); err != nil {

--- a/pkg/storage/sos/object.go
+++ b/pkg/storage/sos/object.go
@@ -129,15 +129,18 @@ type DownloadConfig struct {
 }
 
 func (c *Client) DownloadFiles(ctx context.Context, config *DownloadConfig) error {
-	if len(config.Objects) > 1 && !strings.HasSuffix(config.Destination, "/") {
-		return errors.New(`multiple files to download, destination must end with "/"`)
-	}
-
-	// Handle relative filesystem destination (e.g. ".", "../.." etc.)
-	if dstInfo, err := os.Stat(config.Destination); err == nil {
-		if dstInfo.IsDir() && !strings.HasSuffix(config.Destination, "/") {
-			config.Destination += "/"
+	config.Destination = filepath.Clean(strings.TrimRight(config.Destination, string(os.PathSeparator)))
+	dstInfo, err := os.Stat(config.Destination)
+	if err == nil {
+		if !dstInfo.IsDir() {
+			return fmt.Errorf("destination %q is not a directory, use flag `-f` to overwrite", config.Destination)
 		}
+	} else if os.IsNotExist(err) {
+		if err := os.MkdirAll(config.Destination, 0o755); err != nil {
+			return fmt.Errorf("failed to create destination directory: %w", err)
+		}
+	} else {
+		return fmt.Errorf("error checking destination path: %w", err)
 	}
 
 	if config.DryRun {
@@ -146,30 +149,42 @@ func (c *Client) DownloadFiles(ctx context.Context, config *DownloadConfig) erro
 
 	for _, object := range config.Objects {
 		dst := func() string {
-			if strings.HasSuffix(config.Source, "/") {
-				return path.Join(config.Destination, strings.TrimPrefix(aws.ToString(object.Key), config.Prefix))
+			if config.Recursive {
+				relativePath := strings.TrimPrefix(aws.ToString(object.Key), config.Prefix)
+				if !strings.HasPrefix(config.Prefix, "/") && !strings.HasPrefix(relativePath, config.Prefix) {
+					relativePath = filepath.Join(config.Prefix, relativePath)
+				}
+				return filepath.Join(config.Destination, relativePath)
 			}
 
-			if strings.HasSuffix(config.Destination, "/") {
-				return path.Join(config.Destination, path.Base(aws.ToString(object.Key)))
+			if strings.HasSuffix(config.Destination, string(os.PathSeparator)) || dstInfo.IsDir() {
+				return filepath.Join(config.Destination, path.Base(aws.ToString(object.Key)))
 			}
 
-			return path.Join(config.Destination)
+			return filepath.Clean(config.Destination)
 		}()
 
+		if strings.HasSuffix(aws.ToString(object.Key), "/") {
+			if err := os.MkdirAll(dst, 0o755); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", dst, err)
+			}
+			continue
+		}
+
+		parentDir := filepath.Dir(dst)
+		if _, err := os.Stat(parentDir); os.IsNotExist(err) {
+			if err := os.MkdirAll(parentDir, 0o755); err != nil {
+				return fmt.Errorf("failed to create directories: %w", err)
+			}
+		}
+
 		if config.DryRun {
-			fmt.Printf("%s/%s -> %s\n", config.Bucket, aws.ToString(object.Key), dst)
+			fmt.Printf("[DRY-RUN] %s/%s -> %s\n", config.Bucket, aws.ToString(object.Key), dst)
 			continue
 		}
 
 		if _, err := os.Stat(dst); err == nil && !config.Overwrite {
 			return fmt.Errorf("file %q already exists, use flag `-f` to overwrite", dst)
-		}
-
-		if _, err := os.Stat(path.Dir(dst)); errors.Is(err, os.ErrNotExist) {
-			if err := os.MkdirAll(path.Dir(dst), 0o755); err != nil {
-				return err
-			}
 		}
 
 		if err := c.DownloadFile(ctx, config.Bucket, object, dst); err != nil {


### PR DESCRIPTION
# Description

The user can now use a recursive flag to download files with tree directories, different use cases were considered as well:
- The user can specify a directory with the `-r` flag and the directory with its sub-directory will be downloaded and its content.
- if the sub-directory contains duplicated files it will skip the duplicated files and download the rest.
- if the user specifies destination folder not ending "/", it will check if it's a file, otherwise it throws an error, if not it will create the file
- if the user tries to download a file that already exists it will throw an error.

## Checklist

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

### Before the change


#### Show how the bucket on exoscale side looks like
```
PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> exo storage list sos://test-99/      
  DIR  sub-1/
  DIR  sub-2/
PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> exo storage list sos://test-99/sub-1/
2024-11-25 14:22:33 UTC    0 B  sub-1/
2024-11-25 15:54:59 UTC  431 B  sub-1/testDownload-2 copy.rtf
2024-11-25 15:57:04 UTC  431 B  sub-1/testDownload-2-copy.rtf
2024-11-25 15:32:41 UTC  431 B  sub-1/testDownload-2.rtf


```

#### Show how the local directory  looks like
I have folder `bucket-test-677` which contains only `emptyfile.txt `

```
PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> dir "C:\Users\Administrator\Desktop\Apps\bucket-test-677"


    Directory: C:\Users\Administrator\Desktop\Apps\bucket-test-677


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----        11/26/2024  11:59 AM              0 emptyfile.txt 

```
#### testing to download directory to local directory `without` specifying  `/` at the end

```
PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> exo storage download sos://test-99/sub-1/ "C:\Users\Administrator\Desktop\Apps\bucket-test-677" -r                       
error: multiple files to download, destination must end with "/"
```

#### testing to download directory to local directory `with` specifying  `/` at the end, it trigger an error `bucket-test-677 exists`

```
PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> exo storage download sos://test-99/sub-1/ "C:\Users\Administrator\Desktop\Apps\bucket-test-677/" -r
error: file "C:\\Users\\Administrator\\Desktop\\Apps\\bucket-test-677" already exists, use flag `-f` to overwrite

```

#### testing to download file to local directory `with`   `-r flag` it download it but without the root directories.

```

PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> exo storage download sos://test-99/sub-1/testDownload-2.rtf "C:\Users\Administrator\Desktop\Apps\bucket-test-677/" -r
sub-1/testDownl… [==============================================================================] 431.00 b / 431.00 b | 0s

PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> dir "C:\Users\Administrator\Desktop\Apps\bucket-test-677"                                                            


    Directory: C:\Users\Administrator\Desktop\Apps\bucket-test-677


Mode                 LastWriteTime         Length Name                                                                                                                                                                             
----                 -------------         ------ ----
-a----        11/26/2024  11:59 AM              0 emptyfile.txt
-a----        11/26/2024  12:03 PM            431 testDownload-2.rtf

```

### After the change
#### testing to download directory to local directory `without` specifying  `/` at the end, it download it with all content.

```
PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> go run . storage download sos://test-99/sub-1/ "C:\Users\Administrator\Desktop\Apps\bucket-test-677" -r
sub-1/testDownl… [==============================================================================] 431.00 b / 431.00 b | 0s
sub-1/testDownl… [==============================================================================] 431.00 b / 431.00 b | 0s
sub-1/testDownl… [==============================================================================] 431.00 b / 431.00 b | 0s

```

#### checking the local directory after the download

```
PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> dir "C:\Users\Administrator\Desktop\Apps\bucket-test-677"                                              


    Directory: C:\Users\Administrator\Desktop\Apps\bucket-test-677


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d-----        11/26/2024  12:06 PM                sub-1                                                                                                                                                                            
-a----        11/26/2024  11:59 AM              0 emptyfile.txt
-a----        11/26/2024  12:03 PM            431 testDownload-2.rtf                                                                                                                                                               


PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> dir "C:\Users\Administrator\Desktop\Apps\bucket-test-677/sub-1"


    Directory: C:\Users\Administrator\Desktop\Apps\bucket-test-677\sub-1


Mode                 LastWriteTime         Length Name                                                                                                                                                                             
----                 -------------         ------ ----
-a----        11/26/2024  12:06 PM            431 testDownload-2 copy.rtf                                                                                                                                                          
-a----        11/26/2024  12:06 PM            431 testDownload-2-copy.rtf
-a----        11/26/2024  12:06 PM            431 testDownload-2.rtf

```

#### deleting the `testDownload-2.rtf` file from the local directory `sub-1`, to test what happens if  try to download the sub-1 again where we are missing one file

```
PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> del "C:\Users\Administrator\Desktop\Apps\bucket-test-677\sub-1\testDownload-2.rtf"
PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> dir "C:\Users\Administrator\Desktop\Apps\bucket-test-677/sub-1"                   


    Directory: C:\Users\Administrator\Desktop\Apps\bucket-test-677\sub-1


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----                                                                                                                                                                             
-a----        11/26/2024  12:06 PM            431 testDownload-2 copy.rtf
-a----        11/26/2024  12:06 PM            431 testDownload-2-copy.rtf

```

#### downloading the `sub-1`, and the logs show that the duplicated files are ignored if the flag `-f` not used. and downloading the rest.

```

PS C:\Users\Administrator\Desktop\Apps\Exoscale\CLI\exo-cli show anti-affinity-group with instances> go run . storage download sos://test-99/sub-1/ "C:\Users\Administrator\Desktop\Apps\bucket-test-677" -r
error: file "C:\\Users\\Administrator\\Desktop\\Apps\\bucket-test-677\\sub-1\\testDownload-2 copy.rtf" already exists, use flag `-f` to overwrite
error: file "C:\\Users\\Administrator\\Desktop\\Apps\\bucket-test-677\\sub-1\\testDownload-2-copy.rtf" already exists, use flag `-f` to overwrite
sub-1/testDownl… [==============================================================================] 431.00 b / 431.00 b | 0s
```