### PR TITLE
JSON output: do not escape HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - SKS: more related commands are migrated to egoscale v3
 - dbaas: move all commands to egoscale v3
+- JSON output: do not escape HTML #682
 
 ## 1.84.1
 

--- a/pkg/output/outputter.go
+++ b/pkg/output/outputter.go
@@ -21,13 +21,13 @@ var (
 
 // JSON prints a JSON-formatted rendering of o to the terminal.
 func JSON(o interface{}) {
-	j, err := json.Marshal(o)
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(o)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: unable to encode output to JSON: %s\n", err)
 		os.Exit(1)
 	}
-
-	fmt.Println(string(j))
 }
 
 // Outputter is an interface that must to be implemented by the commands output


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Removes default HTML escaping for json output.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

<!--
Describe the tests you did
-->

```
➜  ~/exo/cli git:(tgrondier/sc-121173/cli-iam-utf8-parsing) exo iam role get --policy 93ecd283-84f2-4b58-9e1c-ede702de2826                                                                                                  25-05-12 11:58 
┼─────────┼────────────────────────────────┼─────────────┼─────────────────────────────────────────────────────────────────────────────┼
│ SERVICE │ TYPE (DEFAULT STRATEGY "DENY") │ RULE ACTION │                               RULE EXPRESSION                               │
┼─────────┼────────────────────────────────┼─────────────┼─────────────────────────────────────────────────────────────────────────────┼
│ sos     │ rules                          │ allow       │ (operation in [get-object, put-object]) && parameters.key == my-allowed-key │
┼─────────┼────────────────────────────────┼─────────────┼─────────────────────────────────────────────────────────────────────────────┼

➜  ~/exo/cli git:(tgrondier/sc-121173/cli-iam-utf8-parsing) exo iam role get --policy 93ecd283-84f2-4b58-9e1c-ede702de2826 -Ojson                                                                                           25-05-12 13:06 
{"default-service-strategy":"deny","services":{"sos":{"type":"rules","rules":[{"action":"allow","expression":"(operation in [get-object, put-object]) \u0026\u0026 parameters.key == my-allowed-key"}]}}}


➜  ~/exo/cli git:(tgrondier/sc-121173/cli-iam-utf8-parsing) ✗ go run . iam role get --policy 93ecd283-84f2-4b58-9e1c-ede702de2826 -Ojson                                                                                    25-05-12 12:05 
{"default-service-strategy":"deny","services":{"sos":{"type":"rules","rules":[{"action":"allow","expression":"(operation in [get-object, put-object]) && parameters.key == my-allowed-key"}]}}}
```
