### PR TITLE
SKS cluster: feature-gates support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - sks: add rotate operators CA cmd
 - sks: add rotate CSI credentials cmd
+- sks: feature-gates support for cluster update and creation #677
 
 ### Bug fixes
 

--- a/cmd/sks_create.go
+++ b/cmd/sks_create.go
@@ -38,6 +38,7 @@ type sksCreateCmd struct {
 	NoExoscaleCCM                bool              `cli-usage:"do not deploy the Exoscale Cloud Controller Manager in the cluster control plane"`
 	NoMetricsServer              bool              `cli-usage:"do not deploy the Kubernetes Metrics Server in the cluster control plane"`
 	ExoscaleCSI                  bool              `cli-usage:"deploy the Exoscale Container Storage Interface on worker nodes"`
+	FeatureGates                 []string          `cli-flag:"feature-gates" cli-usage:"SKS cluster feature gates to enable"`
 	NodepoolAntiAffinityGroups   []string          `cli-flag:"nodepool-anti-affinity-group" cli-usage:"default Nodepool Anti-Affinity Group NAME|ID (can be specified multiple times)"`
 	NodepoolDeployTarget         string            `cli-usage:"default Nodepool Deploy Target NAME|ID"`
 	NodepoolDescription          string            `cli-usage:"default Nodepool description"`
@@ -113,7 +114,7 @@ func (c *sksCreateCmd) cmdRun(cmd *cobra.Command, _ []string) error { //nolint:g
 			}
 			return nil
 		}(),
-		FeatureGates: []string{},
+		FeatureGates: c.FeatureGates,
 	}
 
 	ctx := gContext

--- a/cmd/sks_show.go
+++ b/cmd/sks_show.go
@@ -26,6 +26,7 @@ type sksShowOutput struct {
 	ServiceLevel    string                  `json:"service_level"`
 	CNI             string                  `json:"cni"`
 	AddOns          []string                `json:"addons"`
+	FeatureGates    []string                `json:"feature_gates"`
 	State           string                  `json:"state"`
 	Labels          map[string]string       `json:"labels"`
 	Nodepools       []sksNodepoolShowOutput `json:"nodepools"`
@@ -50,6 +51,7 @@ func (o *sksShowOutput) ToTable() {
 	t.Append([]string{"Service Level", o.ServiceLevel})
 	t.Append([]string{"CNI", o.CNI})
 	t.Append([]string{"Add-Ons", strings.Join(o.AddOns, "\n")})
+	t.Append([]string{"Feature Gates", strings.Join(o.FeatureGates, "\n")})
 	t.Append([]string{"State", o.State})
 	t.Append([]string{"Labels", func() string {
 		if len(o.Labels) > 0 {
@@ -149,7 +151,13 @@ func (c *sksShowCmd) cmdRun(_ *cobra.Command, _ []string) error {
 			EnableKubeProxy: *cluster.EnableKubeProxy,
 			Description:     cluster.Description,
 			Endpoint:        cluster.Endpoint,
-			ID:              cluster.ID,
+			FeatureGates: func() (v []string) {
+				if cluster.FeatureGates != nil {
+					v = cluster.FeatureGates
+				}
+				return
+			}(),
+			ID: cluster.ID,
 			Labels: func() (v map[string]string) {
 				if cluster.Labels != nil {
 					v = cluster.Labels

--- a/cmd/sks_update.go
+++ b/cmd/sks_update.go
@@ -21,6 +21,7 @@ type sksUpdateCmd struct {
 
 	AutoUpgrade    bool              `cli-usage:"enable automatic upgrading of the SKS cluster control plane Kubernetes version(--auto-upgrade=false to disable again)"`
 	Description    string            `cli-usage:"SKS cluster description"`
+	FeatureGates   []string          `cli-flag:"feature-gates" cli-usage:"SKS cluster feature gates to enable"`
 	Labels         map[string]string `cli-flag:"label" cli-usage:"SKS cluster label (format: key=value)"`
 	Name           string            `cli-usage:"SKS cluster name"`
 	EnableCSIAddon bool              `cli-usage:"enable the Exoscale CSI driver"`
@@ -63,12 +64,15 @@ func (c *sksUpdateCmd) cmdRun(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	updateReq := v3.UpdateSKSClusterRequest{
-		FeatureGates: []string{},
-	}
+	updateReq := v3.UpdateSKSClusterRequest{}
 
 	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.AutoUpgrade)) {
 		updateReq.AutoUpgrade = &c.AutoUpgrade
+		updated = true
+	}
+
+	if cmd.Flags().Changed(mustCLICommandFlagName(c, &c.FeatureGates)) {
+		updateReq.FeatureGates = c.FeatureGates
 		updated = true
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/exoscale/egoscale v0.102.4
-	github.com/exoscale/egoscale/v3 v3.1.16
+	github.com/exoscale/egoscale/v3 v3.1.17
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/google/uuid v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
 github.com/exoscale/egoscale v0.102.4 h1:GBKsZMIOzwBfSu+4ZmWka3Ejf2JLiaBDHp4CQUgvp2E=
 github.com/exoscale/egoscale v0.102.4/go.mod h1:ROSmPtle0wvf91iLZb09++N/9BH2Jo9XxIpAEumvocA=
-github.com/exoscale/egoscale/v3 v3.1.16 h1:JaAjY9uHLw9K5jA6kVenbTkJxgds3IU2RkrXXWV+d9s=
-github.com/exoscale/egoscale/v3 v3.1.16/go.mod h1:t9+MpSEam94na48O/xgvvPFpQPRiwZ3kBN4/UuQtKco=
+github.com/exoscale/egoscale/v3 v3.1.17 h1:+T6+GP/k3tFNsYIQzpF3Sou4ecH//FkERDsJze/OZ00=
+github.com/exoscale/egoscale/v3 v3.1.17/go.mod h1:t9+MpSEam94na48O/xgvvPFpQPRiwZ3kBN4/UuQtKco=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/v3/operations.go
+++ b/vendor/github.com/exoscale/egoscale/v3/operations.go
@@ -14938,7 +14938,7 @@ type UpdateSKSClusterRequest struct {
 	// Add or remove the operators certificate authority (CA) from the list of trusted CAs of the api server. The default value is true
 	EnableOperatorsCA *bool `json:"enable-operators-ca,omitempty"`
 	// A list of Kubernetes-only Alpha features to enable for API server component
-	FeatureGates []string         `json:"feature-gates,omitempty"`
+	FeatureGates []string         `json:"feature-gates"`
 	Labels       SKSClusterLabels `json:"labels,omitempty"`
 	// Cluster name
 	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -220,7 +220,7 @@ github.com/exoscale/egoscale/v2
 github.com/exoscale/egoscale/v2/api
 github.com/exoscale/egoscale/v2/oapi
 github.com/exoscale/egoscale/version
-# github.com/exoscale/egoscale/v3 v3.1.16
+# github.com/exoscale/egoscale/v3 v3.1.17
 ## explicit; go 1.22.0
 github.com/exoscale/egoscale/v3
 github.com/exoscale/egoscale/v3/credentials


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Allows updating the list of feature gates for an SKS cluster

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

<!--
Describe the tests you did
-->
```
➜  ~/exo/cli git:(tgrondier/sc-121631/terraform-provider-cli-expose-feature-gates) go run . compute sks update kube-proxy-default -z ch-gva-2 --feature-gates GracefulNodeShutdown                                                                                                                           25-05-07 9:53 
 ✔ Updating SKS cluster "kube-proxy-default"... 42s
┼───────────────────┼──────────────────────────────────────────────────────────────────┼
│    SKS CLUSTER    │                                                                  │
┼───────────────────┼──────────────────────────────────────────────────────────────────┼
│ ID                │ cea1041c-ce7e-4624-9856-67ae9e4bfac7                             │

│ Auto-upgrade      │ false                                                            │

│ Feature Gates     │ GracefulNodeShutdown                                             │

┼───────────────────┼──────────────────────────────────────────────────────────────────┼
➜  ~/exo/cli git:(tgrondier/sc-121631/terraform-provider-cli-expose-feature-gates) go run . compute sks update kube-proxy-default -z ch-gva-2 --auto-upgrade=true                                                                                                                                            25-05-07 9:55 
 ✔ Updating SKS cluster "kube-proxy-default"... 33s

│ Auto-upgrade      │ true                                                             │

│ Feature Gates     │ GracefulNodeShutdown                                             │

┼───────────────────┼──────────────────────────────────────────────────────────────────┼
➜  ~/exo/cli git:(tgrondier/sc-121631/terraform-provider-cli-expose-feature-gates) go run . compute sks update kube-proxy-default -z ch-gva-2 --feature-gates ""                                                                                                                                          25-05-07 10:02 
 ✔ Updating SKS cluster "kube-proxy-default"... 39s
┼───────────────────┼──────────────────────────────────────────────────────────────────┼
│    SKS CLUSTER    │                                                                  │
┼───────────────────┼──────────────────────────────────────────────────────────────────┼
│ ID                │ cea1041c-ce7e-4624-9856-67ae9e4bfac7                             │

│ Feature Gates     │                                                                  │

┼───────────────────┼──────────────────────────────────────────────────────────────────┼


```