### PR TITLE
fix: fix install script

### DIFF
--- a/install-latest.sh
+++ b/install-latest.sh
@@ -178,7 +178,7 @@ verify_pkg() {
 
 if command -v gpg >/dev/null 2>&1 && [ "$PACKAGETYPE" != "yum" ]; then
     if ! gpg --list-keys | grep -q $TOOLING_KEY_FINGERPRINT; then
-        gpg --keyserver keys.openpgp.org --recv-keys "$TOOLING_KEY_FINGERPRINT"
+        gpg --keyserver hkps://keys.openpgp.org:443 --recv-keys "$TOOLING_KEY_FINGERPRINT"
     fi
 
     GPG_AVAILABLE=yes
@@ -220,7 +220,7 @@ case "$PACKAGETYPE" in
     apt)
         $SUDO mkdir -p /etc/apt/keyrings
         gpg --export $TOOLING_KEY_FINGERPRINT | $SUDO tee /etc/apt/keyrings/exoscale.gpg >/dev/null
-        echo "deb [signed-by=/etc/apt/keyrings/exoscale.gpg] https://sos-ch-gva-2.exo.io/exoscale-packages/deb/cli stable main" | $SUDO tee /etc/apt/sources.list.d/exoscale.list >/dev/null
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/exoscale.gpg] https://sos-ch-gva-2.exo.io/exoscale-packages/deb/cli stable main" | $SUDO tee /etc/apt/sources.list.d/exoscale.list >/dev/null
         $SUDO apt-get update
         $SUDO apt-get install -y exoscale-cli
         ;;


### PR DESCRIPTION
# Description
Improve install script:

- gpg use port 11371 per default which is not common port to be open for outgoing connection if outgoing port are restricted. There are more chance to have port 80 and 443 as open. 
- per default apt, at least on my laptop would use the architecture i386 with the error following error message when the `arch` is not  specified
```
Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'https://sos-ch-gva-2.exo.io/exoscale-packages/deb/cli stable InRelease' doesn't support architecture 'i386'
```

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

<!--
Describe the tests you did
-->
