### PR TITLE
security-group show: fix empty response if an API endpoint is misbehaving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - instance update: fixing no err check after creating client #657
 - fix(error): Improve error message on snapshot creation (#655)
+- security-group show: fix empty response if an API endpoint is misbehaving #660
 
 ## 1.82.0
 


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

`exo compute security-group show` iterates through all zones to retrieve instances associated with it. If a single API endpoint happened to throw an error, the call itself would error out. This fix allows showing that security group while still showing an error

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

<!--
Describe the tests you did
-->

```
➜  ~/exo/cli git:(tgrondier/sc-114869/exo-c-sh-show-error-in-preprod) ✗ go run . c sg show edc0d129-2f94-4531-920e-7cf798439cd3                                                                                             25-01-06 16:40 
error while listing instances in security group: 1 error occurred:
        * Get "https://ppapi-at-vie-2.exoscale.com/v2/instance": dial tcp: lookup ppapi-at-vie-2.exoscale.com on 127.0.0.53:53: server misbehaving

┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼
│  SECURITY GROUP  │                                                                                                                 │
┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼
│ ID               │ edc0d129-2f94-4531-920e-7cf798439cd3                                                                            │
│ Name             │ default                                                                                                         │
│ Description      │ Default Security Group                                                                                          │
│ Ingress Rules    │                                                                                                                 │
│                  │   08798387-0c7d-4601-a5ed-93367b889314      TCP   0.0.0.0/0   22                                                │
│                  │                                                                                                                 │
│ Egress Rules     │ -                                                                                                               │
│ External Sources │ -                                                                                                               │
│ Instances        │                                                                                                                 │
│                  │   VM-ec365352-f303-4fac-9cad-26e4a63b2227   ec365352-f303-4fac-9cad-26e4a63b2227   159.100.241.234   ch-gva-2   │
│                  │   VM-79e75e58-34c8-4f99-8168-e37722eb97cc   79e75e58-34c8-4f99-8168-e37722eb97cc   85.217.161.242    ch-gva-2   │
│                  │   VM-33e1fdda-d1d4-4fbd-8c7a-4e49971e3975   33e1fdda-d1d4-4fbd-8c7a-4e49971e3975   85.217.161.235    ch-gva-2   │
│                  │                                                                                                                 │
┼──────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼

```