### PR TITLE
Cmd subfolders: InstancePool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - load-balancer: move to egoscale v3 #687
 - anti-affinity-group: moving the logic to the corresponding subfolder #696
 - security-group: moving the logic to the corresponding subfolder #702
+- instance-pool: moving the logic to the corresponding subfolder #704
 
 ## 1.84.1
 

--- a/cmd/blockstorage_snapshot_update.go
+++ b/cmd/blockstorage_snapshot_update.go
@@ -60,7 +60,7 @@ func (c *blockStorageSnapshotUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) e
 	var updated bool
 	updateReq := v3.UpdateBlockStorageSnapshotRequest{}
 	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.Labels)) {
-		updateReq.Labels = convertIfSpecialEmptyMap(c.Labels)
+		updateReq.Labels = ConvertIfSpecialEmptyMap(c.Labels)
 
 		updated = true
 	}

--- a/cmd/blockstorage_update.go
+++ b/cmd/blockstorage_update.go
@@ -78,7 +78,7 @@ func (c *blockStorageUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error {
 	var updated bool
 	updateReq := v3.UpdateBlockStorageVolumeRequest{}
 	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.Labels)) {
-		updateReq.Labels = convertIfSpecialEmptyMap(c.Labels)
+		updateReq.Labels = ConvertIfSpecialEmptyMap(c.Labels)
 
 		updated = true
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -76,10 +76,10 @@ func CmdSetZoneFlagFromDefault(cmd *cobra.Command) {
 	}
 }
 
-// cmdSetTemplateFlagFromDefault  attempts to set the "--template" flag value based on the current active account's
+// CmdSetTemplateFlagFromDefault  attempts to set the "--template" flag value based on the current active account's
 // default template setting if set. This is a convenience helper, there is no guarantee that the flag will be
 // set once this function returns.
-func cmdSetTemplateFlagFromDefault(cmd *cobra.Command) {
+func CmdSetTemplateFlagFromDefault(cmd *cobra.Command) {
 	if cmd.Flag("template").Value.String() == "" {
 		if account.CurrentAccount.DefaultTemplate != "" {
 			cmd.Flag("template").Value.Set(account.CurrentAccount.DefaultTemplate) // nolint:errcheck
@@ -173,7 +173,7 @@ func cliCommandFlagName(c cliCommand, field interface{}) (string, error) {
 	return "", fmt.Errorf("field not found in struct %s", cv.Type())
 }
 
-func convertIfSpecialEmptyMap(m map[string]string) map[string]string {
+func ConvertIfSpecialEmptyMap(m map[string]string) map[string]string {
 	// since it is not possible to pass an empty map
 	// with a spf13/pflag https://github.com/spf13/pflag/issues/312
 	// we use the special value of a map with only

--- a/cmd/compute/instance_pool/instance_pool.go
+++ b/cmd/compute/instance_pool/instance_pool.go
@@ -1,6 +1,7 @@
-package cmd
+package instance_pool
 
 import (
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/spf13/cobra"
 )
 
@@ -11,5 +12,5 @@ var instancePoolCmd = &cobra.Command{
 }
 
 func init() {
-	ComputeCmd.AddCommand(instancePoolCmd)
+	exocmd.ComputeCmd.AddCommand(instancePoolCmd)
 }

--- a/cmd/compute/instance_pool/instance_pool_create.go
+++ b/cmd/compute/instance_pool/instance_pool_create.go
@@ -1,4 +1,4 @@
-package cmd
+package instance_pool
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
@@ -16,7 +17,7 @@ import (
 )
 
 type instancePoolCreateCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"create"`
 
@@ -43,7 +44,7 @@ type instancePoolCreateCmd struct {
 	Zone               v3.ZoneName       `cli-short:"z" cli-usage:"Instance Pool zone"`
 }
 
-func (c *instancePoolCreateCmd) CmdAliases() []string { return GCreateAlias }
+func (c *instancePoolCreateCmd) CmdAliases() []string { return exocmd.GCreateAlias }
 
 func (c *instancePoolCreateCmd) CmdShort() string { return "Create an Instance Pool" }
 
@@ -56,15 +57,15 @@ Supported output template annotations: %s`,
 
 func (c *instancePoolCreateCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
 
-	CmdSetZoneFlagFromDefault(cmd)
-	cmdSetTemplateFlagFromDefault(cmd)
-	return CliCommandDefaultPreRun(c, cmd, args)
+	exocmd.CmdSetZoneFlagFromDefault(cmd)
+	exocmd.CmdSetTemplateFlagFromDefault(cmd)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *instancePoolCreateCmd) CmdRun(_ *cobra.Command, _ []string) error {
 
-	ctx := GContext
-	client, err := SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
+	ctx := exocmd.GContext
+	client, err := exocmd.SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
 	if err != nil {
 		return err
 	}
@@ -208,7 +209,7 @@ func (c *instancePoolCreateCmd) CmdRun(_ *cobra.Command, _ []string) error {
 
 	var instancePoolID v3.UUID
 
-	decorateAsyncOperation(fmt.Sprintf("Creating Instance Pool %q...", c.Name), func() {
+	utils.DecorateAsyncOperation(fmt.Sprintf("Creating Instance Pool %q...", c.Name), func() {
 		var op *v3.Operation
 		op, err = client.CreateInstancePool(ctx, instancePoolReq)
 		if err != nil {
@@ -241,13 +242,13 @@ func (c *instancePoolCreateCmd) CmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(instancePoolCmd, &instancePoolCreateCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(instancePoolCmd, &instancePoolCreateCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 
 		DiskSize:           50,
-		InstanceType:       fmt.Sprintf("%s.%s", DefaultInstanceTypeFamily, DefaultInstanceType),
+		InstanceType:       fmt.Sprintf("%s.%s", exocmd.DefaultInstanceTypeFamily, exocmd.DefaultInstanceType),
 		Size:               1,
 		MinAvailable:       0,
-		TemplateVisibility: defaultTemplateVisibility,
+		TemplateVisibility: exocmd.DefaultTemplateVisibility,
 	}))
 }

--- a/cmd/compute/instance_pool/instance_pool_delete.go
+++ b/cmd/compute/instance_pool/instance_pool_delete.go
@@ -1,4 +1,4 @@
-package cmd
+package instance_pool
 
 import (
 	"errors"
@@ -6,13 +6,15 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
+	"github.com/exoscale/cli/utils"
 	exoapi "github.com/exoscale/egoscale/v2/api"
 )
 
 type instancePoolDeleteCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"delete"`
 
@@ -22,19 +24,19 @@ type instancePoolDeleteCmd struct {
 	Zone  string `cli-short:"z" cli-usage:"Instance Pool zone"`
 }
 
-func (c *instancePoolDeleteCmd) CmdAliases() []string { return GRemoveAlias }
+func (c *instancePoolDeleteCmd) CmdAliases() []string { return exocmd.GRemoveAlias }
 
 func (c *instancePoolDeleteCmd) CmdShort() string { return "Delete an Instance Pool" }
 
 func (c *instancePoolDeleteCmd) CmdLong() string { return "" }
 
 func (c *instancePoolDeleteCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	CmdSetZoneFlagFromDefault(cmd)
-	return CliCommandDefaultPreRun(c, cmd, args)
+	exocmd.CmdSetZoneFlagFromDefault(cmd)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *instancePoolDeleteCmd) CmdRun(_ *cobra.Command, _ []string) error {
-	ctx := exoapi.WithEndpoint(GContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, c.Zone))
+	ctx := exoapi.WithEndpoint(exocmd.GContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, c.Zone))
 
 	instancePool, err := globalstate.EgoscaleClient.FindInstancePool(ctx, c.Zone, c.InstancePool)
 	if err != nil {
@@ -51,7 +53,7 @@ func (c *instancePoolDeleteCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	}
 
 	if !c.Force {
-		if !askQuestion(fmt.Sprintf("Are you sure you want to delete Instance Pool %q?", c.InstancePool)) {
+		if !utils.AskQuestion(ctx, fmt.Sprintf("Are you sure you want to delete Instance Pool %q?", c.InstancePool)) {
 			return nil
 		}
 	}
@@ -69,7 +71,7 @@ func (c *instancePoolDeleteCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	decorateAsyncOperation(fmt.Sprintf("Deleting Instance Pool %q...", c.InstancePool), func() {
+	utils.DecorateAsyncOperation(fmt.Sprintf("Deleting Instance Pool %q...", c.InstancePool), func() {
 		err = globalstate.EgoscaleClient.DeleteInstancePool(ctx, c.Zone, instancePool)
 	})
 	if err != nil {
@@ -80,7 +82,7 @@ func (c *instancePoolDeleteCmd) CmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(instancePoolCmd, &instancePoolDeleteCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(instancePoolCmd, &instancePoolDeleteCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/instance_pool/instance_pool_list.go
+++ b/cmd/compute/instance_pool/instance_pool_list.go
@@ -1,4 +1,4 @@
-package cmd
+package instance_pool
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
@@ -29,14 +30,14 @@ func (o *instancePoolListOutput) ToText()  { output.Text(o) }
 func (o *instancePoolListOutput) ToTable() { output.Table(o) }
 
 type instancePoolListCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"list"`
 
 	Zone string `cli-short:"z" cli-usage:"zone to filter results to"`
 }
 
-func (c *instancePoolListCmd) CmdAliases() []string { return GListAlias }
+func (c *instancePoolListCmd) CmdAliases() []string { return exocmd.GListAlias }
 
 func (c *instancePoolListCmd) CmdShort() string { return "List Instance Pools" }
 
@@ -48,7 +49,7 @@ Supported output template annotations: %s`,
 }
 
 func (c *instancePoolListCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	return CliCommandDefaultPreRun(c, cmd, args)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *instancePoolListCmd) CmdRun(_ *cobra.Command, _ []string) error {
@@ -71,7 +72,7 @@ func (c *instancePoolListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		done <- struct{}{}
 	}()
 	err := utils.ForEachZone(zones, func(zone string) error {
-		ctx := exoapi.WithEndpoint(GContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, zone))
+		ctx := exoapi.WithEndpoint(exocmd.GContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, zone))
 
 		list, err := globalstate.EgoscaleClient.ListInstancePools(ctx, zone)
 		if err != nil {
@@ -102,7 +103,7 @@ func (c *instancePoolListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(instancePoolCmd, &instancePoolListCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(instancePoolCmd, &instancePoolListCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/instance_pool/instance_pool_show.go
+++ b/cmd/compute/instance_pool/instance_pool_show.go
@@ -1,4 +1,4 @@
-package cmd
+package instance_pool
 
 import (
 	"errors"
@@ -8,6 +8,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
@@ -43,7 +44,7 @@ func (o *instancePoolShowOutput) ToText()      { output.Text(o) }
 func (o *instancePoolShowOutput) ToTable()     { output.Table(o) }
 
 type instancePoolShowCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"show"`
 
@@ -53,7 +54,7 @@ type instancePoolShowCmd struct {
 	Zone         string `cli-short:"z" cli-usage:"Instance Pool zone"`
 }
 
-func (c *instancePoolShowCmd) CmdAliases() []string { return GShowAlias }
+func (c *instancePoolShowCmd) CmdAliases() []string { return exocmd.GShowAlias }
 
 func (c *instancePoolShowCmd) CmdShort() string { return "Show an Instance Pool details" }
 
@@ -65,12 +66,12 @@ Supported output template annotations: %s`,
 }
 
 func (c *instancePoolShowCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	CmdSetZoneFlagFromDefault(cmd)
-	return CliCommandDefaultPreRun(c, cmd, args)
+	exocmd.CmdSetZoneFlagFromDefault(cmd)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *instancePoolShowCmd) CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := exoapi.WithEndpoint(GContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, c.Zone))
+	ctx := exoapi.WithEndpoint(exocmd.GContext, exoapi.NewReqEndpoint(account.CurrentAccount.Environment, c.Zone))
 
 	instancePool, err := globalstate.EgoscaleClient.FindInstancePool(ctx, c.Zone, c.InstancePool)
 	if err != nil {
@@ -184,7 +185,7 @@ func (c *instancePoolShowCmd) CmdRun(cmd *cobra.Command, _ []string) error {
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(instancePoolCmd, &instancePoolShowCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(instancePoolCmd, &instancePoolShowCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 	}))
 }

--- a/cmd/compute/instance_pool/instance_pool_update.go
+++ b/cmd/compute/instance_pool/instance_pool_update.go
@@ -1,4 +1,4 @@
-package cmd
+package instance_pool
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
 	"github.com/exoscale/cli/pkg/userdata"
@@ -15,7 +16,7 @@ import (
 )
 
 type instancePoolUpdateCmd struct {
-	CliCommandSettings `cli-cmd:"-"`
+	exocmd.CliCommandSettings `cli-cmd:"-"`
 
 	_ bool `cli-cmd:"update"`
 
@@ -55,15 +56,15 @@ Supported output template annotations: %s`,
 }
 
 func (c *instancePoolUpdateCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
-	CmdSetZoneFlagFromDefault(cmd)
-	return CliCommandDefaultPreRun(c, cmd, args)
+	exocmd.CmdSetZoneFlagFromDefault(cmd)
+	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
 func (c *instancePoolUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error { //nolint:gocyclo
 	var updated bool
 
-	ctx := GContext
-	client, err := SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
+	ctx := exocmd.GContext
+	client, err := exocmd.SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
 	if err != nil {
 		return err
 	}
@@ -79,7 +80,7 @@ func (c *instancePoolUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error { /
 	}
 	updateReq := v3.UpdateInstancePoolRequest{}
 
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.AntiAffinityGroups)) {
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.AntiAffinityGroups)) {
 		updateReq.AntiAffinityGroups = make([]v3.AntiAffinityGroup, len(c.AntiAffinityGroups))
 		af, err := client.ListAntiAffinityGroups(ctx)
 		if err != nil {
@@ -95,7 +96,7 @@ func (c *instancePoolUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error { /
 		updated = true
 	}
 
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.DeployTarget)) {
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.DeployTarget)) {
 		targets, err := client.ListDeployTargets(ctx)
 		if err != nil {
 			return fmt.Errorf("error listing Deploy Target: %w", err)
@@ -108,17 +109,17 @@ func (c *instancePoolUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error { /
 		updated = true
 	}
 
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.Description)) {
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.Description)) {
 		updateReq.Description = c.Description
 		updated = true
 	}
 
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.DiskSize)) {
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.DiskSize)) {
 		updateReq.DiskSize = c.DiskSize
 		updated = true
 	}
 
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.ElasticIPs)) {
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.ElasticIPs)) {
 		result := []v3.ElasticIP{}
 		eipList, err := client.ListElasticIPS(ctx)
 		if err != nil {
@@ -140,32 +141,32 @@ func (c *instancePoolUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error { /
 		}
 	}
 
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.InstancePrefix)) {
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.InstancePrefix)) {
 		updateReq.InstancePrefix = &c.InstancePrefix
 		updated = true
 	}
 
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.IPv6)) {
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.IPv6)) {
 		updateReq.Ipv6Enabled = &c.IPv6
 		updated = true
 	}
 
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.Labels)) {
-		updateReq.Labels = convertIfSpecialEmptyMap(c.Labels)
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.Labels)) {
+		updateReq.Labels = exocmd.ConvertIfSpecialEmptyMap(c.Labels)
 		updated = true
 	}
 
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.MinAvailable)) {
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.MinAvailable)) {
 		updateReq.MinAvailable = &c.MinAvailable
 		updated = true
 	}
 
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.Name)) {
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.Name)) {
 		updateReq.Name = c.Name
 		updated = true
 	}
 
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.PrivateNetworks)) {
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.PrivateNetworks)) {
 		updateReq.PrivateNetworks = make([]v3.PrivateNetwork, len(c.PrivateNetworks))
 		pn, err := client.ListPrivateNetworks(ctx)
 		if err != nil {
@@ -181,7 +182,7 @@ func (c *instancePoolUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error { /
 		updated = true
 	}
 
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.SecurityGroups)) {
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.SecurityGroups)) {
 		sgs, err := client.ListSecurityGroups(ctx)
 
 		if err != nil {
@@ -199,7 +200,7 @@ func (c *instancePoolUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error { /
 		updated = true
 	}
 
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.InstanceType)) {
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.InstanceType)) {
 		instanceTypes, err := client.ListInstanceTypes(ctx)
 		if err != nil {
 			return fmt.Errorf("error listing instance type: %w", err)
@@ -219,12 +220,12 @@ func (c *instancePoolUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error { /
 		updated = true
 	}
 
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.SSHKey)) {
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.SSHKey)) {
 		updateReq.SSHKey = &v3.SSHKey{Name: c.SSHKey}
 		updated = true
 	}
 
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.Template)) {
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.Template)) {
 		templates, err := client.ListTemplates(ctx, v3.ListTemplatesWithVisibility(v3.ListTemplatesVisibility(c.TemplateVisibility)))
 		if err != nil {
 			return fmt.Errorf("error listing template with visibility %q: %w", c.TemplateVisibility, err)
@@ -242,7 +243,7 @@ func (c *instancePoolUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error { /
 		updated = true
 	}
 
-	if cmd.Flags().Changed(MustCLICommandFlagName(c, &c.CloudInitFile)) {
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.CloudInitFile)) {
 		userData, err := userdata.GetUserDataFromFile(c.CloudInitFile, c.CloudInitCompress)
 		if err != nil {
 			return fmt.Errorf("error parsing cloud-init user data: %w", err)
@@ -252,7 +253,7 @@ func (c *instancePoolUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error { /
 	}
 
 	if updated {
-		decorateAsyncOperation(fmt.Sprintf("Updating Instance Pool %q...", c.InstancePool), func() {
+		utils.DecorateAsyncOperation(fmt.Sprintf("Updating Instance Pool %q...", c.InstancePool), func() {
 			_, updateErr := client.UpdateInstancePool(ctx, instancePool.ID, updateReq)
 			err = updateErr
 		})
@@ -273,9 +274,9 @@ func (c *instancePoolUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error { /
 }
 
 func init() {
-	cobra.CheckErr(RegisterCLICommand(instancePoolCmd, &instancePoolUpdateCmd{
-		CliCommandSettings: DefaultCLICmdSettings(),
+	cobra.CheckErr(exocmd.RegisterCLICommand(instancePoolCmd, &instancePoolUpdateCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
 
-		TemplateVisibility: defaultTemplateVisibility,
+		TemplateVisibility: exocmd.DefaultTemplateVisibility,
 	}))
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -24,7 +24,7 @@ const (
 	DefaultInstanceType       = "medium"
 	DefaultInstanceTypeFamily = "standard"
 	defaultTemplate           = "Linux Ubuntu 22.04 LTS 64-bit"
-	defaultTemplateVisibility = "public"
+	DefaultTemplateVisibility = "public"
 	defaultSosEndpoint        = "https://sos-{zone}.exo.io"
 	defaultZone               = "ch-dk-2"
 	defaultOutputFormat       = "table"

--- a/cmd/instance_create.go
+++ b/cmd/instance_create.go
@@ -69,7 +69,7 @@ Supported output template annotations: %s`,
 
 func (c *instanceCreateCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
 	CmdSetZoneFlagFromDefault(cmd)
-	cmdSetTemplateFlagFromDefault(cmd)
+	CmdSetTemplateFlagFromDefault(cmd)
 	return CliCommandDefaultPreRun(c, cmd, args)
 }
 
@@ -332,6 +332,6 @@ func init() {
 
 		DiskSize:           50,
 		InstanceType:       fmt.Sprintf("%s.%s", DefaultInstanceTypeFamily, DefaultInstanceType),
-		TemplateVisibility: defaultTemplateVisibility,
+		TemplateVisibility: DefaultTemplateVisibility,
 	}))
 }

--- a/cmd/instance_reset.go
+++ b/cmd/instance_reset.go
@@ -105,6 +105,6 @@ func init() {
 	cobra.CheckErr(RegisterCLICommand(instanceCmd, &instanceResetCmd{
 		CliCommandSettings: DefaultCLICmdSettings(),
 
-		TemplateVisibility: defaultTemplateVisibility,
+		TemplateVisibility: DefaultTemplateVisibility,
 	}))
 }

--- a/cmd/instance_template_show.go
+++ b/cmd/instance_template_show.go
@@ -129,6 +129,6 @@ func init() {
 	cobra.CheckErr(RegisterCLICommand(instanceTemplateCmd, &instanceTemplateShowCmd{
 		CliCommandSettings: DefaultCLICmdSettings(),
 
-		Visibility: defaultTemplateVisibility,
+		Visibility: DefaultTemplateVisibility,
 	}))
 }

--- a/cmd/subcommands/init.go
+++ b/cmd/subcommands/init.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/exoscale/cli/cmd/compute/anti_affinity_group"
 	_ "github.com/exoscale/cli/cmd/compute/deploy_target"
 	_ "github.com/exoscale/cli/cmd/compute/elastic_ip"
+	_ "github.com/exoscale/cli/cmd/compute/instance_pool"
 	_ "github.com/exoscale/cli/cmd/compute/load_balancer"
 	_ "github.com/exoscale/cli/cmd/compute/security_group"
 	_ "github.com/exoscale/cli/cmd/compute/sks"


### PR DESCRIPTION
Refactoring CLI folder structure:

Moving InstancePools to the corresponding subfolder

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

```
go run main.go compute instance-pool create testme -t a3955d41-4012-44ea-b442-7e22bad598f8
 ✔ Creating Instance Pool "testme"... 21s
┼──────────────────────┼──────────────────────────────────────┼
│    INSTANCE POOL     │                                      │
┼──────────────────────┼──────────────────────────────────────┼
│ ID                   │ 9f996822-de4f-47e5-b0b9-801bcef02d5c │
│ Name                 │ testme                               │
│ Description          │                                      │
│ Instance Type        │ standard.medium                      │
│ Template             │ Linux Fedora CoreOS 41 64-bit        │
│ Zone                 │ ch-gva-2                             │
│ Anti-Affinity Groups │ n/a                                  │
│ Security Groups      │ n/a                                  │
│ Private Networks     │ n/a                                  │
│ Elastic IPs          │ n/a                                  │
│ IPv6                 │ false                                │
│ SSH Key              │ -                                    │
│ Size                 │ 1                                    │
│ Disk Size            │ 50 GiB                               │
│ Instance Prefix      │ pool                                 │
│ State                │ scaling-up                           │
│ Labels               │ n/a                                  │
│ Instances            │ pool-9f996-wzvvf                     │
┼──────────────────────┼──────────────────────────────────────┼

go run main.go compute instance-pool show testme
┼──────────────────────┼──────────────────────────────────────┼
│    INSTANCE POOL     │                                      │
┼──────────────────────┼──────────────────────────────────────┼
│ ID                   │ 9f996822-de4f-47e5-b0b9-801bcef02d5c │
│ Name                 │ testme                               │
│ Description          │                                      │
│ Instance Type        │ standard.medium                      │
│ Template             │ Linux Fedora CoreOS 41 64-bit        │
│ Zone                 │ ch-gva-2                             │
│ Anti-Affinity Groups │ n/a                                  │
│ Security Groups      │ n/a                                  │
│ Private Networks     │ n/a                                  │
│ Elastic IPs          │ n/a                                  │
│ IPv6                 │ false                                │
│ SSH Key              │ -                                    │
│ Size                 │ 1                                    │
│ Disk Size            │ 50 GiB                               │
│ Instance Prefix      │ pool                                 │
│ State                │ running                              │
│ Labels               │ n/a                                  │
│ Instances            │ pool-9f996-wzvvf                     │
┼──────────────────────┼──────────────────────────────────────┼
```