### PR TITLE
Cmd subfolders: SecurityGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - load-balancer: moving the logic to the corresponding subfolder #686
 - load-balancer: move to egoscale v3 #687
 - anti-affinity-group: moving the logic to the corresponding subfolder #696
+- security-group: moving the logic to the corresponding subfolder #702
 
 ## 1.84.1
 

--- a/cmd/compute/security_group/security_group.go
+++ b/cmd/compute/security_group/security_group.go
@@ -1,6 +1,7 @@
-package cmd
+package security_group
 
 import (
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/spf13/cobra"
 )
 
@@ -11,5 +12,5 @@ var securityGroupCmd = &cobra.Command{
 }
 
 func init() {
-	ComputeCmd.AddCommand(securityGroupCmd)
+	exocmd.ComputeCmd.AddCommand(securityGroupCmd)
 }

--- a/cmd/compute/security_group/security_group_create.go
+++ b/cmd/compute/security_group/security_group_create.go
@@ -1,4 +1,4 @@
-package cmd
+package security_group
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
@@ -15,7 +16,7 @@ import (
 )
 
 type securityGroupCreateCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"create"`
 
@@ -24,7 +25,7 @@ type securityGroupCreateCmd struct {
 	Description string `cli-usage:"Security Group description"`
 }
 
-func (c *securityGroupCreateCmd) CmdAliases() []string { return GCreateAlias }
+func (c *securityGroupCreateCmd) CmdAliases() []string { return exocmd.GCreateAlias }
 
 func (c *securityGroupCreateCmd) CmdShort() string {
 	return "Create a Security Group"
@@ -38,13 +39,13 @@ Supported output template annotations: %s`,
 }
 
 func (c *securityGroupCreateCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	return CliCommandDefaultPreRun(c, cmd, args)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *securityGroupCreateCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	zone := account.CurrentAccount.DefaultZone
 
-	ctx := exoapi.WithEndpoint(GContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, zone))
+	ctx := exoapi.WithEndpoint(exocmd.GContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, zone))
 
 	securityGroup := &egoscale.SecurityGroup{
 		Description: utils.NonEmptyStringPtr(c.Description),
@@ -52,7 +53,7 @@ func (c *securityGroupCreateCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	}
 
 	var err error
-	decorateAsyncOperation(fmt.Sprintf("Creating Security Group %q...", c.Name), func() {
+	utils.DecorateAsyncOperation(fmt.Sprintf("Creating Security Group %q...", c.Name), func() {
 		securityGroup, err = globalstate.EgoscaleClient.CreateSecurityGroup(ctx, zone, securityGroup)
 	})
 	if err != nil {
@@ -70,7 +71,7 @@ func (c *securityGroupCreateCmd) CmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(securityGroupCmd, &securityGroupCreateCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(securityGroupCmd, &securityGroupCreateCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/security_group/security_group_delete.go
+++ b/cmd/compute/security_group/security_group_delete.go
@@ -1,17 +1,19 @@
-package cmd
+package security_group
 
 import (
 	"fmt"
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
+	"github.com/exoscale/cli/utils"
 	exoapi "github.com/exoscale/egoscale/v2/api"
 )
 
 type securityGroupDeleteCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"delete"`
 
@@ -21,7 +23,7 @@ type securityGroupDeleteCmd struct {
 	Force bool `cli-short:"f" cli-usage:"don't prompt for confirmation"`
 }
 
-func (c *securityGroupDeleteCmd) CmdAliases() []string { return GRemoveAlias }
+func (c *securityGroupDeleteCmd) CmdAliases() []string { return exocmd.GRemoveAlias }
 
 func (c *securityGroupDeleteCmd) CmdShort() string {
 	return "Delete a Security Group"
@@ -30,13 +32,13 @@ func (c *securityGroupDeleteCmd) CmdShort() string {
 func (c *securityGroupDeleteCmd) CmdLong() string { return "" }
 
 func (c *securityGroupDeleteCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	return CliCommandDefaultPreRun(c, cmd, args)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *securityGroupDeleteCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	zone := account.CurrentAccount.DefaultZone
 
-	ctx := exoapi.WithEndpoint(GContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, zone))
+	ctx := exoapi.WithEndpoint(exocmd.GContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, zone))
 
 	securityGroup, err := globalstate.EgoscaleClient.FindSecurityGroup(ctx, zone, c.SecurityGroup)
 	if err != nil {
@@ -44,12 +46,12 @@ func (c *securityGroupDeleteCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	}
 
 	if !c.Force {
-		if !askQuestion(fmt.Sprintf("Are you sure you want to delete Security Group %s?", c.SecurityGroup)) {
+		if !utils.AskQuestion(ctx, fmt.Sprintf("Are you sure you want to delete Security Group %s?", c.SecurityGroup)) {
 			return nil
 		}
 	}
 
-	decorateAsyncOperation(fmt.Sprintf("Deleting Security Group %s...", c.SecurityGroup), func() {
+	utils.DecorateAsyncOperation(fmt.Sprintf("Deleting Security Group %s...", c.SecurityGroup), func() {
 		if c.DeleteRules {
 			for _, rule := range securityGroup.Rules {
 				if err = globalstate.EgoscaleClient.DeleteSecurityGroupRule(ctx, zone, securityGroup, rule); err != nil {
@@ -68,7 +70,7 @@ func (c *securityGroupDeleteCmd) CmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(securityGroupCmd, &securityGroupDeleteCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(securityGroupCmd, &securityGroupDeleteCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/security_group/security_group_list.go
+++ b/cmd/compute/security_group/security_group_list.go
@@ -1,4 +1,4 @@
-package cmd
+package security_group
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
@@ -26,14 +27,14 @@ func (o *securityGroupListOutput) ToText()  { output.Text(o) }
 func (o *securityGroupListOutput) ToTable() { output.Table(o) }
 
 type securityGroupListCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"list"`
 
 	Visibility string `cli-usage:"Security Group visibility: private (default) or public"`
 }
 
-func (c *securityGroupListCmd) CmdAliases() []string { return GListAlias }
+func (c *securityGroupListCmd) CmdAliases() []string { return exocmd.GListAlias }
 
 func (c *securityGroupListCmd) CmdShort() string { return "List Security Groups" }
 
@@ -45,12 +46,12 @@ Supported output template annotations: %s`,
 }
 
 func (c *securityGroupListCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	return CliCommandDefaultPreRun(c, cmd, args)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *securityGroupListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	ctx := exoapi.WithEndpoint(
-		GContext,
+		exocmd.GContext,
 		exoapi.NewReqEndpoint(account.CurrentAccount.Environment, account.CurrentAccount.DefaultZone),
 	)
 
@@ -82,7 +83,7 @@ func (c *securityGroupListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(securityGroupCmd, &securityGroupListCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(securityGroupCmd, &securityGroupListCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/security_group/security_group_rule.go
+++ b/cmd/compute/security_group/security_group_rule.go
@@ -1,4 +1,4 @@
-package cmd
+package security_group
 
 import (
 	"github.com/spf13/cobra"

--- a/cmd/compute/security_group/security_group_rule_add.go
+++ b/cmd/compute/security_group/security_group_rule_add.go
@@ -1,4 +1,4 @@
-package cmd
+package security_group
 
 import (
 	"errors"
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
@@ -29,7 +30,7 @@ var securityGroupRuleProtocols = []string{
 }
 
 type securityGroupAddRuleCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"add"`
 
@@ -63,13 +64,13 @@ Supported output template annotations: %s`,
 }
 
 func (c *securityGroupAddRuleCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	return CliCommandDefaultPreRun(c, cmd, args)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *securityGroupAddRuleCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	zone := account.CurrentAccount.DefaultZone
 
-	ctx := exoapi.WithEndpoint(GContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, zone))
+	ctx := exoapi.WithEndpoint(exocmd.GContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, zone))
 
 	securityGroup, err := globalstate.EgoscaleClient.FindSecurityGroup(ctx, zone, c.SecurityGroup)
 	if err != nil {
@@ -160,7 +161,7 @@ func (c *securityGroupAddRuleCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		securityGroupRule.ICMPType = &c.ICMPType
 	}
 
-	decorateAsyncOperation(fmt.Sprintf("Adding rule to Security Group %q...", *securityGroup.Name), func() {
+	utils.DecorateAsyncOperation(fmt.Sprintf("Adding rule to Security Group %q...", *securityGroup.Name), func() {
 		_, err = globalstate.EgoscaleClient.CreateSecurityGroupRule(ctx, zone, securityGroup, securityGroupRule)
 	})
 	if err != nil {
@@ -174,8 +175,8 @@ func (c *securityGroupAddRuleCmd) CmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(securityGroupRuleCmd, &securityGroupAddRuleCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(securityGroupRuleCmd, &securityGroupAddRuleCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 
 		FlowDirection: "ingress",
 		Protocol:      "tcp",

--- a/cmd/compute/security_group/security_group_show.go
+++ b/cmd/compute/security_group/security_group_show.go
@@ -1,4 +1,4 @@
-package cmd
+package security_group
 
 import (
 	"bytes"
@@ -9,6 +9,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
@@ -131,14 +132,14 @@ func (o *securityGroupShowOutput) ToTable() {
 }
 
 type securityGroupShowCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"show"`
 
 	SecurityGroup string `cli-arg:"#" cli-usage:"NAME|ID"`
 }
 
-func (c *securityGroupShowCmd) CmdAliases() []string { return GShowAlias }
+func (c *securityGroupShowCmd) CmdAliases() []string { return exocmd.GShowAlias }
 
 func (c *securityGroupShowCmd) CmdShort() string {
 	return "Show a Security Group details"
@@ -155,13 +156,13 @@ Supported output template annotations for Security Group rules: %s`,
 }
 
 func (c *securityGroupShowCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	return CliCommandDefaultPreRun(c, cmd, args)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *securityGroupShowCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	zone := account.CurrentAccount.DefaultZone
 
-	ctx := exoapi.WithEndpoint(GContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, zone))
+	ctx := exoapi.WithEndpoint(exocmd.GContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, zone))
 
 	securityGroup, err := globalstate.EgoscaleClient.FindSecurityGroup(ctx, zone, c.SecurityGroup)
 	if err != nil {
@@ -224,17 +225,17 @@ func (c *securityGroupShowCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("error retrieving instances in Security Group: %w", err)
 	}
 
-	for _, instance := range instances {
-		publicIP := emptyIPAddressVisualization
-		if instance.PublicIPAddress != nil && (!instance.PublicIPAddress.IsUnspecified() || len(*instance.PublicIPAddress) > 0) {
-			publicIP = instance.PublicIPAddress.String()
+	for _, vm := range instances {
+		publicIP := exocmd.EmptyIPAddressVisualization
+		if vm.PublicIPAddress != nil && (!vm.PublicIPAddress.IsUnspecified() || len(*vm.PublicIPAddress) > 0) {
+			publicIP = vm.PublicIPAddress.String()
 		}
 
 		out.Instances = append(out.Instances, securityGroupInstanceOutput{
-			Name:     utils.DefaultString(instance.Name, "-"),
+			Name:     utils.DefaultString(vm.Name, "-"),
 			PublicIP: publicIP,
-			ID:       utils.DefaultString(instance.ID, "-"),
-			Zone:     utils.DefaultString(instance.Zone, "-"),
+			ID:       utils.DefaultString(vm.ID, "-"),
+			Zone:     utils.DefaultString(vm.Zone, "-"),
 		})
 	}
 
@@ -242,7 +243,7 @@ func (c *securityGroupShowCmd) CmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(securityGroupCmd, &securityGroupShowCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(securityGroupCmd, &securityGroupShowCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/security_group/security_group_source.go
+++ b/cmd/compute/security_group/security_group_source.go
@@ -1,4 +1,4 @@
-package cmd
+package security_group
 
 import (
 	"github.com/spf13/cobra"

--- a/cmd/compute/security_group/security_group_source_add.go
+++ b/cmd/compute/security_group/security_group_source_add.go
@@ -1,4 +1,4 @@
-package cmd
+package security_group
 
 import (
 	"fmt"
@@ -6,14 +6,16 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
+	"github.com/exoscale/cli/utils"
 	exoapi "github.com/exoscale/egoscale/v2/api"
 )
 
 type securityGroupAddSourceCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"add"`
 
@@ -35,20 +37,20 @@ Supported output template annotations: %s`,
 }
 
 func (c *securityGroupAddSourceCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	return CliCommandDefaultPreRun(c, cmd, args)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *securityGroupAddSourceCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	zone := account.CurrentAccount.DefaultZone
 
-	ctx := exoapi.WithEndpoint(GContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, zone))
+	ctx := exoapi.WithEndpoint(exocmd.GContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, zone))
 
 	securityGroup, err := globalstate.EgoscaleClient.FindSecurityGroup(ctx, zone, c.SecurityGroup)
 	if err != nil {
 		return err
 	}
 
-	decorateAsyncOperation(fmt.Sprintf("Adding Security Group source %s...", c.Cidr), func() {
+	utils.DecorateAsyncOperation(fmt.Sprintf("Adding Security Group source %s...", c.Cidr), func() {
 		err = globalstate.EgoscaleClient.AddExternalSourceToSecurityGroup(ctx, zone, securityGroup, c.Cidr)
 	})
 	if err != nil {
@@ -62,7 +64,7 @@ func (c *securityGroupAddSourceCmd) CmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(securityGroupSourceCmd, &securityGroupAddSourceCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(securityGroupSourceCmd, &securityGroupAddSourceCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/security_group/security_group_source_remove.go
+++ b/cmd/compute/security_group/security_group_source_remove.go
@@ -1,4 +1,4 @@
-package cmd
+package security_group
 
 import (
 	"fmt"
@@ -6,14 +6,16 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
+	"github.com/exoscale/cli/utils"
 	exoapi "github.com/exoscale/egoscale/v2/api"
 )
 
 type securityGroupRemoveSourceCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"remove"`
 
@@ -21,7 +23,7 @@ type securityGroupRemoveSourceCmd struct {
 	Cidr          string `cli-arg:"#" cli-usage:"CIDR"`
 }
 
-func (c *securityGroupRemoveSourceCmd) CmdAliases() []string { return GRemoveAlias }
+func (c *securityGroupRemoveSourceCmd) CmdAliases() []string { return exocmd.GRemoveAlias }
 
 func (c *securityGroupRemoveSourceCmd) CmdShort() string {
 	return "Remove an external source from a Security Group"
@@ -35,20 +37,20 @@ Supported output template annotations: %s`,
 }
 
 func (c *securityGroupRemoveSourceCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	return CliCommandDefaultPreRun(c, cmd, args)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *securityGroupRemoveSourceCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	zone := account.CurrentAccount.DefaultZone
 
-	ctx := exoapi.WithEndpoint(GContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, zone))
+	ctx := exoapi.WithEndpoint(exocmd.GContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, zone))
 
 	securityGroup, err := globalstate.EgoscaleClient.FindSecurityGroup(ctx, zone, c.SecurityGroup)
 	if err != nil {
 		return err
 	}
 
-	decorateAsyncOperation(fmt.Sprintf("Removing Security Group source %s...", c.Cidr), func() {
+	utils.DecorateAsyncOperation(fmt.Sprintf("Removing Security Group source %s...", c.Cidr), func() {
 		err = globalstate.EgoscaleClient.RemoveExternalSourceFromSecurityGroup(ctx, zone, securityGroup, c.Cidr)
 	})
 	if err != nil {
@@ -62,7 +64,7 @@ func (c *securityGroupRemoveSourceCmd) CmdRun(_ *cobra.Command, _ []string) erro
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(securityGroupSourceCmd, &securityGroupRemoveSourceCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(securityGroupSourceCmd, &securityGroupRemoveSourceCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/instance_list.go
+++ b/cmd/instance_list.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	emptyIPAddressVisualization = "-"
+	EmptyIPAddressVisualization = "-"
 )
 
 type instanceListItemOutput struct {
@@ -108,7 +108,7 @@ func (c *instanceListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 				Name:      *i.Name,
 				Zone:      zone,
 				Type:      fmt.Sprintf("%s.%s", *instanceType.Family, *instanceType.Size),
-				IPAddress: utils.DefaultIP(i.PublicIPAddress, emptyIPAddressVisualization),
+				IPAddress: utils.DefaultIP(i.PublicIPAddress, EmptyIPAddressVisualization),
 				State:     *i.State,
 			}
 		}

--- a/cmd/subcommands/init.go
+++ b/cmd/subcommands/init.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/exoscale/cli/cmd/compute/deploy_target"
 	_ "github.com/exoscale/cli/cmd/compute/elastic_ip"
 	_ "github.com/exoscale/cli/cmd/compute/load_balancer"
+	_ "github.com/exoscale/cli/cmd/compute/security_group"
 	_ "github.com/exoscale/cli/cmd/compute/sks"
 	_ "github.com/exoscale/cli/cmd/compute/ssh_key"
 )


### PR DESCRIPTION
Refactoring CLI folder structure:

Moving SecurityGroups to the corresponding subfolder

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

```
o run main.go compute security-group create new-sg
 ✔ Creating Security Group "new-sg"... 3s

┼──────────────────┼──────────────────────────────────────┼
│  SECURITY GROUP  │                                      │
┼──────────────────┼──────────────────────────────────────┼
│ ID               │ 76f49f1a-3ae5-4966-b523-02040fe2996c │
│ Name             │ new-sg                               │
│ Description      │                                      │
│ Ingress Rules    │ -                                    │
│ Egress Rules     │ -                                    │
│ External Sources │ -                                    │
│ Instances        │ -                                    │
┼──────────────────┼──────────────────────────────────────┼

go run main.go compute security-group show new-sg

┼──────────────────┼──────────────────────────────────────┼
│  SECURITY GROUP  │                                      │
┼──────────────────┼──────────────────────────────────────┼
│ ID               │ 76f49f1a-3ae5-4966-b523-02040fe2996c │
│ Name             │ new-sg                               │
│ Description      │                                      │
│ Ingress Rules    │ -                                    │
│ Egress Rules     │ -                                    │
│ External Sources │ -                                    │
│ Instances        │ -                                    │
┼──────────────────┼──────────────────────────────────────┼

go run main.go compute security-group list
┼──────────────────────────────────────┼───────────────────────┼────────────┼
│                  ID                  │         NAME          │ VISIBILITY │
┼──────────────────────────────────────┼───────────────────────┼────────────┼
│ 757ee92c-d1a5-4161-bb7c-4adebe3d388d │ default               │ private    │
│ 1f1e1bdf-e919-4527-85cf-96719883f069 │ sks-security-group    │ private    │
│ fcc6d0b4-22cc-41a0-afca-67019bb8e3af │ load-balancer-http    │ private    │
│ 28ea6bbd-9581-4d6c-8ef1-652af2cdaafe │ eightyeighty          │ private    │
│ 01377dd8-4cff-428c-a2e6-b172fc0c922a │ three_thousand        │ private    │
│ 285bc461-74f9-4f04-8da7-42cde4cd0de5 │ icmp-check            │ private    │
│ 91358e37-6f3f-4b62-80fe-2efec3c06623 │ some-name             │ private    │
...
```