### PR TITLE
CLI: adding dbaas acl management

### DIFF
--- a/cmd/dbaas_acl.go
+++ b/cmd/dbaas_acl.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var dbaasAclCmd = &cobra.Command{
+	Use:   "acl",
+	Short: "Manage DBaaS acl",
+}
+
+func init() {
+	dbaasCmd.AddCommand(dbaasAclCmd)
+}

--- a/cmd/dbaas_acl_create.go
+++ b/cmd/dbaas_acl_create.go
@@ -1,0 +1,1 @@
+package cmd

--- a/cmd/dbaas_acl_delete.go
+++ b/cmd/dbaas_acl_delete.go
@@ -1,0 +1,1 @@
+package cmd

--- a/cmd/dbaas_acl_list.go
+++ b/cmd/dbaas_acl_list.go
@@ -1,0 +1,1 @@
+package cmd

--- a/cmd/dbaas_acl_show.go
+++ b/cmd/dbaas_acl_show.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/exoscale/cli/pkg/output"
+	"github.com/exoscale/cli/table"
+	"github.com/spf13/cobra"
+)
+
+type dbaasAclShowOutput struct {
+	Username   string `json:"username,omitempty"`
+	Permission string `json:"permission,omitempty"`
+	Topic      string `json:"topic,omitempty"`
+}
+
+func (o *dbaasAclShowOutput) ToJSON() { output.JSON(o) }
+func (o *dbaasAclShowOutput) ToText() { output.Text(o) }
+
+func (o *dbaasAclShowOutput) ToTable() {
+	t := table.NewTable(os.Stdout)
+	t.SetHeader([]string{"ACL Entry"})
+	defer t.Render()
+
+	t.Append([]string{"Username", o.Username})
+	t.Append([]string{"Topic", o.Topic})
+	t.Append([]string{"Permission", o.Permission})
+}
+
+type dbaasAclShowCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_           bool   `cli-cmd:"show"`
+	Name        string `cli-flag:"name" cli-usage:"Name of the DBaaS service"`
+	Username    string `cli-flag:"username" cli-usage:"Username of the ACL entry"`
+	ServiceType string `cli-short:"t" cli-usage:"type of the DBaaS service (e.g., kafka, opensearch)"`
+	Zone        string `cli-short:"z" cli-usage:"Database Service zone"`
+}
+
+func (c *dbaasAclShowCmd) cmdAliases() []string { return nil }
+
+func (c *dbaasAclShowCmd) cmdShort() string { return "Show the details of an acl" }
+
+func (c *dbaasAclShowCmd) cmdLong() string {
+	return `This command show an acl entty and its details for a specified DBAAS service.`
+}
+
+func (c *dbaasAclShowCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	cmdSetZoneFlagFromDefault(cmd)
+
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *dbaasAclShowCmd) cmdRun(cmd *cobra.Command, args []string) error {
+	ctx := gContext
+
+	if c.Name == "" || c.Username == "" {
+		return fmt.Errorf("both --name and --username flags must be specified")
+	}
+
+	db, err := dbaasGetV3(ctx, c.Name, c.Zone)
+	if err != nil {
+		return fmt.Errorf("error retrieving DBaaS service %q in zone %q: %w", c.Name, c.Zone, err)
+	}
+
+	var output output.Outputter
+	switch db.Type {
+	case "kafka":
+		output, err = c.showKafka(ctx, c.Name)
+		//case "opensearch":
+		//output, err = c.showOpensearch(ctx)
+	default:
+		return fmt.Errorf("listing ACL unsupported for service of type %q", db.Type)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return c.outputFunc(output, nil)
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(dbaasAclCmd, &dbaasAclShowCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/dbaas_acl_show.go
+++ b/cmd/dbaas_acl_show.go
@@ -19,13 +19,13 @@ func (o *dbaasAclShowOutput) ToJSON() { output.JSON(o) }
 func (o *dbaasAclShowOutput) ToText() { output.Text(o) }
 
 func (o *dbaasAclShowOutput) ToTable() {
-	t := table.NewTable(os.Stdout)
-	t.SetHeader([]string{"ACL Entry"})
-	defer t.Render()
+	table := table.NewTable(os.Stdout)
+	table.SetHeader([]string{"ACL Entry"})
+	defer table.Render()
 
-	t.Append([]string{"Username", o.Username})
-	t.Append([]string{"Topic", o.Topic})
-	t.Append([]string{"Permission", o.Permission})
+	table.Append([]string{"Username", o.Username})
+	table.Append([]string{"Topic", o.Topic})
+	table.Append([]string{"Permission", o.Permission})
 }
 
 // Main command for showing ACLs

--- a/cmd/dbaas_acl_show_kafka.go
+++ b/cmd/dbaas_acl_show_kafka.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/exoscale/cli/pkg/globalstate"
+	"github.com/exoscale/cli/pkg/output"
+	v3 "github.com/exoscale/egoscale/v3"
+)
+
+func (c *dbaasAclShowCmd) showKafka(ctx context.Context, serviceName string) (output.Outputter, error) {
+	client, err := switchClientZoneV3(ctx, globalstate.EgoscaleV3Client, v3.ZoneName(c.Zone))
+	if err != nil {
+		return nil, fmt.Errorf("error initializing client for zone %s: %w", c.Zone, err)
+	}
+
+	// Fetch Kafka ACLs for the specified service
+	acls, err := client.GetDBAASKafkaAclConfig(ctx, serviceName)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching ACL configuration for service %q: %w", serviceName, err)
+	}
+
+	// Search for the specific username in the fetched ACLs
+	for _, acl := range acls.TopicAcl {
+		if acl.Username == c.Username {
+			return &dbaasAclShowOutput{
+				Username:   acl.Username,
+				Topic:      acl.Topic,
+				Permission: string(acl.Permission),
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("ACL entry for username %q not found in service %q", c.Username, serviceName)
+}

--- a/cmd/dbaas_acl_show_kafka.go
+++ b/cmd/dbaas_acl_show_kafka.go
@@ -8,6 +8,7 @@ import (
 	v3 "github.com/exoscale/egoscale/v3"
 )
 
+// Fetch OpenSearch ACL configuration and process its details
 func (c *dbaasAclShowCmd) showKafka(ctx context.Context, serviceName string) (output.Outputter, error) {
 	client, err := switchClientZoneV3(ctx, globalstate.EgoscaleV3Client, v3.ZoneName(c.Zone))
 	if err != nil {

--- a/cmd/dbaas_acl_show_opensearch.go
+++ b/cmd/dbaas_acl_show_opensearch.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/exoscale/cli/pkg/globalstate"
+	"github.com/exoscale/cli/pkg/output"
+	"github.com/exoscale/cli/table"
+	v3 "github.com/exoscale/egoscale/v3"
+)
+
+type dbaasAclShowOpensearchOutput struct {
+	Username           string                                 `json:"username,omitempty"`
+	Rules              []v3.DBAASOpensearchAclConfigAclsRules `json:"rules,omitempty"`
+	AclEnabled         bool                                   `json:"acl_enabled,omitempty"`
+	ExtendedAclEnabled bool                                   `json:"extended_acl_enabled,omitempty"`
+}
+
+func (o *dbaasAclShowOpensearchOutput) ToJSON() { output.JSON(o) }
+
+func (o *dbaasAclShowOpensearchOutput) ToText() { output.Text(o) }
+
+func (o *dbaasAclShowOpensearchOutput) ToTable() {
+	t := table.NewTable(os.Stdout)
+	t.SetHeader([]string{"Field", "Value"})
+	defer t.Render()
+
+	t.Append([]string{"ACL Enabled", fmt.Sprintf("%t", o.AclEnabled)})
+	t.Append([]string{"Extended ACL Enabled", fmt.Sprintf("%t", o.ExtendedAclEnabled)})
+
+	for _, rule := range o.Rules {
+		t.Append([]string{"Rule", fmt.Sprintf("ACL pattern: %s, Permission: %s", rule.Index, rule.Permission)})
+	}
+}
+
+func (c *dbaasAclShowCmd) showOpensearch(ctx context.Context, serviceName string) (output.Outputter, error) {
+	client, err := switchClientZoneV3(ctx, globalstate.EgoscaleV3Client, v3.ZoneName(c.Zone))
+	if err != nil {
+		return nil, fmt.Errorf("error initializing client for zone %s: %w", c.Zone, err)
+	}
+
+	aclsConfig, err := client.GetDBAASOpensearchAclConfig(ctx, serviceName)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching ACL configuration for service %q: %w", serviceName, err)
+	}
+
+	aclEnabled := false
+	if aclsConfig.AclEnabled != nil {
+		aclEnabled = *aclsConfig.AclEnabled
+	}
+
+	extendedAclEnabled := false
+	if aclsConfig.ExtendedAclEnabled != nil {
+		extendedAclEnabled = *aclsConfig.ExtendedAclEnabled
+	}
+
+	for _, acl := range aclsConfig.Acls {
+		if string(acl.Username) == c.Username {
+			return &dbaasAclShowOpensearchOutput{
+				Username:           string(acl.Username),
+				Rules:              acl.Rules,
+				AclEnabled:         aclEnabled,
+				ExtendedAclEnabled: extendedAclEnabled,
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("ACL entry for username %q not found in service %q", c.Username, serviceName)
+}

--- a/cmd/dbaas_acl_show_opensearch.go
+++ b/cmd/dbaas_acl_show_opensearch.go
@@ -22,42 +22,52 @@ func (o *dbaasAclShowOpensearchOutput) ToJSON() { output.JSON(o) }
 
 func (o *dbaasAclShowOpensearchOutput) ToText() { output.Text(o) }
 
+// ToTable Define table output formatting for OpenSearch
 func (o *dbaasAclShowOpensearchOutput) ToTable() {
 	t := table.NewTable(os.Stdout)
 	t.SetHeader([]string{"Field", "Value"})
 	defer t.Render()
 
+	// Display whether ACL and extended ACL are enabled
 	t.Append([]string{"ACL Enabled", fmt.Sprintf("%t", o.AclEnabled)})
 	t.Append([]string{"Extended ACL Enabled", fmt.Sprintf("%t", o.ExtendedAclEnabled)})
 
+	// Iterate over rules and display each
 	for _, rule := range o.Rules {
 		t.Append([]string{"Rule", fmt.Sprintf("ACL pattern: %s, Permission: %s", rule.Index, rule.Permission)})
 	}
 }
 
+// Fetch OpenSearch ACL configuration and process its details
 func (c *dbaasAclShowCmd) showOpensearch(ctx context.Context, serviceName string) (output.Outputter, error) {
+	// Switch to the appropriate client for the specified zone
 	client, err := switchClientZoneV3(ctx, globalstate.EgoscaleV3Client, v3.ZoneName(c.Zone))
 	if err != nil {
 		return nil, fmt.Errorf("error initializing client for zone %s: %w", c.Zone, err)
 	}
 
+	// Fetch OpenSearch ACL configuration for the specified service
 	aclsConfig, err := client.GetDBAASOpensearchAclConfig(ctx, serviceName)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching ACL configuration for service %q: %w", serviceName, err)
 	}
 
+	// Check if ACLs are enabled
 	aclEnabled := false
 	if aclsConfig.AclEnabled != nil {
 		aclEnabled = *aclsConfig.AclEnabled
 	}
 
+	// Check if extended ACLs are enabled
 	extendedAclEnabled := false
 	if aclsConfig.ExtendedAclEnabled != nil {
 		extendedAclEnabled = *aclsConfig.ExtendedAclEnabled
 	}
 
+	// Search for the specific username in the fetched ACLs
 	for _, acl := range aclsConfig.Acls {
 		if string(acl.Username) == c.Username {
+			// Return the ACL details for the matched username
 			return &dbaasAclShowOpensearchOutput{
 				Username:           string(acl.Username),
 				Rules:              acl.Rules,
@@ -66,6 +76,6 @@ func (c *dbaasAclShowCmd) showOpensearch(ctx context.Context, serviceName string
 			}, nil
 		}
 	}
-
+	// If no matching username is found, return an error
 	return nil, fmt.Errorf("ACL entry for username %q not found in service %q", c.Username, serviceName)
 }

--- a/cmd/dbaas_acl_show_opensearch.go
+++ b/cmd/dbaas_acl_show_opensearch.go
@@ -24,17 +24,17 @@ func (o *dbaasAclShowOpensearchOutput) ToText() { output.Text(o) }
 
 // ToTable Define table output formatting for OpenSearch
 func (o *dbaasAclShowOpensearchOutput) ToTable() {
-	t := table.NewTable(os.Stdout)
-	t.SetHeader([]string{"Field", "Value"})
-	defer t.Render()
+	table := table.NewTable(os.Stdout)
+	table.SetHeader([]string{"Field", "Value"})
+	defer table.Render()
 
 	// Display whether ACL and extended ACL are enabled
-	t.Append([]string{"ACL Enabled", fmt.Sprintf("%t", o.AclEnabled)})
-	t.Append([]string{"Extended ACL Enabled", fmt.Sprintf("%t", o.ExtendedAclEnabled)})
+	table.Append([]string{"ACL Enabled", fmt.Sprintf("%t", o.AclEnabled)})
+	table.Append([]string{"Extended ACL Enabled", fmt.Sprintf("%t", o.ExtendedAclEnabled)})
 
 	// Iterate over rules and display each
 	for _, rule := range o.Rules {
-		t.Append([]string{"Rule", fmt.Sprintf("ACL pattern: %s, Permission: %s", rule.Index, rule.Permission)})
+		table.Append([]string{"Rule", fmt.Sprintf("ACL pattern: %s, Permission: %s", rule.Index, rule.Permission)})
 	}
 }
 


### PR DESCRIPTION
# Description
Adding the ACL management to the CLI

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing
### acl sub-command

```
go run . dbaas -h                                                                             
Database as a Service management

Usage:
  exo dbaas [command]

Available Commands:
  acl                  Manage DBaaS acl
  ca-certificate       Retrieve the Database CA certificate
  create               Create a Database Service
  delete               Delete a Database Service
  external-endpoint    Manage DBaaS external endpoints
  external-integration Manage DBaaS external integrations
  list                 List Database Services
  logs                 Query a Database Service logs
  metrics              Query a Database Service metrics over time
  migration            database migration management
  show                 Show a Database Service details
  type                 Database Services types management
  update               Update Database Service
  user                 Manage DBaaS users

Flags:
  -h, --help   help for dbaas

Global Flags:
  -C, --config string            Specify an alternate config file [env EXOSCALE_CONFIG]
  -O, --output-format string     Output format (table|json|text), see "exo output --help" for more information
      --output-template string   Template to use if output format is "text"
  -Q, --quiet                    Quiet mode (disable non-essential command output)
  -A, --use-account string       Account to use in config file [env EXOSCALE_ACCOUNT]

Use "exo dbaas [command] --help" for more information about a command.

```
### dbaas acl -h sub-command
```
go run . dbaas acl -h
Manage DBaaS acl

Usage:
  exo dbaas acl [command]

Available Commands:
  show        Show the details of an acl

Flags:
  -h, --help   help for acl

Global Flags:
  -C, --config string            Specify an alternate config file [env EXOSCALE_CONFIG]
  -O, --output-format string     Output format (table|json|text), see "exo output --help" for more information
      --output-template string   Template to use if output format is "text"
  -Q, --quiet                    Quiet mode (disable non-essential command output)
  -A, --use-account string       Account to use in config file [env EXOSCALE_ACCOUNT]

Use "exo dbaas acl [command] --help" for more information about a command.

```

### show DBaas service acl user
#### show helper sub-command

```
go run . dbaas acl show -h
This command show an acl entty and its details for a specified DBAAS service.

Usage:
  exo dbaas acl show [flags]

Flags:
  -h, --help              help for show
      --name string       Name of the DBaaS service
  -t, --type string       type of the DBaaS service (e.g., kafka, opensearch)
      --username string   Username of the ACL entry
  -z, --zone string       Database Service zone

Global Flags:
  -C, --config string            Specify an alternate config file [env EXOSCALE_CONFIG]
  -O, --output-format string     Output format (table|json|text), see "exo output --help" for more information
      --output-template string   Template to use if output format is "text"
  -Q, --quiet                    Quiet mode (disable non-essential command output)
  -A, --use-account string       Account to use in config file [env EXOSCALE_ACCOUNT]
```

#### Kafka Tests
##### show user 
```
 go run . dbaas acl show --type=kafka --name=se-test-2 --zone=ch-gva-2 --username=avnadmin     
┼────────────┼──────────┼
│ ACL ENTRY  │          │
┼────────────┼──────────┼
│ Username   │ avnadmin │
│ Topic      │ *        │
│ Permission │ admin    │
┼────────────┼──────────┼
```



#### Opensearch Tests

```
go run . dbaas acl show --type=opensearch --name=se-test-4 --zone=ch-gva-2 --username=avnadmin
┼──────────────────────┼────────────────────────────────────────────────────────────────────────┼
│        FIELD         │                                 VALUE                                  │
┼──────────────────────┼────────────────────────────────────────────────────────────────────────┼
│ ACL Enabled          │ false                                                                  │
│ Extended ACL Enabled │ false                                                                  │
│ Rule                 │ ACL pattern: test_1_and_test_2_and_test_4_and_test_4, Permission: deny │
│ Rule                 │ ACL pattern: book, Permission: admin                                   │
┼──────────────────────┼────────────────────────────────────────────────────────────────────────┼

```

##### use-case-1: Show acl with wrong Db name
if the user entered db name that exists in different service other the one stated in the flag if it exists in the other db it will give info about the other db that contains the he service, e.g. below `se-test-2` is kafka service but in the command below opensearch was stated instead 
```
go run . dbaas acl show --name=se-test-2 --username=avnadmin -z=ch-gva-2 --type=opensearch
error: mismatched service type: expected "opensearch" but got "kafka" for service "se-test-2"
exit status 1
```

##### use-case-2: Show acl with  missing required flag

```
go run . dbaas acl show --name=se-test-2 --username=avnadmin -z=ch-gva-2                  
error: both --name, --username and --type flags must be specified
exit status 1
```