### PR TITLE
Cmd subfolders: Instance template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - instance: show migrated to egoscale v3
 - instance-type: moving the logic to the corresponding subfolder #700
 - private-networks: moving the logic to the corresponding subfolder #700
+- instance-template: moving the logic to the corresponding subfolder #701
 - SKS: more related commands are migrated to egoscale v3
 - SKS: moving the logic to the corresponding subfolder #697
 - dbaas: move all commands to egoscale v3

--- a/cmd/compute/instance_template/instance_template.go
+++ b/cmd/compute/instance_template/instance_template.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/spf13/cobra"
 )
 
@@ -11,5 +12,5 @@ var instanceTemplateCmd = &cobra.Command{
 }
 
 func init() {
-	ComputeCmd.AddCommand(instanceTemplateCmd)
+	exocmd.ComputeCmd.AddCommand(instanceTemplateCmd)
 }

--- a/cmd/compute/instance_template/instance_template_list.go
+++ b/cmd/compute/instance_template/instance_template_list.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
@@ -28,7 +29,7 @@ func (o *instanceTemplateListOutput) ToText()  { output.Text(o) }
 func (o *instanceTemplateListOutput) ToTable() { output.Table(o) }
 
 type instanceTemplateListCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"list"`
 
@@ -49,7 +50,7 @@ Supported output template annotations: %s`,
 }
 
 func (c *instanceTemplateListCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	return CliCommandDefaultPreRun(c, cmd, args)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *instanceTemplateListCmd) CmdRun(_ *cobra.Command, _ []string) error {
@@ -58,7 +59,7 @@ func (c *instanceTemplateListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	}
 
 	ctx := exoapi.WithEndpoint(
-		GContext,
+		exocmd.GContext,
 		exoapi.NewReqEndpoint(account.CurrentAccount.Environment, c.Zone),
 	)
 
@@ -93,8 +94,8 @@ func (c *instanceTemplateListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(instanceTemplateCmd, &instanceTemplateListCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(instanceTemplateCmd, &instanceTemplateListCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 
 		Visibility: "public",
 	}))

--- a/cmd/compute/instance_template/instance_template_show.go
+++ b/cmd/compute/instance_template/instance_template_show.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
@@ -61,7 +62,7 @@ func (o *instanceTemplateShowOutput) ToTable() {
 }
 
 type instanceTemplateShowCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"show"`
 
@@ -71,7 +72,7 @@ type instanceTemplateShowCmd struct {
 	Zone       string `cli-short:"z" cli-usage:"zone to filter results to (default: current account's default zone)"`
 }
 
-func (c *instanceTemplateShowCmd) CmdAliases() []string { return GShowAlias }
+func (c *instanceTemplateShowCmd) CmdAliases() []string { return exocmd.GShowAlias }
 
 func (c *instanceTemplateShowCmd) CmdShort() string {
 	return "Show a Compute instance template details"
@@ -85,13 +86,13 @@ Supported output template annotations: %s`,
 }
 
 func (c *instanceTemplateShowCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	CmdSetZoneFlagFromDefault(cmd)
-	return CliCommandDefaultPreRun(c, cmd, args)
+	exocmd.CmdSetZoneFlagFromDefault(cmd)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *instanceTemplateShowCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	ctx := exoapi.WithEndpoint(
-		GContext,
+		exocmd.GContext,
 		exoapi.NewReqEndpoint(account.CurrentAccount.Environment, account.CurrentAccount.DefaultZone),
 	)
 
@@ -126,9 +127,9 @@ func (c *instanceTemplateShowCmd) CmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(instanceTemplateCmd, &instanceTemplateShowCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(instanceTemplateCmd, &instanceTemplateShowCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 
-		Visibility: DefaultTemplateVisibility,
+		Visibility: exocmd.DefaultTemplateVisibility,
 	}))
 }

--- a/cmd/subcommands/init.go
+++ b/cmd/subcommands/init.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/exoscale/cli/cmd/compute/deploy_target"
 	_ "github.com/exoscale/cli/cmd/compute/elastic_ip"
 	_ "github.com/exoscale/cli/cmd/compute/instance_pool"
+	_ "github.com/exoscale/cli/cmd/compute/instance_template"
 	_ "github.com/exoscale/cli/cmd/compute/instance_type"
 	_ "github.com/exoscale/cli/cmd/compute/load_balancer"
 	_ "github.com/exoscale/cli/cmd/compute/private_network"


### PR DESCRIPTION
Refactoring CLI folder structure:

Moving instance template related commands to the corresponding subfolder

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

```
go run main.go compute instance-template list
┼──────────────────────────────────────┼─────────────────────────────────────────────────────┼─────────────────────────┼───────────────────────────────┼
│                  ID                  │                        NAME                         │         FAMILY          │         CREATION DATE         │
┼──────────────────────────────────────┼─────────────────────────────────────────────────────┼─────────────────────────┼───────────────────────────────┼
│ 1299c3d9-d484-44cb-9f85-cfaf6ffc890c │ VMware SD-WAN 3.3.2 BYOL                            │ vmware sd-wan           │ 2020-10-16 07:19:04 +0000 UTC │
│ d21503c8-b425-4b36-9e51-d6d9ad3c56b9 │ IPFire 2.25 - Core Update 157                       │ ipfire                  │ 2021-07-08 09:34:18 +0000 UTC │
│ 90bff733-233b-4e0c-8c9e-47a62b257d68 │ Open Pryv.io v1.7                                   │ pryv.io                 │ 2021-11-02 16:37:20 +0000 UTC │
│ 7b3a7abb-5d6e-42c5-8352-c0ea7c70b3a6 │ Storage Made Easy - Enterprise File Fabric          │ sme-filefabric          │ 2022-04-13 12:10:12 +0000 UTC │
│ 5d81c79a-9b6c-4495-a771-23e9402b8fb8 │ QNAP QuTScloud c5.0.1.2044                          │ qnap                    │ 2022-06-13 11:18:04 +0000 UTC │
...

go run main.go compute instance-template show def022ef-2fdb-41f9-9c9f-922b0af29dee
┼──────────────────┼────────────────────────────────────────────────────┼
│     TEMPLATE     │                                                    │
┼──────────────────┼────────────────────────────────────────────────────┼
│ ID               │ def022ef-2fdb-41f9-9c9f-922b0af29dee               │
│ Zone             │ ch-gva-2                                           │
│ Name             │ Palo Alto Network FW - 10.1.5-h1                   │
│ Description      │ Palo Alto Network FW - 10.1.5-h1 2022-09-05-ffa2ff │
│ Family           │ palo alto                                          │
│ Creation Date    │ 2022-09-05 12:34:02 +0000 UTC                      │
│ Visibility       │ public                                             │
│ Size             │ 60 GiB                                             │
│ Version          │ 10.1.5-h1                                          │
│ Build            │ 2022-09-05-ffa2ff                                  │
│ Maintainer       │ SCRT                                               │
│ Default User     │ adminpalo                                          │
│ SSH key enabled  │ true                                               │
│ Password enabled │ false                                              │
│ Boot Mode        │ legacy                                             │
│ Checksum         │ ffa2ffc9d55befcf29b387330258beba                   │
┼──────────────────┼────────────────────────────────────────────────────┼
```