### PR TITLE
Cmd subfolders: blockstorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - anti-affinity-group: moving the logic to the corresponding subfolder #696
 - security-group: moving the logic to the corresponding subfolder #702
 - instance-pool: moving the logic to the corresponding subfolder #704
+- blockstorage: moving the logic to the corresponding subfolder #703
 
 ## 1.84.1
 

--- a/cmd/compute/blockstorage/blockstorage.go
+++ b/cmd/compute/blockstorage/blockstorage.go
@@ -1,6 +1,7 @@
-package cmd
+package blockstorage
 
 import (
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/spf13/cobra"
 )
 
@@ -11,5 +12,5 @@ var blockstorageCmd = &cobra.Command{
 }
 
 func init() {
-	ComputeCmd.AddCommand(blockstorageCmd)
+	exocmd.ComputeCmd.AddCommand(blockstorageCmd)
 }

--- a/cmd/compute/blockstorage/blockstorage_attach.go
+++ b/cmd/compute/blockstorage/blockstorage_attach.go
@@ -1,4 +1,4 @@
-package cmd
+package blockstorage
 
 import (
 	"fmt"
@@ -6,13 +6,15 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
+	"github.com/exoscale/cli/utils"
 	v3 "github.com/exoscale/egoscale/v3"
 )
 
 type blockStorageAttachCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"attach"`
 
@@ -33,13 +35,13 @@ Supported output template annotations: %s`,
 }
 
 func (c *blockStorageAttachCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	CmdSetZoneFlagFromDefault(cmd)
-	return CliCommandDefaultPreRun(c, cmd, args)
+	exocmd.CmdSetZoneFlagFromDefault(cmd)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *blockStorageAttachCmd) CmdRun(_ *cobra.Command, _ []string) error {
-	ctx := GContext
-	client, err := SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
+	ctx := exocmd.GContext
+	client, err := exocmd.SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
 	if err != nil {
 		return err
 	}
@@ -74,7 +76,7 @@ func (c *blockStorageAttachCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	decorateAsyncOperation(fmt.Sprintf("Attaching volume %q to instance %q...", c.Volume, c.Instance), func() {
+	utils.DecorateAsyncOperation(fmt.Sprintf("Attaching volume %q to instance %q...", c.Volume, c.Instance), func() {
 		op, err = client.Wait(ctx, op, v3.OperationStateSuccess)
 	})
 
@@ -82,7 +84,7 @@ func (c *blockStorageAttachCmd) CmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(blockstorageCmd, &blockStorageAttachCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(blockstorageCmd, &blockStorageAttachCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/blockstorage/blockstorage_create.go
+++ b/cmd/compute/blockstorage/blockstorage_create.go
@@ -1,4 +1,4 @@
-package cmd
+package blockstorage
 
 import (
 	"fmt"
@@ -6,13 +6,15 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
+	"github.com/exoscale/cli/utils"
 	v3 "github.com/exoscale/egoscale/v3"
 )
 
 type blockStorageCreateCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"create"`
 
@@ -24,7 +26,7 @@ type blockStorageCreateCmd struct {
 	Zone     v3.ZoneName       `cli-short:"z" cli-usage:"block storage zone"`
 }
 
-func (c *blockStorageCreateCmd) CmdAliases() []string { return GCreateAlias }
+func (c *blockStorageCreateCmd) CmdAliases() []string { return exocmd.GCreateAlias }
 
 func (c *blockStorageCreateCmd) CmdShort() string { return "Create a Block Storage Volume" }
 
@@ -36,13 +38,13 @@ Supported output template annotations: %s`,
 }
 
 func (c *blockStorageCreateCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	CmdSetZoneFlagFromDefault(cmd)
-	return CliCommandDefaultPreRun(c, cmd, args)
+	exocmd.CmdSetZoneFlagFromDefault(cmd)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *blockStorageCreateCmd) CmdRun(_ *cobra.Command, _ []string) error {
-	ctx := GContext
-	client, err := SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
+	ctx := exocmd.GContext
+	client, err := exocmd.SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
 	if err != nil {
 		return err
 	}
@@ -79,7 +81,7 @@ func (c *blockStorageCreateCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	decorateAsyncOperation(fmt.Sprintf("Creating block storage volume %q...", c.Name), func() {
+	utils.DecorateAsyncOperation(fmt.Sprintf("Creating block storage volume %q...", c.Name), func() {
 		op, err = client.Wait(ctx, op, v3.OperationStateSuccess)
 	})
 	if err != nil {
@@ -98,7 +100,7 @@ func (c *blockStorageCreateCmd) CmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(blockstorageCmd, &blockStorageCreateCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(blockstorageCmd, &blockStorageCreateCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/blockstorage/blockstorage_delete.go
+++ b/cmd/compute/blockstorage/blockstorage_delete.go
@@ -1,4 +1,4 @@
-package cmd
+package blockstorage
 
 import (
 	"fmt"
@@ -6,13 +6,15 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
+	"github.com/exoscale/cli/utils"
 	v3 "github.com/exoscale/egoscale/v3"
 )
 
 type blockStorageDeleteCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"delete"`
 
@@ -21,7 +23,7 @@ type blockStorageDeleteCmd struct {
 	Force bool        `cli-short:"f" cli-usage:"don't prompt for confirmation"`
 }
 
-func (c *blockStorageDeleteCmd) CmdAliases() []string { return GDeleteAlias }
+func (c *blockStorageDeleteCmd) CmdAliases() []string { return exocmd.GDeleteAlias }
 
 func (c *blockStorageDeleteCmd) CmdShort() string { return "Delete a Block Storage Volume" }
 
@@ -33,13 +35,13 @@ Supported output template annotations: %s`,
 }
 
 func (c *blockStorageDeleteCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	CmdSetZoneFlagFromDefault(cmd)
-	return CliCommandDefaultPreRun(c, cmd, args)
+	exocmd.CmdSetZoneFlagFromDefault(cmd)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *blockStorageDeleteCmd) CmdRun(_ *cobra.Command, _ []string) error {
-	ctx := GContext
-	client, err := SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
+	ctx := exocmd.GContext
+	client, err := exocmd.SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
 	if err != nil {
 		return err
 	}
@@ -54,7 +56,7 @@ func (c *blockStorageDeleteCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	}
 
 	if !c.Force {
-		if !askQuestion(fmt.Sprintf("Are you sure you want to delete block storage volume %q?", c.Name)) {
+		if !utils.AskQuestion(ctx, fmt.Sprintf("Are you sure you want to delete block storage volume %q?", c.Name)) {
 			return nil
 		}
 	}
@@ -64,7 +66,7 @@ func (c *blockStorageDeleteCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	decorateAsyncOperation(fmt.Sprintf("Deleting block storage volume %q...", c.Name), func() {
+	utils.DecorateAsyncOperation(fmt.Sprintf("Deleting block storage volume %q...", c.Name), func() {
 		_, err = client.Wait(ctx, op, v3.OperationStateSuccess)
 	})
 
@@ -72,7 +74,7 @@ func (c *blockStorageDeleteCmd) CmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(blockstorageCmd, &blockStorageDeleteCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(blockstorageCmd, &blockStorageDeleteCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/blockstorage/blockstorage_detach.go
+++ b/cmd/compute/blockstorage/blockstorage_detach.go
@@ -1,4 +1,4 @@
-package cmd
+package blockstorage
 
 import (
 	"fmt"
@@ -6,13 +6,15 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
+	"github.com/exoscale/cli/utils"
 	v3 "github.com/exoscale/egoscale/v3"
 )
 
 type blockStorageDetachCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"detach"`
 
@@ -33,13 +35,13 @@ Supported output template annotations: %s`,
 }
 
 func (c *blockStorageDetachCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	CmdSetZoneFlagFromDefault(cmd)
-	return CliCommandDefaultPreRun(c, cmd, args)
+	exocmd.CmdSetZoneFlagFromDefault(cmd)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *blockStorageDetachCmd) CmdRun(_ *cobra.Command, _ []string) error {
-	ctx := GContext
-	client, err := SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
+	ctx := exocmd.GContext
+	client, err := exocmd.SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
 	if err != nil {
 		return err
 	}
@@ -55,7 +57,7 @@ func (c *blockStorageDetachCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	}
 
 	if !c.Force {
-		if !askQuestion(fmt.Sprintf("Are you sure you want to detach block storage volume %q?", c.Volume)) {
+		if !utils.AskQuestion(ctx, fmt.Sprintf("Are you sure you want to detach block storage volume %q?", c.Volume)) {
 			return nil
 		}
 	}
@@ -65,7 +67,7 @@ func (c *blockStorageDetachCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	decorateAsyncOperation(fmt.Sprintf("Detaching block storage volume %q...", c.Volume), func() {
+	utils.DecorateAsyncOperation(fmt.Sprintf("Detaching block storage volume %q...", c.Volume), func() {
 		op, err = client.Wait(ctx, op, v3.OperationStateSuccess)
 	})
 
@@ -73,7 +75,7 @@ func (c *blockStorageDetachCmd) CmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(blockstorageCmd, &blockStorageDetachCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(blockstorageCmd, &blockStorageDetachCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/blockstorage/blockstorage_list.go
+++ b/cmd/compute/blockstorage/blockstorage_list.go
@@ -1,4 +1,4 @@
-package cmd
+package blockstorage
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
 	v3 "github.com/exoscale/egoscale/v3"
@@ -27,14 +28,14 @@ func (o *blockStorageListOutput) ToText()  { output.Text(o) }
 func (o *blockStorageListOutput) ToTable() { output.Table(o) }
 
 type blockStorageListCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"list"`
 
 	Zone v3.ZoneName `cli-short:"z" cli-usage:"zone to filter results to"`
 }
 
-func (c *blockStorageListCmd) CmdAliases() []string { return GListAlias }
+func (c *blockStorageListCmd) CmdAliases() []string { return exocmd.GListAlias }
 
 func (c *blockStorageListCmd) CmdShort() string { return "List Block Storage Volumes" }
 
@@ -46,12 +47,12 @@ Supported output template annotations: %s`,
 }
 
 func (c *blockStorageListCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	return CliCommandDefaultPreRun(c, cmd, args)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *blockStorageListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	client := globalstate.EgoscaleV3Client
-	ctx := GContext
+	ctx := exocmd.GContext
 
 	resp, err := client.ListZones(ctx)
 	if err != nil {
@@ -99,7 +100,7 @@ func (c *blockStorageListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(blockstorageCmd, &blockStorageListCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(blockstorageCmd, &blockStorageListCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/blockstorage/blockstorage_show.go
+++ b/cmd/compute/blockstorage/blockstorage_show.go
@@ -1,4 +1,4 @@
-package cmd
+package blockstorage
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
 	v3 "github.com/exoscale/egoscale/v3"
@@ -30,7 +31,7 @@ func (o *blockStorageShowOutput) ToText()      { output.Text(o) }
 func (o *blockStorageShowOutput) ToTable()     { output.Table(o) }
 
 type blockStorageShowCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"show"`
 
@@ -38,7 +39,7 @@ type blockStorageShowCmd struct {
 	Zone v3.ZoneName `cli-short:"z" cli-usage:"block storage volume zone"`
 }
 
-func (c *blockStorageShowCmd) CmdAliases() []string { return GShowAlias }
+func (c *blockStorageShowCmd) CmdAliases() []string { return exocmd.GShowAlias }
 
 func (c *blockStorageShowCmd) CmdShort() string { return "Show a Block Storage Volume details" }
 
@@ -46,17 +47,17 @@ func (c *blockStorageShowCmd) CmdLong() string {
 	return fmt.Sprintf(`This command shows a Block Storage Volume details.
 
 Supported output template annotations: %s`,
-		strings.Join(output.TemplateAnnotations(&instanceShowOutput{}), ", "))
+		strings.Join(output.TemplateAnnotations(&exocmd.InstanceShowOutput{}), ", "))
 }
 
 func (c *blockStorageShowCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	CmdSetZoneFlagFromDefault(cmd)
-	return CliCommandDefaultPreRun(c, cmd, args)
+	exocmd.CmdSetZoneFlagFromDefault(cmd)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *blockStorageShowCmd) CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := GContext
-	client, err := SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
+	ctx := exocmd.GContext
+	client, err := exocmd.SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
 	if err != nil {
 		return err
 	}
@@ -88,7 +89,7 @@ func (c *blockStorageShowCmd) CmdRun(cmd *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(blockstorageCmd, &blockStorageShowCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(blockstorageCmd, &blockStorageShowCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/blockstorage/blockstorage_snapshot.go
+++ b/cmd/compute/blockstorage/blockstorage_snapshot.go
@@ -1,4 +1,4 @@
-package cmd
+package blockstorage
 
 import (
 	"github.com/spf13/cobra"

--- a/cmd/compute/blockstorage/blockstorage_snapshot_create.go
+++ b/cmd/compute/blockstorage/blockstorage_snapshot_create.go
@@ -1,4 +1,4 @@
-package cmd
+package blockstorage
 
 import (
 	"fmt"
@@ -6,13 +6,15 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
+	"github.com/exoscale/cli/utils"
 	v3 "github.com/exoscale/egoscale/v3"
 )
 
 type blockStorageSnapshotCreateCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"create"`
 
@@ -22,7 +24,7 @@ type blockStorageSnapshotCreateCmd struct {
 	Zone   v3.ZoneName       `cli-short:"z" cli-usage:"block storage volume snapshot zone"`
 }
 
-func (c *blockStorageSnapshotCreateCmd) CmdAliases() []string { return GCreateAlias }
+func (c *blockStorageSnapshotCreateCmd) CmdAliases() []string { return exocmd.GCreateAlias }
 
 func (c *blockStorageSnapshotCreateCmd) CmdShort() string {
 	return "Create a Block Storage Volume Snapshot"
@@ -36,13 +38,13 @@ Supported output template annotations: %s`,
 }
 
 func (c *blockStorageSnapshotCreateCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	CmdSetZoneFlagFromDefault(cmd)
-	return CliCommandDefaultPreRun(c, cmd, args)
+	exocmd.CmdSetZoneFlagFromDefault(cmd)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *blockStorageSnapshotCreateCmd) CmdRun(_ *cobra.Command, _ []string) error {
-	ctx := GContext
-	client, err := SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
+	ctx := exocmd.GContext
+	client, err := exocmd.SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
 	if err != nil {
 		return err
 	}
@@ -67,7 +69,7 @@ func (c *blockStorageSnapshotCreateCmd) CmdRun(_ *cobra.Command, _ []string) err
 		return err
 	}
 
-	decorateAsyncOperation(fmt.Sprintf("Snapshotting block storage volume %q...", c.Volume), func() {
+	utils.DecorateAsyncOperation(fmt.Sprintf("Snapshotting block storage volume %q...", c.Volume), func() {
 		op, err = client.Wait(ctx, op, v3.OperationStateSuccess)
 	})
 	if err != nil {
@@ -91,7 +93,7 @@ func (c *blockStorageSnapshotCreateCmd) CmdRun(_ *cobra.Command, _ []string) err
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(blockstorageSnapshotCmd, &blockStorageSnapshotCreateCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(blockstorageSnapshotCmd, &blockStorageSnapshotCreateCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/blockstorage/blockstorage_snapshot_delete.go
+++ b/cmd/compute/blockstorage/blockstorage_snapshot_delete.go
@@ -1,4 +1,4 @@
-package cmd
+package blockstorage
 
 import (
 	"fmt"
@@ -6,13 +6,15 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
+	"github.com/exoscale/cli/utils"
 	v3 "github.com/exoscale/egoscale/v3"
 )
 
 type blockStorageSnapshotDeleteCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"delete"`
 
@@ -21,7 +23,7 @@ type blockStorageSnapshotDeleteCmd struct {
 	Force bool        `cli-short:"f" cli-usage:"don't prompt for confirmation"`
 }
 
-func (c *blockStorageSnapshotDeleteCmd) CmdAliases() []string { return GDeleteAlias }
+func (c *blockStorageSnapshotDeleteCmd) CmdAliases() []string { return exocmd.GDeleteAlias }
 
 func (c *blockStorageSnapshotDeleteCmd) CmdShort() string {
 	return "Delete a Block Storage Volume Snapshot"
@@ -35,13 +37,13 @@ Supported output template annotations: %s`,
 }
 
 func (c *blockStorageSnapshotDeleteCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	CmdSetZoneFlagFromDefault(cmd)
-	return CliCommandDefaultPreRun(c, cmd, args)
+	exocmd.CmdSetZoneFlagFromDefault(cmd)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *blockStorageSnapshotDeleteCmd) CmdRun(_ *cobra.Command, _ []string) error {
-	ctx := GContext
-	client, err := SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
+	ctx := exocmd.GContext
+	client, err := exocmd.SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
 	if err != nil {
 		return err
 	}
@@ -56,7 +58,7 @@ func (c *blockStorageSnapshotDeleteCmd) CmdRun(_ *cobra.Command, _ []string) err
 	}
 
 	if !c.Force {
-		if !askQuestion(fmt.Sprintf("Are you sure you want to delete block storage volume snapshot %q?", c.Name)) {
+		if !utils.AskQuestion(ctx, fmt.Sprintf("Are you sure you want to delete block storage volume snapshot %q?", c.Name)) {
 			return nil
 		}
 	}
@@ -66,7 +68,7 @@ func (c *blockStorageSnapshotDeleteCmd) CmdRun(_ *cobra.Command, _ []string) err
 		return err
 	}
 
-	decorateAsyncOperation(fmt.Sprintf("Deleting block storage volume snapshot %q...", c.Name), func() {
+	utils.DecorateAsyncOperation(fmt.Sprintf("Deleting block storage volume snapshot %q...", c.Name), func() {
 		_, err = client.Wait(ctx, op, v3.OperationStateSuccess)
 	})
 
@@ -74,7 +76,7 @@ func (c *blockStorageSnapshotDeleteCmd) CmdRun(_ *cobra.Command, _ []string) err
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(blockstorageSnapshotCmd, &blockStorageSnapshotDeleteCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(blockstorageSnapshotCmd, &blockStorageSnapshotDeleteCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/blockstorage/blockstorage_snapshot_list.go
+++ b/cmd/compute/blockstorage/blockstorage_snapshot_list.go
@@ -1,4 +1,4 @@
-package cmd
+package blockstorage
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
 	v3 "github.com/exoscale/egoscale/v3"
@@ -25,14 +26,14 @@ func (o *blockStorageSnapshotListOutput) ToText()  { output.Text(o) }
 func (o *blockStorageSnapshotListOutput) ToTable() { output.Table(o) }
 
 type blockStorageSnapshotListCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"list"`
 
 	Zone v3.ZoneName `cli-short:"z" cli-usage:"zone to filter results to"`
 }
 
-func (c *blockStorageSnapshotListCmd) CmdAliases() []string { return GListAlias }
+func (c *blockStorageSnapshotListCmd) CmdAliases() []string { return exocmd.GListAlias }
 
 func (c *blockStorageSnapshotListCmd) CmdShort() string { return "List Block Storage Volume Snapshots" }
 
@@ -44,12 +45,12 @@ Supported output template annotations: %s`,
 }
 
 func (c *blockStorageSnapshotListCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	return CliCommandDefaultPreRun(c, cmd, args)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *blockStorageSnapshotListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	client := globalstate.EgoscaleV3Client
-	ctx := GContext
+	ctx := exocmd.GContext
 
 	resp, err := client.ListZones(ctx)
 	if err != nil {
@@ -94,7 +95,7 @@ func (c *blockStorageSnapshotListCmd) CmdRun(_ *cobra.Command, _ []string) error
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(blockstorageSnapshotCmd, &blockStorageSnapshotListCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(blockstorageSnapshotCmd, &blockStorageSnapshotListCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/blockstorage/blockstorage_snapshot_show.go
+++ b/cmd/compute/blockstorage/blockstorage_snapshot_show.go
@@ -1,4 +1,4 @@
-package cmd
+package blockstorage
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
 	v3 "github.com/exoscale/egoscale/v3"
@@ -28,7 +29,7 @@ func (o *blockStorageSnapshotShowOutput) ToText()      { output.Text(o) }
 func (o *blockStorageSnapshotShowOutput) ToTable()     { output.Table(o) }
 
 type blockStorageSnapshotShowCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"show"`
 
@@ -36,7 +37,7 @@ type blockStorageSnapshotShowCmd struct {
 	Zone v3.ZoneName `cli-short:"z" cli-usage:"block storage zone"`
 }
 
-func (c *blockStorageSnapshotShowCmd) CmdAliases() []string { return GShowAlias }
+func (c *blockStorageSnapshotShowCmd) CmdAliases() []string { return exocmd.GShowAlias }
 
 func (c *blockStorageSnapshotShowCmd) CmdShort() string { return "Show a Block Storage Volume details" }
 
@@ -44,17 +45,17 @@ func (c *blockStorageSnapshotShowCmd) CmdLong() string {
 	return fmt.Sprintf(`This command shows a Block Storage Volume Snapshot details.
 
 Supported output template annotations: %s`,
-		strings.Join(output.TemplateAnnotations(&instanceShowOutput{}), ", "))
+		strings.Join(output.TemplateAnnotations(&exocmd.InstanceShowOutput{}), ", "))
 }
 
 func (c *blockStorageSnapshotShowCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	CmdSetZoneFlagFromDefault(cmd)
-	return CliCommandDefaultPreRun(c, cmd, args)
+	exocmd.CmdSetZoneFlagFromDefault(cmd)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *blockStorageSnapshotShowCmd) CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := GContext
-	client, err := SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
+	ctx := exocmd.GContext
+	client, err := exocmd.SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
 	if err != nil {
 		return err
 	}
@@ -80,7 +81,7 @@ func (c *blockStorageSnapshotShowCmd) CmdRun(cmd *cobra.Command, _ []string) err
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(blockstorageSnapshotCmd, &blockStorageSnapshotShowCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(blockstorageSnapshotCmd, &blockStorageSnapshotShowCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/blockstorage/blockstorage_snapshot_update.go
+++ b/cmd/compute/blockstorage/blockstorage_snapshot_update.go
@@ -1,4 +1,4 @@
-package cmd
+package blockstorage
 
 import (
 	"fmt"
@@ -6,13 +6,14 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
 	v3 "github.com/exoscale/egoscale/v3"
 )
 
 type blockStorageSnapshotUpdateCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"update"`
 
@@ -36,13 +37,13 @@ Supported output template annotations: %s`,
 }
 
 func (c *blockStorageSnapshotUpdateCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	CmdSetZoneFlagFromDefault(cmd)
-	return CliCommandDefaultPreRun(c, cmd, args)
+	exocmd.CmdSetZoneFlagFromDefault(cmd)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *blockStorageSnapshotUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := GContext
-	client, err := SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
+	ctx := exocmd.GContext
+	client, err := exocmd.SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
 	if err != nil {
 		return err
 	}
@@ -59,13 +60,13 @@ func (c *blockStorageSnapshotUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) e
 
 	var updated bool
 	updateReq := v3.UpdateBlockStorageSnapshotRequest{}
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.Labels)) {
-		updateReq.Labels = ConvertIfSpecialEmptyMap(c.Labels)
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.Labels)) {
+		updateReq.Labels = exocmd.ConvertIfSpecialEmptyMap(c.Labels)
 
 		updated = true
 	}
 
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.Rename)) {
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.Rename)) {
 		updateReq.Name = &c.Rename
 
 		updated = true
@@ -99,7 +100,7 @@ func (c *blockStorageSnapshotUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) e
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(blockstorageSnapshotCmd, &blockStorageSnapshotUpdateCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(blockstorageSnapshotCmd, &blockStorageSnapshotUpdateCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/blockstorage/blockstorage_update.go
+++ b/cmd/compute/blockstorage/blockstorage_update.go
@@ -1,4 +1,4 @@
-package cmd
+package blockstorage
 
 import (
 	"fmt"
@@ -6,13 +6,15 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
+	"github.com/exoscale/cli/utils"
 	v3 "github.com/exoscale/egoscale/v3"
 )
 
 type blockStorageUpdateCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"update"`
 
@@ -35,13 +37,13 @@ Supported output template annotations: %s`,
 }
 
 func (c *blockStorageUpdateCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	CmdSetZoneFlagFromDefault(cmd)
-	return CliCommandDefaultPreRun(c, cmd, args)
+	exocmd.CmdSetZoneFlagFromDefault(cmd)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *blockStorageUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := GContext
-	client, err := SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
+	ctx := exocmd.GContext
+	client, err := exocmd.SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
 	if err != nil {
 		return err
 	}
@@ -59,7 +61,7 @@ func (c *blockStorageUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error {
 	var resized bool
 
 	if c.Size > 0 {
-		decorateAsyncOperation(fmt.Sprintf("Updating block storage volume %q...", c.Name), func() {
+		utils.DecorateAsyncOperation(fmt.Sprintf("Updating block storage volume %q...", c.Name), func() {
 			_, err = client.ResizeBlockStorageVolume(ctx, volume.ID,
 				v3.ResizeBlockStorageVolumeRequest{
 					Size: c.Size,
@@ -77,13 +79,13 @@ func (c *blockStorageUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error {
 
 	var updated bool
 	updateReq := v3.UpdateBlockStorageVolumeRequest{}
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.Labels)) {
-		updateReq.Labels = ConvertIfSpecialEmptyMap(c.Labels)
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.Labels)) {
+		updateReq.Labels = exocmd.ConvertIfSpecialEmptyMap(c.Labels)
 
 		updated = true
 	}
 
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.Rename)) {
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.Rename)) {
 		updateReq.Name = &c.Rename
 
 		updated = true
@@ -117,7 +119,7 @@ func (c *blockStorageUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(blockstorageCmd, &blockStorageUpdateCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(blockstorageCmd, &blockStorageUpdateCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/instance_create.go
+++ b/cmd/instance_create.go
@@ -64,7 +64,7 @@ Supported Compute instance type sizes: %s
 Supported output template annotations: %s`,
 		strings.Join(instanceTypeFamilies, ", "),
 		strings.Join(instanceTypeSizes, ", "),
-		strings.Join(output.TemplateAnnotations(&instanceShowOutput{}), ", "))
+		strings.Join(output.TemplateAnnotations(&InstanceShowOutput{}), ", "))
 }
 
 func (c *instanceCreateCmd) CmdPreRun(cmd *cobra.Command, args []string) error {

--- a/cmd/instance_elastic_ip_attach.go
+++ b/cmd/instance_elastic_ip_attach.go
@@ -35,7 +35,7 @@ func (c *instanceEIPAttachCmd) CmdLong() string {
 	return fmt.Sprintf(`This command attaches an Elastic IP address to a Compute instance.
 
 Supported output template annotations: %s`,
-		strings.Join(output.TemplateAnnotations(&instanceShowOutput{}), ", "),
+		strings.Join(output.TemplateAnnotations(&InstanceShowOutput{}), ", "),
 	)
 }
 

--- a/cmd/instance_elastic_ip_detach.go
+++ b/cmd/instance_elastic_ip_detach.go
@@ -35,7 +35,7 @@ func (c *instanceEIPDetachCmd) CmdLong() string {
 	return fmt.Sprintf(`This command detaches an Elastic IP address from a Compute instance.
 
 Supported output template annotations: %s`,
-		strings.Join(output.TemplateAnnotations(&instanceShowOutput{}), ", "),
+		strings.Join(output.TemplateAnnotations(&InstanceShowOutput{}), ", "),
 	)
 }
 

--- a/cmd/instance_private_network_attach.go
+++ b/cmd/instance_private_network_attach.go
@@ -38,7 +38,7 @@ func (c *instancePrivnetAttachCmd) CmdLong() string {
 	return fmt.Sprintf(`This command attaches a Compute instance to a Private Network.
 
 Supported output template annotations: %s`,
-		strings.Join(output.TemplateAnnotations(&instanceShowOutput{}), ", "),
+		strings.Join(output.TemplateAnnotations(&InstanceShowOutput{}), ", "),
 	)
 }
 

--- a/cmd/instance_private_network_detach.go
+++ b/cmd/instance_private_network_detach.go
@@ -35,7 +35,7 @@ func (c *instancePrivnetDetachCmd) CmdLong() string {
 	return fmt.Sprintf(`This command detaches a Compute instance from a Private Network.
 
 Supported output template annotations: %s`,
-		strings.Join(output.TemplateAnnotations(&instanceShowOutput{}), ", "),
+		strings.Join(output.TemplateAnnotations(&InstanceShowOutput{}), ", "),
 	)
 }
 

--- a/cmd/instance_private_network_updateip.go
+++ b/cmd/instance_private_network_updateip.go
@@ -38,7 +38,7 @@ func (c *instancePrivnetUpdateIPCmd) CmdLong() string {
 managed Private Network.
 
 Supported output template annotations: %s`,
-		strings.Join(output.TemplateAnnotations(&instanceShowOutput{}), ", "),
+		strings.Join(output.TemplateAnnotations(&InstanceShowOutput{}), ", "),
 	)
 }
 

--- a/cmd/instance_reset.go
+++ b/cmd/instance_reset.go
@@ -41,7 +41,7 @@ THIS OPERATION EFFECTIVELY WIPES ALL DATA STORED ON THE INSTANCE'S DISK
 /!\ **************************************************************** /!\
 
 Supported output template annotations: %s`,
-		strings.Join(output.TemplateAnnotations(&instanceShowOutput{}), ", "))
+		strings.Join(output.TemplateAnnotations(&InstanceShowOutput{}), ", "))
 }
 
 func (c *instanceResetCmd) CmdPreRun(cmd *cobra.Command, args []string) error {

--- a/cmd/instance_resizedisk.go
+++ b/cmd/instance_resizedisk.go
@@ -34,7 +34,7 @@ func (c *instanceResizeDiskCmd) CmdLong() string {
 	return fmt.Sprintf(`This commands grows a Compute instance's disk to a larger size.'
 
 Supported output template annotations: %s`,
-		strings.Join(output.TemplateAnnotations(&instanceShowOutput{}), ", "))
+		strings.Join(output.TemplateAnnotations(&InstanceShowOutput{}), ", "))
 }
 
 func (c *instanceResizeDiskCmd) CmdPreRun(cmd *cobra.Command, args []string) error {

--- a/cmd/instance_scale.go
+++ b/cmd/instance_scale.go
@@ -37,7 +37,7 @@ Supported Compute instance type sizes: %s
 
 Supported output template annotations: %s`,
 		strings.Join(instanceTypeSizes, ", "),
-		strings.Join(output.TemplateAnnotations(&instanceShowOutput{}), ", "))
+		strings.Join(output.TemplateAnnotations(&InstanceShowOutput{}), ", "))
 }
 
 func (c *instanceScaleCmd) CmdPreRun(cmd *cobra.Command, args []string) error {

--- a/cmd/instance_security_group_add.go
+++ b/cmd/instance_security_group_add.go
@@ -34,7 +34,7 @@ func (c *instanceSGAddCmd) CmdLong() string {
 	return fmt.Sprintf(`This command adds a Compute instance to Security Groups.
 
 Supported output template annotations: %s`,
-		strings.Join(output.TemplateAnnotations(&instanceShowOutput{}), ", "),
+		strings.Join(output.TemplateAnnotations(&InstanceShowOutput{}), ", "),
 	)
 }
 

--- a/cmd/instance_security_group_remove.go
+++ b/cmd/instance_security_group_remove.go
@@ -36,7 +36,7 @@ func (c *instanceSGRemoveCmd) CmdLong() string {
 	return fmt.Sprintf(`This command removes a Compute instance from Security Groups.
 
 Supported output template annotations: %s`,
-		strings.Join(output.TemplateAnnotations(&instanceShowOutput{}), ", "),
+		strings.Join(output.TemplateAnnotations(&InstanceShowOutput{}), ", "),
 	)
 }
 

--- a/cmd/instance_show.go
+++ b/cmd/instance_show.go
@@ -16,7 +16,7 @@ import (
 	v3 "github.com/exoscale/egoscale/v3"
 )
 
-type instanceShowOutput struct {
+type InstanceShowOutput struct {
 	ID                 v3.UUID           `json:"id"`
 	Name               string            `json:"name"`
 	CreationDate       string            `json:"creation_date"`
@@ -40,10 +40,10 @@ type instanceShowOutput struct {
 	ReverseDNS         v3.DomainName     `json:"reverse_dns" outputLabel:"Reverse DNS"`
 }
 
-func (o *instanceShowOutput) Type() string { return "Compute instance" }
-func (o *instanceShowOutput) ToJSON()      { output.JSON(o) }
-func (o *instanceShowOutput) ToText()      { output.Text(o) }
-func (o *instanceShowOutput) ToTable()     { output.Table(o) }
+func (o *InstanceShowOutput) Type() string { return "Compute instance" }
+func (o *InstanceShowOutput) ToJSON()      { output.JSON(o) }
+func (o *InstanceShowOutput) ToText()      { output.Text(o) }
+func (o *InstanceShowOutput) ToTable()     { output.Table(o) }
 
 type instanceShowCmd struct {
 	CliCommandSettings `cli-cmd:"-"`
@@ -64,7 +64,7 @@ func (c *instanceShowCmd) CmdLong() string {
 	return fmt.Sprintf(`This command shows a Compute instance details.
 
 Supported output template annotations: %s`,
-		strings.Join(output.TemplateAnnotations(&instanceShowOutput{}), ", "))
+		strings.Join(output.TemplateAnnotations(&InstanceShowOutput{}), ", "))
 }
 
 func (c *instanceShowCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
@@ -117,7 +117,7 @@ func (c *instanceShowCmd) CmdRun(cmd *cobra.Command, _ []string) error {
 		sshKeyName = &instance.SSHKey.Name
 	}
 
-	out := instanceShowOutput{
+	out := InstanceShowOutput{
 		AntiAffinityGroups: make([]string, 0),
 		CreationDate:       instance.CreatedAT.String(),
 		DiskSize:           humanize.IBytes(uint64(instance.DiskSize << 30)),

--- a/cmd/instance_snapshot_revert.go
+++ b/cmd/instance_snapshot_revert.go
@@ -42,7 +42,7 @@ LOST.
 /!\ **************************************************************** /!\
 
 Supported output template annotations: %s`,
-		strings.Join(output.TemplateAnnotations(&instanceShowOutput{}), ", "))
+		strings.Join(output.TemplateAnnotations(&InstanceShowOutput{}), ", "))
 }
 
 func (c *instanceSnapshotRevertCmd) CmdPreRun(cmd *cobra.Command, args []string) error {

--- a/cmd/instance_update.go
+++ b/cmd/instance_update.go
@@ -39,7 +39,7 @@ func (c *instanceUpdateCmd) CmdLong() string {
 	return fmt.Sprintf(`This command updates an Instance .
 
 Supported output template annotations: %s`,
-		strings.Join(output.TemplateAnnotations(&instanceShowOutput{}), ", "),
+		strings.Join(output.TemplateAnnotations(&InstanceShowOutput{}), ", "),
 	)
 }
 

--- a/cmd/subcommands/init.go
+++ b/cmd/subcommands/init.go
@@ -7,6 +7,7 @@ package subcommands
 
 import (
 	_ "github.com/exoscale/cli/cmd/compute/anti_affinity_group"
+	_ "github.com/exoscale/cli/cmd/compute/blockstorage"
 	_ "github.com/exoscale/cli/cmd/compute/deploy_target"
 	_ "github.com/exoscale/cli/cmd/compute/elastic_ip"
 	_ "github.com/exoscale/cli/cmd/compute/instance_pool"


### PR DESCRIPTION
Refactoring CLI folder structure:

Moving blockstorage to the corresponding subfolder

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

```
go run main.go compute block-storage create test
 ✔ Creating block storage volume "test"... 3s
┼─────────────────────────┼──────────────────────────────────────┼
│  BLOCK STORAGE VOLUME   │                                      │
┼─────────────────────────┼──────────────────────────────────────┼
│ Block Storage Snapshots │ n/a                                  │
│ Blocksize               │ 4096                                 │
│ Created AT              │ 2025-05-26 13:01:32 +0000 UTC        │
│ ID                      │ b2673dfa-25eb-4c80-b953-5351c07cba3a │
│ Instance                │ {}                                   │
│ Name                    │ test                                 │
│ Size                    │ 10 GiB                               │
│ Labels                  │ n/a                                  │
│ State                   │ detached                             │
┼─────────────────────────┼──────────────────────────────────────┼

go run main.go compute block-storage list
┼──────────────────────────────────────┼──────────────────────┼──────────┼─────────┼──────────┼
│                  ID                  │         NAME         │   ZONE   │  SIZE   │  STATE   │
┼──────────────────────────────────────┼──────────────────────┼──────────┼─────────┼──────────┼
│ 5c8c937e-4524-4b79-8cb7-08c760adead2 │ block-storage-volume │ ch-gva-2 │ 100 GiB │ detached │
│ b2673dfa-25eb-4c80-b953-5351c07cba3a │ test                 │ ch-gva-2 │ 10 GiB  │ detached │
┼──────────────────────────────────────┼──────────────────────┼──────────┼─────────┼──────────┼
```