### PR TITLE
fixing bigfile upload stuck issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixing bigfile upload stuck issue. #671
+
 ### Features
 
 - storage: bucket replication support #668

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Bug fixes
+
 - fixing bigfile upload stuck issue. #671
 
 ### Features


### PR DESCRIPTION
# Description

uploading bigfiles hangs, if there are no permissions, instead of throwing.
[Ticket](https://app.shortcut.com/exoscale/story/117395/gh-issue-cli-bug-upload-of-big-objects-to-bucket-stuck)


testing:

```
dd if=/dev/zero of=smallfile bs=1M count=1
dd if=/dev/zero of=bigfile bs=10M count=1
```

**bigfile  HANGS, UNTIL CTRL+C**

```
go run main.go storage upload bigfile sos://buckettest
bigfile          [======================================>---------------------------------------] 5.00 MiB / 10.00 MiB | 1s
^Cerror: operation error S3: CreateMultipartUpload, https response error StatusCode: 403, RequestID: b88e8a41-9db1-414e-bff1-cbfe2d6803ca, HostID: b88e8a41-9db1-414e-bff1-cbfe2d6803ca, api error AccessDenied: You are not authorized to perform put-object on bucket buckettest
exit status 1
```

**smallfile SHOWS THE ERROR STRAIGHTAWAY**

```
go run main.go storage upload smallfile sos://buckettest
smallfile        [==============================================================================] 1.00 MiB / 1.00 MiB | 0s
error: operation error S3: PutObject, https response error StatusCode: 403, RequestID: 6d038a7e-c34c-4fe9-b563-10cce0b34fb6, HostID: 6d038a7e-c34c-4fe9-b563-10cce0b34fb6, api error AccessDenied: You are not authorized to perform put-object on bucket buckettest
exit status 1
```

**WITH THE FIX - NO HANGING**

```
go run main.go storage upload bigfile sos://buckettest
bigfile          [======================================>---------------------------------------] 5.00 MiB / 10.00 MiB | 0s
error: operation error S3: CreateMultipartUpload, https response error StatusCode: 403, RequestID: 6a4ae3dd-0307-47bc-861e-97477fd760a0, HostID: 6a4ae3dd-0307-47bc-861e-97477fd760a0, api error AccessDenied: You are not authorized to perform put-object on bucket buckettest
exit status 1
```

```
go run main.go storage upload smallfile sos://buckettest
smallfile        [==============================================================================] 1.00 MiB / 1.00 MiB | 0s
error: operation error S3: PutObject, https response error StatusCode: 403, RequestID: 17f2e43f-508c-4fc2-93aa-7ff2537e9d24, HostID: 17f2e43f-508c-4fc2-93aa-7ff2537e9d24, api error AccessDenied: You are not authorized to perform put-object on bucket buckettest
exit status 1
```

**GIVE BACK PERMISSION FOR TESTING**

```
go run main.go storage upload smallfile sos://buckettest
smallfile        [==============================================================================] 1.00 MiB / 1.00 MiB | 0s

go run main.go storage upload bigfile sos://buckettest
bigfile          [==============================================================================] 10.00 MiB / 10.00 MiB | 0s

go run main.go storage show sos://buckettest/bigfile
┼───────────────┼───────────────────────────────────────────────┼
│    STORAGE    │                                               │
┼───────────────┼───────────────────────────────────────────────┼
│ Path          │ bigfile                                       │
│ Bucket        │ buckettest                                    │
│ Last Modified │ 2025-03-12 09:42:00 UTC                       │
│ Size          │ 10 MiB                                        │
│ URL           │ https://sos-ch-dk-2.exo.io/buckettest/bigfile │
│ ACL           │                                               │
│               │   Read           -                            │
│               │   Write          -                            │
│               │   Read ACP       -                            │
│               │   Write ACP      -                            │
│               │   Full Control   arthur-aliiev-exoscale-com   │
│               │                                               │
│ Metadata      │                                               │
│ Headers       │                                               │
│               │   Content-Type   application/octet-stream     │
│               │                                               │
┼───────────────┼───────────────────────────────────────────────┼

go run main.go storage show sos://buckettest/smallfile
┼───────────────┼─────────────────────────────────────────────────┼
│    STORAGE    │                                                 │
┼───────────────┼─────────────────────────────────────────────────┼
│ Path          │ smallfile                                       │
│ Bucket        │ buckettest                                      │
│ Last Modified │ 2025-03-12 09:41:34 UTC                         │
│ Size          │ 1.0 MiB                                         │
│ URL           │ https://sos-ch-dk-2.exo.io/buckettest/smallfile │
│ ACL           │                                                 │
│               │   Read           -                              │
│               │   Write          -                              │
│               │   Read ACP       -                              │
│               │   Write ACP      -                              │
│               │   Full Control   arthur-aliiev-exoscale-com     │
│               │                                                 │
│ Metadata      │                                                 │
│ Headers       │                                                 │
│               │   Content-Type   application/octet-stream       │
│               │                                                 │
┼───────────────┼─────────────────────────────────────────────────┼

```




<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

<!--
Describe the tests you did
-->
