### PR TITLE
Infrastructure support for running GPU-accelerated AI workloads on Exoscale's platform.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ contrib
 go.work
 .aptlydata
 .idea/
+cli

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/cmd/ai.go
+++ b/cmd/ai.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var aiCmd = &cobra.Command{
+	Use:        "ai",
+	Short:      "AI services management",
+	Aliases:    []string{"a"},
+	SuggestFor: []string{"ai", "vm"},
+}
+
+func init() {
+	RootCmd.AddCommand(aiCmd)
+}

--- a/cmd/ai_job.go
+++ b/cmd/ai_job.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var gpuInstanceTypeFamilies = []string{
+	"gpu",
+	"gpu2",
+	"gpu3",
+}
+
+var gpuInstanceTypeSizes = []string{
+	"medium",
+	"large",
+	"huge",
+}
+
+var aiJobCmd = &cobra.Command{
+	Use:     "job",
+	Short:   "AI jobs management",
+	Aliases: []string{"j"},
+}
+
+func init() {
+	aiCmd.AddCommand(aiJobCmd)
+}

--- a/cmd/ai_job_create.go
+++ b/cmd/ai_job_create.go
@@ -1,0 +1,390 @@
+package cmd
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/exoscale/cli/pkg/account"
+	"github.com/exoscale/cli/pkg/globalstate"
+	"github.com/exoscale/cli/pkg/output"
+	exossh "github.com/exoscale/cli/pkg/ssh"
+	"github.com/exoscale/cli/pkg/userdata"
+	"github.com/exoscale/cli/utils"
+	v3 "github.com/exoscale/egoscale/v3"
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	// AI job default template name
+	aiJobDefaultTemplateID = "linux-debian-12-gpu"
+)
+
+var (
+	// Creates a PVC to store the fine-tuning check points
+	aiJobPVCTemplate = `
+#cloud-config
+write_files:
+ - path: /var/lib/rancher/k3s/server/manifests/ai-job.yaml
+   content: |
+     apiVersion: ai.re-cinq.com/v1
+     kind: Job
+     metadata:
+       name: ai-job
+     spec:
+       image: %s
+       model: %s
+       diskSize: %d
+       huggingFaceSecret: %s
+   owner: 'root:root'
+   permissions: '0640'
+`
+)
+
+type aiJobCreateCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"create"`
+
+	Name string `cli-arg:"#" cli-usage:"NAME"`
+
+	AntiAffinityGroups []string          `cli-flag:"anti-affinity-group" cli-usage:"instance Anti-Affinity Group NAME|ID (can be specified multiple times)"`
+	DeployTarget       string            `cli-usage:"instance Deploy Target NAME|ID"`
+	DiskSize           int64             `cli-usage:"instance disk size"`
+	IPv6               bool              `cli-flag:"ipv6" cli-usage:"enable IPv6 on instance"`
+	InstanceType       string            `cli-usage:"instance type (format: [FAMILY.]SIZE)"`
+	Labels             map[string]string `cli-flag:"label" cli-usage:"instance label (format: key=value)"`
+	PrivateNetworks    []string          `cli-flag:"private-network" cli-usage:"instance Private Network NAME|ID (can be specified multiple times)"`
+	PrivateInstance    bool              `cli-flag:"private-instance" cli-usage:"enable private instance to be created"`
+	SSHKeys            []string          `cli-flag:"ssh-key" cli-usage:"SSH key to deploy on the instance (can be specified multiple times)"`
+	Protection         bool              `cli-flag:"protection" cli-usage:"enable delete protection"`
+	SecurityGroups     []string          `cli-flag:"security-group" cli-usage:"instance Security Group NAME|ID (can be specified multiple times)"`
+	Template           string            `cli-usage:"instance template NAME|ID"`
+	TemplateVisibility string            `cli-usage:"instance template visibility (public|private)"`
+	Zone               v3.ZoneName       `cli-short:"z" cli-usage:"instance zone"`
+
+	// AI job options
+	ContainerImage    string `cli-short:"i" cli-flag:"container-image" cli-usage:"container image to use for the AI job"`
+	HuggingFaceSecret string `cli-short:"s" cli-flag:"hf-secret" cli-usage:"HuggingFace secret to use for the AI job"`
+	Model             string `cli-flag:"m" cli-usage:"model to use for the AI job"`
+	JobName           string `cli-short:"j" cli-flag:"job-name" cli-usage:"name of the AI job to create"`
+}
+
+func (c *aiJobCreateCmd) cmdAliases() []string { return gCreateAlias }
+
+func (c *aiJobCreateCmd) cmdShort() string { return "Create an AI job" }
+
+func (c *aiJobCreateCmd) cmdLong() string {
+	return fmt.Sprintf(`This command creates an AI Job.
+
+Supported Compute instance type families: %s
+
+Supported Compute instance type sizes: %s
+
+Supported output template annotations: %s`,
+		strings.Join(gpuInstanceTypeFamilies, ", "),
+		strings.Join(gpuInstanceTypeSizes, ", "),
+		strings.Join(output.TemplateAnnotations(&instanceShowOutput{}), ", "))
+}
+
+func (c *aiJobCreateCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	cmdSetZoneFlagFromDefault(cmd)
+	cmdSetTemplateFlagFromDefault(cmd)
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *aiJobCreateCmd) cmdRun(_ *cobra.Command, _ []string) error { //nolint:gocyclo
+	var (
+		singleUseSSHPrivateKey *rsa.PrivateKey
+		singleUseSSHPublicKey  ssh.PublicKey
+	)
+	ctx := gContext
+	client, err := switchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
+	if err != nil {
+		return err
+	}
+
+	var sshKeys []v3.SSHKey
+	for _, sshkeyName := range c.SSHKeys {
+		sshKeys = append(sshKeys, v3.SSHKey{Name: sshkeyName})
+	}
+
+	// Set the default AI JOB template if not specified
+	visibility := "private"
+	if c.TemplateVisibility != "" {
+		visibility = c.TemplateVisibility
+	}
+
+	// Set the default template
+	templateID := aiJobDefaultTemplateID
+
+	instanceReq := v3.CreateInstanceRequest{
+		DiskSize:    c.DiskSize,
+		Ipv6Enabled: &c.IPv6,
+		Labels:      c.Labels,
+		Name:        c.Name,
+		SSHKeys:     sshKeys,
+	}
+
+	if c.PrivateInstance {
+		instanceReq.PublicIPAssignment = v3.PublicIPAssignmentNone
+	}
+
+	if l := len(c.AntiAffinityGroups); l > 0 {
+		instanceReq.AntiAffinityGroups = make([]v3.AntiAffinityGroup, l)
+		af, err := client.ListAntiAffinityGroups(ctx)
+		if err != nil {
+			return fmt.Errorf("error listing Anti-Affinity Group: %w", err)
+		}
+		for i := range c.AntiAffinityGroups {
+			antiAffinityGroup, err := af.FindAntiAffinityGroup(c.AntiAffinityGroups[i])
+			if err != nil {
+				return fmt.Errorf("error retrieving Anti-Affinity Group: %w", err)
+			}
+			instanceReq.AntiAffinityGroups[i] = v3.AntiAffinityGroup{ID: antiAffinityGroup.ID}
+		}
+	}
+
+	if c.DeployTarget != "" {
+		targets, err := client.ListDeployTargets(ctx)
+		if err != nil {
+			return fmt.Errorf("error listing Deploy Target: %w", err)
+		}
+		deployTarget, err := targets.FindDeployTarget(c.DeployTarget)
+		if err != nil {
+			return fmt.Errorf("error retrieving Deploy Target: %w", err)
+		}
+		instanceReq.DeployTarget = &v3.DeployTarget{ID: deployTarget.ID}
+	}
+
+	instanceTypes, err := client.ListInstanceTypes(ctx)
+	if err != nil {
+		return fmt.Errorf("error listing instance type: %w", err)
+	}
+
+	// c.InstanceType is never empty
+	instanceType := utils.ParseInstanceType(c.InstanceType)
+	for i, it := range instanceTypes.InstanceTypes {
+		if it.Family == instanceType.Family && it.Size == instanceType.Size {
+			instanceReq.InstanceType = &instanceTypes.InstanceTypes[i]
+			break
+		}
+	}
+	if instanceReq.InstanceType == nil {
+		return fmt.Errorf("error retrieving instance type %s: not found", c.InstanceType)
+	}
+
+	privateNetworks := make([]v3.PrivateNetwork, len(c.PrivateNetworks))
+	if l := len(c.PrivateNetworks); l > 0 {
+		pNetworks, err := client.ListPrivateNetworks(ctx)
+		if err != nil {
+			return fmt.Errorf("error listing Private Network: %w", err)
+		}
+
+		for i := range c.PrivateNetworks {
+			privateNetwork, err := pNetworks.FindPrivateNetwork(c.PrivateNetworks[i])
+			if err != nil {
+				return fmt.Errorf("error retrieving Private Network: %w", err)
+			}
+			privateNetworks[i] = privateNetwork
+		}
+	}
+
+	if l := len(c.SecurityGroups); l > 0 {
+		sgs, err := client.ListSecurityGroups(ctx)
+		if err != nil {
+			return fmt.Errorf("error listing Security Group: %w", err)
+		}
+		instanceReq.SecurityGroups = make([]v3.SecurityGroup, l)
+		for i := range c.SecurityGroups {
+			securityGroup, err := sgs.FindSecurityGroup(c.SecurityGroups[i])
+			if err != nil {
+				return fmt.Errorf("error retrieving Security Group: %w", err)
+			}
+			instanceReq.SecurityGroups[i] = v3.SecurityGroup{ID: securityGroup.ID}
+		}
+	}
+
+	if instanceReq.SSHKeys == nil && account.CurrentAccount.DefaultSSHKey != "" {
+		instanceReq.SSHKeys = []v3.SSHKey{{Name: account.CurrentAccount.DefaultSSHKey}}
+	}
+
+	// Generating a single-use SSH key pair for this instance.
+	if instanceReq.SSHKeys == nil {
+		singleUseSSHPrivateKey, err = rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			return fmt.Errorf("error generating SSH private key: %w", err)
+		}
+		if err = singleUseSSHPrivateKey.Validate(); err != nil {
+			return fmt.Errorf("error generating SSH private key: %w", err)
+		}
+
+		singleUseSSHPublicKey, err = ssh.NewPublicKey(&singleUseSSHPrivateKey.PublicKey)
+		if err != nil {
+			return fmt.Errorf("error generating SSH public key: %w", err)
+		}
+
+		sshKeyName := fmt.Sprintf("%s-%d", c.Name, time.Now().Unix())
+		op, err := client.RegisterSSHKey(
+			ctx,
+			v3.RegisterSSHKeyRequest{
+				Name:      sshKeyName,
+				PublicKey: string(ssh.MarshalAuthorizedKey(singleUseSSHPublicKey)),
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("error registering SSH key: %w", err)
+		}
+		_, err = client.Wait(ctx, op, v3.OperationStateSuccess)
+		if err != nil {
+			return fmt.Errorf("error wait registering SSH key: %w", err)
+		}
+
+		instanceReq.SSHKeys = []v3.SSHKey{{Name: sshKeyName}}
+	}
+
+	templates, err := client.ListTemplates(ctx, v3.ListTemplatesWithVisibility(v3.ListTemplatesVisibility(visibility)))
+	if err != nil {
+		return fmt.Errorf("error listing template with visibility %q: %w", visibility, err)
+	}
+	template, err := templates.FindTemplate(templateID)
+	if err != nil {
+		return fmt.Errorf(
+			"no template %q found with visibility %s in zone %s",
+			templateID,
+			visibility,
+			c.Zone,
+		)
+	}
+	instanceReq.Template = &v3.Template{ID: template.ID}
+
+	// Build the cloud-init user data
+	// Make sure we have valid input parameters
+	if c.HuggingFaceSecret == "" {
+		return fmt.Errorf("HuggingFace secret cannot be empty")
+	}
+
+	// Set the volume size to 25GB if not specified
+	// or set it to half of the disk size if specified
+	// (minimum 25GB)
+	var volumeSize int64
+	if c.DiskSize == 0 {
+		volumeSize = 25
+	} else {
+		volumeSize = c.DiskSize / 2
+	}
+
+	aiJobConfig := fmt.Sprintf(aiJobPVCTemplate,
+		c.ContainerImage,
+		c.Model,
+		volumeSize,
+		c.HuggingFaceSecret,
+	)
+
+	userData, err := userdata.EncodeUserData([]byte(aiJobConfig), false)
+	if err != nil {
+		return fmt.Errorf("error encoding cloud-init user data: %w", err)
+
+	}
+	instanceReq.UserData = userData
+
+	var instanceID v3.UUID
+	decorateAsyncOperation(fmt.Sprintf("Creating instance %q...", c.Name), func() {
+		var op *v3.Operation
+		op, err = client.CreateInstance(ctx, instanceReq)
+		if err != nil {
+			return
+		}
+
+		op, err = client.Wait(ctx, op, v3.OperationStateSuccess)
+		if err != nil {
+			return
+		}
+		if op.Reference != nil {
+			instanceID = op.Reference.ID
+		}
+
+		for _, p := range privateNetworks {
+			op, err = client.AttachInstanceToPrivateNetwork(ctx, p.ID, v3.AttachInstanceToPrivateNetworkRequest{
+				Instance: &v3.AttachInstanceToPrivateNetworkRequestInstance{ID: instanceID},
+			})
+			if err != nil {
+				return
+			}
+			_, err = client.Wait(ctx, op)
+			if err != nil {
+				return
+			}
+		}
+
+		if c.Protection {
+			var value v3.UUID
+			var op *v3.Operation
+			value, err = v3.ParseUUID(instanceID.String())
+			if err != nil {
+				return
+			}
+			op, err = globalstate.EgoscaleV3Client.AddInstanceProtection(ctx, value)
+			if err != nil {
+				return
+			}
+			_, err = globalstate.EgoscaleV3Client.Wait(ctx, op, v3.OperationStateSuccess)
+
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	if singleUseSSHPrivateKey != nil {
+		privateKeyFilePath := exossh.GetInstanceSSHKeyPath(instanceID.String())
+
+		if err = os.MkdirAll(path.Dir(privateKeyFilePath), 0o700); err != nil {
+			return fmt.Errorf("error writing SSH private key file: %w", err)
+		}
+
+		if err = os.WriteFile(
+			privateKeyFilePath,
+			pem.EncodeToMemory(&pem.Block{
+				Type:  "RSA PRIVATE KEY",
+				Bytes: x509.MarshalPKCS1PrivateKey(singleUseSSHPrivateKey),
+			}),
+			0o600,
+		); err != nil {
+			return fmt.Errorf("error writing SSH private key file: %w", err)
+		}
+
+		op, err := client.DeleteSSHKey(ctx, instanceReq.SSHKeys[0].Name)
+		if err != nil {
+			return fmt.Errorf("error deleting SSH key: %w", err)
+		}
+		_, err = client.Wait(ctx, op, v3.OperationStateSuccess)
+		if err != nil {
+			return fmt.Errorf("error wait deleting SSH key: %w", err)
+		}
+	}
+
+	if !globalstate.Quiet {
+		return (&instanceShowCmd{
+			cliCommandSettings: c.cliCommandSettings,
+			Instance:           instanceID.String(),
+			// TODO migrate instanceShow to v3 to pass v3.ZoneName
+			Zone: string(c.Zone),
+		}).cmdRun(nil, nil)
+	}
+
+	return nil
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(aiJobCmd, &aiJobCreateCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/ai_job_delete.go
+++ b/cmd/ai_job_delete.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/exoscale/cli/pkg/globalstate"
+	v3 "github.com/exoscale/egoscale/v3"
+)
+
+type aiJobDeleteCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"delete"`
+
+	Instances []string `cli-arg:"#" cli-usage:"NAME|ID"`
+
+	Force bool   `cli-short:"f" cli-usage:"don't prompt for confirmation"`
+	Zone  string `cli-short:"z" cli-usage:"instance zone"`
+}
+
+func (c *aiJobDeleteCmd) cmdAliases() []string { return gRemoveAlias }
+
+func (c *aiJobDeleteCmd) cmdShort() string { return "Delete an AI job" }
+
+func (c *aiJobDeleteCmd) cmdLong() string { return "" }
+
+func (c *aiJobDeleteCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	cmdSetZoneFlagFromDefault(cmd)
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *aiJobDeleteCmd) cmdRun(_ *cobra.Command, _ []string) error {
+	ctx := gContext
+	client, err := switchClientZoneV3(
+		ctx,
+		globalstate.EgoscaleV3Client,
+		v3.ZoneName(c.Zone),
+	)
+	if err != nil {
+		return err
+	}
+
+	instances, err := client.ListInstances(ctx)
+	if err != nil {
+		return err
+	}
+
+	instanceToDelete := []v3.UUID{}
+	for _, i := range c.Instances {
+		instance, err := instances.FindListInstancesResponseInstances(i)
+		if err != nil {
+			if !c.Force {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "warning: %s not found.\n", i)
+
+			continue
+		}
+
+		if !c.Force {
+			if !askQuestion(fmt.Sprintf("Are you sure you want to delete the AI Job instance %q?", i)) {
+				return nil
+			}
+		}
+
+		instanceToDelete = append(instanceToDelete, instance.ID)
+	}
+
+	var fns []func() error
+	for _, i := range instanceToDelete {
+		fns = append(fns, func() error {
+			op, err := client.DeleteInstance(ctx, i)
+			if err != nil {
+				return err
+			}
+			_, err = client.Wait(ctx, op, v3.OperationStateSuccess)
+			return err
+		})
+	}
+
+	err = decorateAsyncOperations(fmt.Sprintf("Deleting AI Job instance %q...", strings.Join(c.Instances, ", ")), fns...)
+	if err != nil {
+		return err
+	}
+
+	// Cleaning up resources created in create instance
+	// https://github.com/exoscale/cli/blob/master/cmd/instance_create.go#L220
+	for _, i := range instanceToDelete {
+		instanceDir := path.Join(globalstate.ConfigFolder, "instances", i.String())
+		if _, err := os.Stat(instanceDir); !os.IsNotExist(err) {
+			if err := os.RemoveAll(instanceDir); err != nil {
+				return fmt.Errorf("error deleting AI Job instance directory: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(aiJobCmd, &aiJobDeleteCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/ai_job_show.go
+++ b/cmd/ai_job_show.go
@@ -1,0 +1,200 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/exoscale/cli/pkg/account"
+	"github.com/exoscale/cli/pkg/globalstate"
+	"github.com/exoscale/cli/pkg/output"
+	exossh "github.com/exoscale/cli/pkg/ssh"
+	"github.com/exoscale/cli/utils"
+	exoapi "github.com/exoscale/egoscale/v2/api"
+
+	"github.com/dustin/go-humanize"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// Job status command
+	jobStatusCommand = "sudo kubectl get job %s"
+	defaultAIJobName = "ai-job"
+)
+
+type aiJobShowCmd struct {
+	cliCommandSettings `cli-cmd:"-"`
+
+	_ bool `cli-cmd:"show"`
+
+	// SSH options
+	SshKey  string `cli-short:"k" cli-flag:"ssh-key" cli-usage:"instance ssh private key"`
+	SshUser string `cli-short:"u" cli-flag:"ssh-user" cli-usage:"instance ssh user"`
+	SshPort string `cli-short:"p" cli-flag:"ssh-port" cli-usage:"instance ssh port"`
+
+	// AI job options
+	JobName string `cli-short:"j" cli-flag:"job-name" cli-usage:"name of the AI job to show"`
+
+	Instance string `cli-arg:"#" cli-usage:"NAME|ID"`
+
+	Zone string `cli-short:"z" cli-usage:"instance zone"`
+}
+
+func (c *aiJobShowCmd) cmdAliases() []string { return gShowAlias }
+
+func (c *aiJobShowCmd) cmdShort() string { return "Show an AI job status" }
+
+func (c *aiJobShowCmd) cmdLong() string {
+	return fmt.Sprintf(`This command shows an AI job status.
+
+Supported output template annotations: %s`,
+		strings.Join(output.TemplateAnnotations(&instanceShowOutput{}), ", "))
+}
+
+func (c *aiJobShowCmd) cmdPreRun(cmd *cobra.Command, args []string) error {
+	cmdSetZoneFlagFromDefault(cmd)
+	return cliCommandDefaultPreRun(c, cmd, args)
+}
+
+func (c *aiJobShowCmd) cmdRun(_ *cobra.Command, _ []string) error { //nolint:gocyclo
+
+	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, c.Zone))
+
+	instance, err := globalstate.EgoscaleClient.FindInstance(ctx, c.Zone, c.Instance)
+	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			return fmt.Errorf("resource not found in zone %q", c.Zone)
+		}
+		return err
+	}
+
+	// Assign the job command
+	if c.JobName != "" {
+		jobStatusCommand = fmt.Sprintf(jobStatusCommand, c.JobName)
+	} else {
+		jobStatusCommand = fmt.Sprintf(jobStatusCommand, defaultAIJobName)
+	}
+
+	// SSH Port
+	if c.SshPort == "" {
+		c.SshPort = "22"
+	}
+	// SSH User
+	if c.SshUser == "" {
+		c.SshUser = "debian"
+	}
+
+	// Connect via the SSH tunnel and issue the command to check the job
+	cmdResponse, err := exossh.RunCmd(instance, c.SshUser, c.SshPort, c.SshKey, jobStatusCommand)
+	if err != nil {
+		return err
+	}
+
+	out := instanceShowOutput{
+		AntiAffinityGroups: make([]string, 0),
+		CreationDate:       instance.CreatedAt.String(),
+		DiskSize:           humanize.IBytes(uint64(*instance.DiskSize << 30)),
+		ElasticIPs:         make([]string, 0),
+		ID:                 *instance.ID,
+		IPAddress:          utils.DefaultIP(instance.PublicIPAddress, "-"),
+		IPv6Address:        utils.DefaultIP(instance.IPv6Address, "-"),
+		Labels: func() (v map[string]string) {
+			if instance.Labels != nil {
+				v = *instance.Labels
+			}
+			return
+		}(),
+		Name:            *instance.Name,
+		PrivateNetworks: make([]string, 0),
+		SSHKey:          utils.DefaultString(instance.SSHKey, "-"),
+		SecurityGroups:  make([]string, 0),
+		State:           *instance.State,
+		Zone:            c.Zone,
+		AIJobStatus:     cmdResponse,
+	}
+
+	out.PrivateInstance = "No"
+	if instance.PublicIPAssignment != nil && *instance.PublicIPAssignment == "none" {
+		out.PrivateInstance = "Yes"
+	}
+
+	if instance.AntiAffinityGroupIDs != nil {
+		for _, id := range *instance.AntiAffinityGroupIDs {
+			antiAffinityGroup, err := globalstate.EgoscaleClient.GetAntiAffinityGroup(ctx, c.Zone, id)
+			if err != nil {
+				return fmt.Errorf("error retrieving Anti-Affinity Group: %w", err)
+			}
+			out.AntiAffinityGroups = append(out.AntiAffinityGroups, *antiAffinityGroup.Name)
+		}
+	}
+
+	out.DeployTarget = "-"
+	if instance.DeployTargetID != nil {
+		DeployTarget, err := globalstate.EgoscaleClient.GetDeployTarget(ctx, c.Zone, *instance.DeployTargetID)
+		if err != nil {
+			return fmt.Errorf("error retrieving Deploy Target: %w", err)
+		}
+		out.DeployTarget = *DeployTarget.Name
+	}
+
+	if instance.ElasticIPIDs != nil {
+		for _, id := range *instance.ElasticIPIDs {
+			elasticIP, err := globalstate.EgoscaleClient.GetElasticIP(ctx, c.Zone, id)
+			if err != nil {
+				return fmt.Errorf("error retrieving Elastic IP: %w", err)
+			}
+			out.ElasticIPs = append(out.ElasticIPs, elasticIP.IPAddress.String())
+		}
+	}
+
+	instanceType, err := globalstate.EgoscaleClient.GetInstanceType(ctx, c.Zone, *instance.InstanceTypeID)
+	if err != nil {
+		return err
+	}
+	out.InstanceType = fmt.Sprintf("%s.%s", *instanceType.Family, *instanceType.Size)
+
+	if instance.PrivateNetworkIDs != nil {
+		for _, id := range *instance.PrivateNetworkIDs {
+			privateNetwork, err := globalstate.EgoscaleClient.GetPrivateNetwork(ctx, c.Zone, id)
+			if err != nil {
+				return fmt.Errorf("error retrieving Private Network: %w", err)
+			}
+			out.PrivateNetworks = append(out.PrivateNetworks, *privateNetwork.Name)
+		}
+	}
+
+	if instance.SecurityGroupIDs != nil {
+		for _, id := range *instance.SecurityGroupIDs {
+			securityGroup, err := globalstate.EgoscaleClient.GetSecurityGroup(ctx, c.Zone, id)
+			if err != nil {
+				return fmt.Errorf("error retrieving Security Group: %w", err)
+			}
+			out.SecurityGroups = append(out.SecurityGroups, *securityGroup.Name)
+		}
+	}
+
+	template, err := globalstate.EgoscaleClient.GetTemplate(ctx, c.Zone, *instance.TemplateID)
+	if err != nil {
+		return err
+	}
+	out.Template = *template.Name
+
+	rdns, err := globalstate.EgoscaleClient.GetInstanceReverseDNS(ctx, c.Zone, *instance.ID)
+	if err != nil {
+		if errors.Is(err, exoapi.ErrNotFound) {
+			out.ReverseDNS = ""
+		} else {
+			return err
+		}
+	}
+
+	out.ReverseDNS = rdns
+
+	return c.outputFunc(&out, nil)
+}
+
+func init() {
+	cobra.CheckErr(registerCLICommand(aiJobCmd, &aiJobShowCmd{
+		cliCommandSettings: defaultCLICmdSettings(),
+	}))
+}

--- a/cmd/instance_show.go
+++ b/cmd/instance_show.go
@@ -18,6 +18,7 @@ import (
 
 type instanceShowOutput struct {
 	ID                 string            `json:"id"`
+	AIJobStatus        string            `json:"ai_job_status"`
 	Name               string            `json:"name"`
 	CreationDate       string            `json:"creation_date"`
 	InstanceType       string            `json:"instance_type"`

--- a/pkg/ssh/tunnel.go
+++ b/pkg/ssh/tunnel.go
@@ -1,0 +1,133 @@
+package ssh
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	v2 "github.com/exoscale/egoscale/v2"
+
+	"golang.org/x/crypto/ssh"
+)
+
+var (
+	errNoSSHCommand = errors.New("ssh command cannot be empty")
+	errNoUser       = errors.New("ssh user cannot be empty")
+	errNoInstance   = errors.New("ssh target instance cannot be empty")
+	errNoSSHKey     = errors.New("no valid SSH private keys found")
+)
+
+func RunCmd(instance *v2.Instance, user, port, sshKeyName, cmd string) (string, error) {
+
+	// Check if the instance is nil
+	if instance == nil {
+		return "", errNoInstance
+	}
+
+	// Check if the user is empty
+	if user == "" {
+		return "", errNoUser
+	}
+
+	// Make sure the command is not empty
+	if cmd == "" {
+		return "", errNoSSHCommand
+	}
+
+	if port == "" {
+		port = "22" // Default SSH port
+	}
+
+	signers, err := loadSSHKeys(sshKeyName)
+	if err != nil {
+		return "", err
+	}
+
+	// Define SSH server and credentials
+	server := fmt.Sprintf("%s:%s", instance.PublicIPAddress.String(), port)
+
+	// Create SSH client configuration
+	config := &ssh.ClientConfig{
+		User: user,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(signers...),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	// Connect to the SSH server
+	client, err := ssh.Dial("tcp", server, config)
+	if err != nil {
+		log.Fatalf("Failed to dial: %v", err)
+	}
+	defer func() {
+		if err := client.Close(); err != nil {
+			log.Printf("Failed to close SSH client: %v", err)
+		}
+	}()
+
+	// Create a new session
+	session, err := client.NewSession()
+	if err != nil {
+		log.Fatalf("Failed to create session: %v", err)
+	}
+	defer func() {
+		if err := session.Close(); err != nil && err != io.EOF {
+			log.Printf("Failed to close SSH session: %v", err)
+		}
+	}()
+
+	// Run the command and capture the output
+	var stdoutBuf bytes.Buffer
+	session.Stdout = &stdoutBuf
+
+	if err := session.Start(cmd); err != nil {
+		return "", fmt.Errorf("failed to start command: %v", err)
+	}
+
+	if err := session.Wait(); err != nil {
+		return "", fmt.Errorf("failed to wait for command: %v", err)
+	}
+
+	return stdoutBuf.String(), nil
+
+}
+
+func loadSSHKeys(sshKeyName string) ([]ssh.Signer, error) {
+	// Check for the existence of RSA and ed25519 keys
+	rsaKeyPath := filepath.Join(os.Getenv("HOME"), ".ssh", "id_rsa")
+	ed25519KeyPath := filepath.Join(os.Getenv("HOME"), ".ssh", "id_ed25519")
+
+	var signers []ssh.Signer
+
+	if sshKeyName != "" {
+		customSSHKeyPath := filepath.Join(os.Getenv("HOME"), ".ssh", sshKeyName)
+		if key, err := os.ReadFile(customSSHKeyPath); err == nil {
+			if signer, err := ssh.ParsePrivateKey(key); err == nil {
+				signers = append(signers, signer)
+			}
+		}
+	}
+
+	if key, err := os.ReadFile(rsaKeyPath); err == nil {
+		if signer, err := ssh.ParsePrivateKey(key); err == nil {
+			signers = append(signers, signer)
+		}
+	}
+
+	if key, err := os.ReadFile(ed25519KeyPath); err == nil {
+		if signer, err := ssh.ParsePrivateKey(key); err == nil {
+			signers = append(signers, signer)
+		}
+	}
+
+	if len(signers) == 0 {
+		return signers, errNoSSHKey
+	}
+
+	return signers, nil
+}


### PR DESCRIPTION
# Description
This PR allows to schedule AI fine-tuning jobs in the Exoscale platform.

- It uses the operating system template which can be generated via `mkosi`, available in [this repository](https://github.com/re-cinq/exo-template).
- It also leverages a simple kubernetes operator for scheduling AI jobs. Here the r[epository for the AI-Operator](https://github.com/re-cinq/ai-operator)

The operating system templates automatically deploys the AI-Operator.

## How to use it:

1. Create an AI job via:  `exo ai job create --instance-type gpu2.small --zone at-vie-1 --disk-size 100 --ssh-key sebastian -s hf_XXXXXX ai-job`
2. Check the job status via: `exo ai job show ai-job`
3. Delete the AI Job via: `exo ai job delete ai`

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

<!--
Describe the tests you did
-->
