### PR TITLE
dns: move to egoscale v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - SKS: more related commands are migrated to egoscale v3
 - dbaas: move all commands to egoscale v3
+- dns: move to egoscale v3 #683
 
 ## 1.84.1
 

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -1,76 +1,12 @@
 package cmd
 
 import (
-	"errors"
-	"fmt"
-
 	"github.com/spf13/cobra"
-
-	"github.com/exoscale/cli/pkg/account"
-	"github.com/exoscale/cli/pkg/globalstate"
-	exo "github.com/exoscale/egoscale/v2"
-	exoapi "github.com/exoscale/egoscale/v2/api"
 )
 
 var dnsCmd = &cobra.Command{
 	Use:   "dns",
 	Short: "DNS cmd lets you host your zones and manage records",
-}
-
-// domainFromIdent returns a DNS domain from identifier (domain name or ID).
-func domainFromIdent(ident string) (*exo.DNSDomain, error) {
-	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, account.CurrentAccount.DefaultZone))
-	if exo.IsValidUUID(ident) {
-		return globalstate.EgoscaleClient.GetDNSDomain(ctx, account.CurrentAccount.DefaultZone, ident)
-	}
-
-	domains, err := globalstate.EgoscaleClient.ListDNSDomains(ctx, account.CurrentAccount.DefaultZone)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, domain := range domains {
-		if *domain.UnicodeName == ident {
-			return &domain, nil
-		}
-	}
-
-	return nil, fmt.Errorf("domain %q not found", ident)
-}
-
-// domainRecordFromIdent returns a DNS record from identifier (record name or ID) and optional type
-func domainRecordFromIdent(domainID, ident string, rType *string) (*exo.DNSDomainRecord, error) {
-	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, account.CurrentAccount.DefaultZone))
-	if exo.IsValidUUID(ident) {
-		return globalstate.EgoscaleClient.GetDNSDomainRecord(ctx, account.CurrentAccount.DefaultZone, domainID, ident)
-	}
-
-	records, err := globalstate.EgoscaleClient.ListDNSDomainRecords(ctx, account.CurrentAccount.DefaultZone, domainID)
-	if err != nil {
-		return nil, err
-	}
-
-	var foundRecord *exo.DNSDomainRecord
-
-	for _, r := range records {
-		if rType != nil && *r.Type != *rType {
-			continue
-		}
-
-		if ident == *r.Name {
-			if foundRecord != nil {
-				return nil, errors.New("more than one records were found")
-			}
-			t := r
-			foundRecord = &t
-		}
-	}
-
-	if foundRecord == nil {
-		return nil, fmt.Errorf("no records were found")
-	}
-
-	return foundRecord, nil
 }
 
 func init() {

--- a/cmd/dns_add.go
+++ b/cmd/dns_add.go
@@ -1,14 +1,14 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
-	exo "github.com/exoscale/egoscale/v2"
-	exoapi "github.com/exoscale/egoscale/v2/api"
+	v3 "github.com/exoscale/egoscale/v3"
 )
 
 var dnsAddCmd = &cobra.Command{
@@ -21,27 +21,49 @@ func init() {
 }
 
 func addDomainRecord(domainIdent, name, rType, content string, ttl int64, priority *int64) error {
-	domain, err := domainFromIdent(domainIdent)
+
+	ctx := gContext
+	client, err := switchClientZoneV3(ctx, globalstate.EgoscaleV3Client, v3.ZoneName(account.CurrentAccount.DefaultZone))
 	if err != nil {
 		return err
 	}
 
-	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, account.CurrentAccount.DefaultZone))
-	decorateAsyncOperation(fmt.Sprintf("Adding DNS record %q to %q...", rType, *domain.UnicodeName), func() {
-		_, err = globalstate.EgoscaleClient.CreateDNSDomainRecord(ctx, account.CurrentAccount.DefaultZone, *domain.ID, &exo.DNSDomainRecord{
-			Name:     &name,
-			Type:     &rType,
-			Content:  &content,
-			TTL:      &ttl,
-			Priority: priority,
-		})
+	domainsList, err := client.ListDNSDomains(ctx)
+	if err != nil {
+		return err
+	}
+	domain, err := domainsList.FindDNSDomain(domainIdent)
+	if err != nil {
+		if errors.Is(err, v3.ErrNotFound) {
+			return fmt.Errorf("resource not found")
+		}
+		return err
+	}
+
+	req := v3.CreateDNSDomainRecordRequest{
+		Name:    name,
+		Type:    v3.CreateDNSDomainRecordRequestType(rType),
+		Content: content,
+		Ttl:     ttl,
+	}
+	if priority != nil {
+		req.Priority = *priority
+	}
+
+	op, err := client.CreateDNSDomainRecord(ctx, domain.ID, req)
+	if err != nil {
+		return err
+	}
+
+	decorateAsyncOperation(fmt.Sprintf("Adding DNS record %q to %q...", rType, domain.UnicodeName), func() {
+		_, err = client.Wait(ctx, op)
 	})
 	if err != nil {
 		return err
 	}
 
 	if !globalstate.Quiet {
-		fmt.Printf("Record %q was created successfully to %q\n", rType, *domain.UnicodeName)
+		fmt.Printf("Record %q was created successfully to %q\n", rType, domain.UnicodeName)
 	}
 
 	return nil

--- a/cmd/dns_delete.go
+++ b/cmd/dns_delete.go
@@ -1,13 +1,14 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
-	exoapi "github.com/exoscale/egoscale/v2/api"
+	v3 "github.com/exoscale/egoscale/v3"
 )
 
 func init() {
@@ -33,29 +34,45 @@ func init() {
 }
 
 func deleteDomain(ident string, force bool) error {
-	domain, err := domainFromIdent(ident)
+	ctx := gContext
+	client, err := switchClientZoneV3(ctx, globalstate.EgoscaleV3Client, v3.ZoneName(account.CurrentAccount.DefaultZone))
 	if err != nil {
 		return err
 	}
 
-	if !force && !askQuestion(fmt.Sprintf("Are you sure you want to delete %q domain?", *domain.UnicodeName)) {
+	domainsList, err := client.ListDNSDomains(ctx)
+	if err != nil {
+		return err
+	}
+	domain, err := domainsList.FindDNSDomain(ident)
+	if err != nil {
+		if errors.Is(err, v3.ErrNotFound) {
+			return fmt.Errorf("resource not found")
+		}
+		return err
+	}
+
+	if !force && !askQuestion(fmt.Sprintf("Are you sure you want to delete %q domain?", domain.UnicodeName)) {
 		return nil
 	}
 
-	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, account.CurrentAccount.DefaultZone))
-	decorateAsyncOperation(fmt.Sprintf("Deleting DNS domain %q...", *domain.UnicodeName), func() {
-		err = globalstate.EgoscaleClient.DeleteDNSDomain(
-			ctx,
-			account.CurrentAccount.DefaultZone,
-			domain,
-		)
+	op, err := client.DeleteDNSDomain(
+		ctx,
+		domain.ID,
+	)
+	if err != nil {
+		return err
+	}
+
+	decorateAsyncOperation(fmt.Sprintf("Deleting DNS domain %q...", domain.UnicodeName), func() {
+		_, err = client.Wait(ctx, op)
 	})
 	if err != nil {
 		return err
 	}
 
 	if !globalstate.Quiet {
-		fmt.Printf("Domain %q was deleted successfully\n", *domain.UnicodeName)
+		fmt.Printf("Domain %q was deleted successfully\n", domain.UnicodeName)
 	}
 
 	return nil

--- a/cmd/dns_show.go
+++ b/cmd/dns_show.go
@@ -10,7 +10,7 @@ import (
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
-	exoapi "github.com/exoscale/egoscale/v2/api"
+	v3 "github.com/exoscale/egoscale/v3"
 )
 
 type dnsShowItemOutput struct {
@@ -65,58 +65,60 @@ func showDNS(ident, name string, types []string) (output.Outputter, error) {
 		tMap[t] = struct{}{}
 	}
 
-	domain, err := domainFromIdent(ident)
+	ctx := gContext
+	client, err := switchClientZoneV3(ctx, globalstate.EgoscaleV3Client, v3.ZoneName(account.CurrentAccount.DefaultZone))
 	if err != nil {
 		return nil, err
 	}
 
-	ctx := exoapi.WithEndpoint(gContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, account.CurrentAccount.DefaultZone))
-	records, err := globalstate.EgoscaleClient.ListDNSDomainRecords(ctx, account.CurrentAccount.DefaultZone, *domain.ID)
+	domainsList, err := client.ListDNSDomains(ctx)
+	if err != nil {
+		return nil, err
+	}
+	domain, err := domainsList.FindDNSDomain(ident)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, r := range records {
-		if r.Name == nil || r.Type == nil {
-			continue
-		}
+	records, err := client.ListDNSDomainRecords(ctx, domain.ID)
+	if err != nil {
+		return nil, err
+	}
 
-		if name != "" && *r.Name != name {
-			continue
-		}
+	for _, r := range records.DNSDomainRecords {
 
 		if len(tMap) > 0 {
-			_, ok := tMap[*r.Type]
+			_, ok := tMap[string(r.Type)]
 			if !ok {
 				continue
 			}
 		}
 
-		record, err := globalstate.EgoscaleClient.GetDNSDomainRecord(ctx, account.CurrentAccount.DefaultZone, *domain.ID, *r.ID)
+		record, err := client.GetDNSDomainRecord(ctx, domain.ID, r.ID)
 		if err != nil {
 			return nil, err
 		}
 
 		var priority int64
-		if record.Priority != nil {
-			priority = *record.Priority
+		if record.Priority != 0 {
+			priority = record.Priority
 		}
 
 		var ttl int64
-		if record.TTL != nil {
-			ttl = *record.TTL
+		if record.Ttl != 0 {
+			ttl = record.Ttl
 		}
 
 		out = append(out, dnsShowItemOutput{
-			ID:         *record.ID,
-			DomainID:   *domain.ID,
-			Name:       *record.Name,
-			RecordType: *record.Type,
-			Content:    StrPtrFormatOutput(record.Content),
+			ID:         record.ID.String(),
+			DomainID:   domain.ID.String(),
+			Name:       record.Name,
+			RecordType: string(record.Type),
+			Content:    StrPtrFormatOutput(&record.Content),
 			TTL:        ttl,
 			Prio:       priority,
-			CreatedAt:  DatePtrFormatOutput(record.CreatedAt),
-			UpdatedAt:  DatePtrFormatOutput(record.UpdatedAt),
+			CreatedAt:  DatePtrFormatOutput(&record.CreatedAT),
+			UpdatedAt:  DatePtrFormatOutput(&record.UpdatedAT),
 		})
 	}
 


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

<!--
Describe the tests you did
-->


```
➜  ~/exo/cli git:(tgrondier/feat/dns-egoscale-v3) ✗ go run . dns create foo.bar                                                                                                                                             25-05-12 14:36 
 ✔ Creating DNS domain "foo.bar"... 3s
Domain "foo.bar" was created successfully
➜  ~/exo/cli git:(tgrondier/feat/dns-egoscale-v3) ✗ go run . dns ls                                                                                                                                                         25-05-12 14:36 
┼──────────────────────────────────────┼─────────┼
│                  ID                  │  NAME   │
┼──────────────────────────────────────┼─────────┼
│ 89083a5c-b648-474a-0000-00000013966a │ foo.bar │
┼──────────────────────────────────────┼─────────┼
➜  ~/exo/cli git:(tgrondier/feat/dns-egoscale-v3) ✗ go run . dns show foo.bar                                                                                                                                               25-05-12 14:36 
┼──────────────────────────────────────┼──────┼─────────────┼──────────────────────────────────────────────────────────────────────┼──────┼──────┼
│                  ID                  │ NAME │ RECORD TYPE │                               CONTENT                                │ PRIO │ TTL  │
┼──────────────────────────────────────┼──────┼─────────────┼──────────────────────────────────────────────────────────────────────┼──────┼──────┼
│ 89083a5c-b648-474a-0000-000003d4ffec │      │ SOA         │ ns1.dnsimple.com admin.dnsimple.com 1747053389 86400 7200 604800 300 │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4ffed │      │ NS          │ ns1.dnsimple.com                                                     │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4ffee │      │ NS          │ ns2.dnsimple-edge.net                                                │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4ffef │      │ NS          │ ns3.dnsimple.com                                                     │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4fff0 │      │ NS          │ ns4.dnsimple-edge.org                                                │ 0    │ 3600 │
┼──────────────────────────────────────┼──────┼─────────────┼──────────────────────────────────────────────────────────────────────┼──────┼──────┼
➜  ~/exo/cli git:(tgrondier/feat/dns-egoscale-v3) ✗ go run . dns show 89083a5c-b648-474a-0000-00000013966a                                                                                                                  25-05-12 14:36 
┼──────────────────────────────────────┼──────┼─────────────┼──────────────────────────────────────────────────────────────────────┼──────┼──────┼
│                  ID                  │ NAME │ RECORD TYPE │                               CONTENT                                │ PRIO │ TTL  │
┼──────────────────────────────────────┼──────┼─────────────┼──────────────────────────────────────────────────────────────────────┼──────┼──────┼
│ 89083a5c-b648-474a-0000-000003d4ffec │      │ SOA         │ ns1.dnsimple.com admin.dnsimple.com 1747053389 86400 7200 604800 300 │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4ffed │      │ NS          │ ns1.dnsimple.com                                                     │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4ffee │      │ NS          │ ns2.dnsimple-edge.net                                                │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4ffef │      │ NS          │ ns3.dnsimple.com                                                     │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4fff0 │      │ NS          │ ns4.dnsimple-edge.org                                                │ 0    │ 3600 │
┼──────────────────────────────────────┼──────┼─────────────┼──────────────────────────────────────────────────────────────────────┼──────┼──────┼

➜  ~/exo/cli git:(tgrondier/feat/dns-egoscale-v3) ✗ go run . dns add A foo.bar --address 127.0.0.2                                                                                                                          25-05-12 14:37 
 ✔ Adding DNS record "A" to "foo.bar"... 0s
Record "A" was created successfully to "foo.bar"
➜  ~/exo/cli git:(tgrondier/feat/dns-egoscale-v3) ✗ go run . dns show 89083a5c-b648-474a-0000-00000013966a                                                                                                                  25-05-12 14:39 
┼──────────────────────────────────────┼──────┼─────────────┼──────────────────────────────────────────────────────────────────────┼──────┼──────┼
│                  ID                  │ NAME │ RECORD TYPE │                               CONTENT                                │ PRIO │ TTL  │
┼──────────────────────────────────────┼──────┼─────────────┼──────────────────────────────────────────────────────────────────────┼──────┼──────┼
│ 89083a5c-b648-474a-0000-000003d4ffec │      │ SOA         │ ns1.dnsimple.com admin.dnsimple.com 1747053390 86400 7200 604800 300 │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4ffed │      │ NS          │ ns1.dnsimple.com                                                     │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4ffee │      │ NS          │ ns2.dnsimple-edge.net                                                │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4ffef │      │ NS          │ ns3.dnsimple.com                                                     │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4fff0 │      │ NS          │ ns4.dnsimple-edge.org                                                │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d50032 │      │ A           │ 127.0.0.2                                                            │ 0    │ 3600 │
┼──────────────────────────────────────┼──────┼─────────────┼──────────────────────────────────────────────────────────────────────┼──────┼──────┼

➜  ~/exo/cli git:(tgrondier/feat/dns-egoscale-v3) ✗ go run . dns update A foo.bar 89083a5c-b648-474a-0000-000003d50032 -c 127.0.0.3                                                                                         25-05-12 14:39 
 ✔ Updating DNS record "89083a5c-b648-474a-0000-000003d50032"... 0s
Record "89083a5c-b648-474a-0000-000003d50032" was updated successfully
➜  ~/exo/cli git:(tgrondier/feat/dns-egoscale-v3) ✗ go run . dns show 89083a5c-b648-474a-0000-00000013966a                                                                                                                  25-05-12 14:39 
┼──────────────────────────────────────┼──────┼─────────────┼──────────────────────────────────────────────────────────────────────┼──────┼──────┼
│                  ID                  │ NAME │ RECORD TYPE │                               CONTENT                                │ PRIO │ TTL  │
┼──────────────────────────────────────┼──────┼─────────────┼──────────────────────────────────────────────────────────────────────┼──────┼──────┼
│ 89083a5c-b648-474a-0000-000003d4ffec │      │ SOA         │ ns1.dnsimple.com admin.dnsimple.com 1747053391 86400 7200 604800 300 │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4ffed │      │ NS          │ ns1.dnsimple.com                                                     │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4ffee │      │ NS          │ ns2.dnsimple-edge.net                                                │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4ffef │      │ NS          │ ns3.dnsimple.com                                                     │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4fff0 │      │ NS          │ ns4.dnsimple-edge.org                                                │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d50032 │      │ A           │ 127.0.0.3                                                            │ 0    │ 3600 │
┼──────────────────────────────────────┼──────┼─────────────┼──────────────────────────────────────────────────────────────────────┼──────┼──────┼
➜  ~/exo/cli git:(tgrondier/feat/dns-egoscale-v3) ✗ go run . dns remove foo.bar 89083a5c-b648-474a-0000-000003d50032                                                                                                        25-05-12 14:40 
[+] Are you sure you want to delete record "89083a5c-b648-474a-0000-000003d50032"? [yN]: y
 ✔ Deleting DNS record "foo.bar"... 0s
Record "89083a5c-b648-474a-0000-000003d50032" removed successfully from "foo.bar"
➜  ~/exo/cli git:(tgrondier/feat/dns-egoscale-v3) ✗ go run . dns show 89083a5c-b648-474a-0000-00000013966a                                                                                                                  25-05-12 14:40 
┼──────────────────────────────────────┼──────┼─────────────┼──────────────────────────────────────────────────────────────────────┼──────┼──────┼
│                  ID                  │ NAME │ RECORD TYPE │                               CONTENT                                │ PRIO │ TTL  │
┼──────────────────────────────────────┼──────┼─────────────┼──────────────────────────────────────────────────────────────────────┼──────┼──────┼
│ 89083a5c-b648-474a-0000-000003d4ffec │      │ SOA         │ ns1.dnsimple.com admin.dnsimple.com 1747053392 86400 7200 604800 300 │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4ffed │      │ NS          │ ns1.dnsimple.com                                                     │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4ffee │      │ NS          │ ns2.dnsimple-edge.net                                                │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4ffef │      │ NS          │ ns3.dnsimple.com                                                     │ 0    │ 3600 │
│ 89083a5c-b648-474a-0000-000003d4fff0 │      │ NS          │ ns4.dnsimple-edge.org                                                │ 0    │ 3600 │
┼──────────────────────────────────────┼──────┼─────────────┼──────────────────────────────────────────────────────────────────────┼──────┼──────┼
➜  ~/exo/cli git:(tgrondier/feat/dns-egoscale-v3) ✗ go run . dns delete foo.bar                                                                                                                                             25-05-12 14:40 
[+] Are you sure you want to delete "foo.bar" domain? [yN]: y
 ✔ Deleting DNS domain "foo.bar"... 0s
Domain "foo.bar" was deleted successfully
