### PR TITLE
Refactor sos.DownloadFiles & fix file rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - lint: add golangci-lint action #665
 
+### Bug fixes
+- Refactor sos.DownloadFiles & fix file rename #664
+
 ## 1.83.0
 
 ### Features

--- a/pkg/storage/sos/object.go
+++ b/pkg/storage/sos/object.go
@@ -149,10 +149,6 @@ func (c *Client) DownloadFiles(ctx context.Context, config *DownloadConfig) erro
 		if len(config.Objects) != 1 {
 			return fmt.Errorf("multiple objects but destination is a file")
 		}
-
-		if !config.Overwrite {
-			return fmt.Errorf("file %q already exists, use flag `-f` to overwrite", config.Destination)
-		}
 	case dstInfo.IsDir():
 		// Mark folder with explicit ending separator to differ from file rename.
 		if !strings.HasSuffix(config.Destination, string(filepath.Separator)) {
@@ -166,6 +162,11 @@ func (c *Client) DownloadFiles(ctx context.Context, config *DownloadConfig) erro
 		dst := config.Destination
 		if strings.HasSuffix(config.Destination, string(filepath.Separator)) {
 			dst = filepath.Join(config.Destination, aws.ToString(object.Key))
+		}
+
+		if _, err := os.Stat(dst); err == nil && !config.Overwrite {
+			fmt.Printf("error: file %q already exists, use flag `-f` to overwrite\n", dst)
+			continue
 		}
 
 		if config.DryRun {

--- a/pkg/storage/sos/object.go
+++ b/pkg/storage/sos/object.go
@@ -117,82 +117,46 @@ func (c *Client) GenPresignedURL(ctx context.Context, method, bucket, key string
 	return psURL.URL, nil
 }
 
-type DownloadConfig struct {
-	Bucket      string
-	Prefix      string
-	Source      string
-	Destination string
-	Objects     []*types.Object
-	Recursive   bool
-	Overwrite   bool
-	DryRun      bool
-}
-
-func (c *Client) DownloadFiles(ctx context.Context, config *DownloadConfig) error {
-	if config.DryRun {
-		fmt.Println("[DRY-RUN]")
-	}
-
-	config.Destination = filepath.Clean(config.Destination)
-
-	// Validate destination
-	dstInfo, err := os.Stat(config.Destination)
-	switch {
-	case err != nil && os.IsNotExist(err):
-		// Only acceptable for 1 object (implemented as a file rename).
-		if len(config.Objects) != 1 {
-			return fmt.Errorf("destination folder %q does not exist", config.Destination)
-		}
-	case err != nil: //err == nil implicit after this case
-		return fmt.Errorf("error checking destination path %w", err)
-	case dstInfo.Mode().IsRegular():
-		if len(config.Objects) != 1 {
-			return fmt.Errorf("multiple objects but destination is a file")
-		}
-	case dstInfo.IsDir():
-		// Mark folder with explicit ending path separator to differ from file rename.
-		if !strings.HasSuffix(config.Destination, string(filepath.Separator)) {
-			config.Destination = config.Destination + string(filepath.Separator)
-		}
-	default:
-		return fmt.Errorf("destination provided exists but is not a regular file or folder")
-	}
-
-	for _, object := range config.Objects {
-		dst := config.Destination
-		key := strings.TrimPrefix(aws.ToString(object.Key), config.Prefix)
-
-		fmt.Println("config.Destination: " + dst)
-		fmt.Println("key: " + key)
-
-		if config.Recursive {
-			if strings.HasSuffix(config.Destination, string(filepath.Separator)) {
-				dst = filepath.Join(config.Destination, key)
+func (c *Client) DownloadFiles(
+	ctx context.Context,
+	bucket, prefix, src, dst string,
+	objects []*types.Object,
+	overwrite, dryRun bool,
+) error {
+	if dst != "" {
+		dstInfo, err := os.Stat(dst)
+		switch {
+		case err != nil: //err == nil implicit after this case
+			if os.IsNotExist(err) {
+				return fmt.Errorf("destination folder %q does not exist", dst)
 			}
 
-			if !config.DryRun {
-				if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-					return fmt.Errorf("failed to create directory %s: %w", dst, err)
-				}
+			return fmt.Errorf("error checking destination path %w", err)
+		case !dstInfo.IsDir():
+			return fmt.Errorf("destination is not a folder")
+		}
+	}
+
+	for _, object := range objects {
+		key := aws.ToString(object.Key)
+		subpath := strings.TrimPrefix(key, prefix)
+		dst := filepath.Join(dst, subpath) // new local-scope dst variable!
+
+		if !dryRun {
+			err := os.MkdirAll(filepath.Dir(dst), 0o755)
+			if err != nil {
+				return fmt.Errorf("failed to create directory %q: %w", dst, err)
 			}
-		} else {
-			dst = filepath.Join(dst, filepath.Base(key))
 		}
 
-		fmt.Println("dst: " + dst)
-
-		if config.DryRun {
-			fmt.Printf("[DRY-RUN] %s/%s -> %s\n", config.Bucket, aws.ToString(object.Key), dst)
+		err := c.DownloadFile(ctx, bucket, dst, object, overwrite, dryRun)
+		if err != nil {
+			// We might have downloaded files succesfuly before this error,
+			// to quit with error now does not make much sense.
+			// Instead we print error to STDERR and continue.
+			// End result is some files complated & errors printed for those failed.
+			fmt.Fprintf(os.Stderr, "failed to dowload object %q: %v\n", key, err)
 			continue
-		}
-
-		if _, err := os.Stat(dst); err == nil && !config.Overwrite {
-			fmt.Printf("error: file %q already exists, use flag `-f` to overwrite\n", dst)
-			continue
-		}
-
-		if err := c.DownloadFile(ctx, config.Bucket, object, dst); err != nil {
-			return err
 		}
 	}
 
@@ -223,7 +187,37 @@ func (prox *proxyWriterAt) WriteAt(p []byte, off int64) (n int, err error) {
 	return n, err
 }
 
-func (c *Client) DownloadFile(ctx context.Context, bucket string, object *types.Object, dst string) error {
+func (c *Client) DownloadFile(
+	ctx context.Context,
+	bucket, dst string,
+	object *types.Object,
+	overwrite, dryRun bool,
+) error {
+	if dst == "" {
+		dst = filepath.Base(aws.ToString(object.Key))
+	}
+
+	dstInfo, err := os.Stat(dst)
+	switch {
+	case err != nil: //err == nil implicit after this case
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("error checking destination path: %w", err)
+		}
+	case dstInfo.Mode().IsRegular():
+		if !overwrite {
+			return fmt.Errorf("file %q already exists, use flag `-f` to overwrite", dst)
+		}
+	case dstInfo.IsDir():
+		dst = filepath.Join(dst, filepath.Base(aws.ToString(object.Key)))
+	default:
+		return fmt.Errorf("destination provided exists but is not a regular file or folder")
+	}
+
+	if dryRun {
+		fmt.Printf("[DRY-RUN] %s/%s -> %s\n", bucket, aws.ToString(object.Key), dst)
+		return nil
+	}
+
 	maxFilenameLen := 16
 
 	pb := mpb.NewWithContext(ctx,


### PR DESCRIPTION
# Description

This PR fixes a bug in file rename for `storage download` command. Bug was introduced in 1.83.0.
To make it easier to grasp the code for file downloads I refactored it to be explicit on supported download patterns.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

One file download, no rename:
```
$ ./cli storage download predrag-test-bucket/website/prepare.sh
website/prepare… [==============================================================================] 155.00 b / 155.00 b | 0s
$ ls prepare.sh 
prepare.sh
```
Same file download, no rename, no force flag
```
$ ./cli storage download predrag-test-bucket/website/prepare.sh
error: failed to download single file: file "prepare.sh" already exists, use flag `-f` to overwrite
```
One file download, no rename, force flag
```
$ ./cli storage download predrag-test-bucket/website/prepare.sh --force
website/prepare… [==============================================================================] 155.00 b / 155.00 b | 0s
$ ls prepare.sh 
prepare.sh
```
One file download with rename:
```
$ ./cli storage download predrag-test-bucket/website/prepare.sh newfile.sh
website/prepare… [==============================================================================] 155.00 b / 155.00 b | 0s
$ ls newfile.sh 
newfile.sh
```
Download prefix in current dir, no recursive flag:
```
$ ./cli storage download predrag-test-bucket/website/
website/.gitign… [==============================================================================] 14.00 b / 14.00 b | 0s
website/config.… [==============================================================================] 613.00 b / 613.00 b | 0s
website/prepare… [==============================================================================] 155.00 b / 155.00 b | 0s
$ ls
cli  config.toml  prepare.sh
```
Download prefix in current dir with recursive flag:
```
$ ./cli storage download predrag-test-bucket/website/ --recursive
website/.gitign… [==============================================================================] 14.00 b / 14.00 b | 0s
website/config.… [==============================================================================] 613.00 b / 613.00 b | 0s
website/content… [==============================================================================] 16.00 b / 16.00 b | 0s
website/layouts… [==============================================================================] 155.00 b / 155.00 b | 0s
website/layouts… [==============================================================================] 1.28 KiB / 1.28 KiB | 0s
website/layouts… [==============================================================================] 121.00 b / 121.00 b | 0s
website/layouts… [==============================================================================] 475.00 b / 475.00 b | 0s
website/layouts… [==============================================================================] 514.00 b / 514.00 b | 0s
website/layouts… [==============================================================================] 454.00 b / 454.00 b | 0s
website/layouts… [==============================================================================] 712.00 b / 712.00 b | 0s
website/layouts… [==============================================================================] 426.00 b / 426.00 b | 0s
website/layouts… [==============================================================================] 468.00 b / 468.00 b | 0s
website/layouts… [==============================================================================] 282.00 b / 282.00 b | 0s
website/layouts… [==============================================================================] 1.92 KiB / 1.92 KiB | 0s
website/layouts… [==============================================================================] 997.00 b / 997.00 b | 0s
website/layouts… [==============================================================================] 320.00 b / 320.00 b | 0s
website/prepare… [==============================================================================] 155.00 b / 155.00 b | 0s
$ ls
cli  config.toml  content  layouts  prepare.sh
```
Download prefix to existing subfolder:
```
$ mkdir subfolder
$ ./cli storage download predrag-test-bucket/website/ subfolder --recursive
website/.gitign… [==============================================================================] 14.00 b / 14.00 b | 0s
website/config.… [==============================================================================] 613.00 b / 613.00 b | 0s
website/content… [==============================================================================] 16.00 b / 16.00 b | 0s
website/layouts… [==============================================================================] 155.00 b / 155.00 b | 0s
website/layouts… [==============================================================================] 1.28 KiB / 1.28 KiB | 0s
website/layouts… [==============================================================================] 121.00 b / 121.00 b | 0s
website/layouts… [==============================================================================] 475.00 b / 475.00 b | 0s
website/layouts… [==============================================================================] 514.00 b / 514.00 b | 0s
website/layouts… [==============================================================================] 454.00 b / 454.00 b | 0s
website/layouts… [==============================================================================] 712.00 b / 712.00 b | 0s
website/layouts… [==============================================================================] 426.00 b / 426.00 b | 0s
website/layouts… [==============================================================================] 468.00 b / 468.00 b | 0s
website/layouts… [==============================================================================] 282.00 b / 282.00 b | 0s
website/layouts… [==============================================================================] 1.92 KiB / 1.92 KiB | 0s
website/layouts… [==============================================================================] 997.00 b / 997.00 b | 0s
website/layouts… [==============================================================================] 320.00 b / 320.00 b | 0s
website/prepare… [==============================================================================] 155.00 b / 155.00 b | 0s
$ ls subfolder/
config.toml  content  layouts  prepare.sh
```
Using non-existing folder as destination throws error:
```
$ ./cli storage download predrag-test-bucket/website/ non-existing-subfolder  --recursive
error: batch file download failed: destination folder "non-existing-subfolder" does not exist
```