### PR TITLE
eip show shows incorrect instance info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Bug fixes
 
+- eip show: correctly list associated instances #706
+
 ### Improvements
 
 - instance: show migrated to egoscale v3

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/exoscale/egoscale v0.102.4
-	github.com/exoscale/egoscale/v3 v3.1.19
+	github.com/exoscale/egoscale/v3 v3.1.20
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/hashicorp/go-multierror v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
 github.com/exoscale/egoscale v0.102.4 h1:GBKsZMIOzwBfSu+4ZmWka3Ejf2JLiaBDHp4CQUgvp2E=
 github.com/exoscale/egoscale v0.102.4/go.mod h1:ROSmPtle0wvf91iLZb09++N/9BH2Jo9XxIpAEumvocA=
-github.com/exoscale/egoscale/v3 v3.1.19 h1:6CG+AJqAmoIAwJCwHHKh5vilTSZdIe7JE/gPdgnDnT4=
-github.com/exoscale/egoscale/v3 v3.1.19/go.mod h1:A53enXfm8nhVMpIYw0QxiwQ2P6AdCF4F/nVYChNEzdE=
+github.com/exoscale/egoscale/v3 v3.1.20 h1:AZw7VWblEM4+77bjFt9pHBvOQj+spqLkDVxGxK7cbUU=
+github.com/exoscale/egoscale/v3 v3.1.20/go.mod h1:A53enXfm8nhVMpIYw0QxiwQ2P6AdCF4F/nVYChNEzdE=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/v3/operations.go
+++ b/vendor/github.com/exoscale/egoscale/v3/operations.go
@@ -465,7 +465,7 @@ type ListBlockStorageVolumesOpt func(url.Values)
 
 func ListBlockStorageVolumesWithInstanceID(instanceID UUID) ListBlockStorageVolumesOpt {
 	return func(q url.Values) {
-		q.Add("instanceID", fmt.Sprint(instanceID))
+		q.Add("instance-id", fmt.Sprint(instanceID))
 	}
 }
 
@@ -10674,19 +10674,19 @@ type ListInstancesOpt func(url.Values)
 
 func ListInstancesWithManagerID(managerID UUID) ListInstancesOpt {
 	return func(q url.Values) {
-		q.Add("managerID", fmt.Sprint(managerID))
+		q.Add("manager-id", fmt.Sprint(managerID))
 	}
 }
 
 func ListInstancesWithManagerType(managerType ListInstancesManagerType) ListInstancesOpt {
 	return func(q url.Values) {
-		q.Add("managerType", fmt.Sprint(managerType))
+		q.Add("manager-type", fmt.Sprint(managerType))
 	}
 }
 
 func ListInstancesWithIPAddress(ipAddress string) ListInstancesOpt {
 	return func(q url.Values) {
-		q.Add("ipAddress", fmt.Sprint(ipAddress))
+		q.Add("ip-address", fmt.Sprint(ipAddress))
 	}
 }
 
@@ -14620,6 +14620,8 @@ type CreateSKSClusterRequest struct {
 	Level CreateSKSClusterRequestLevel `json:"level" validate:"required"`
 	// Cluster name
 	Name string `json:"name" validate:"required,gte=1,lte=255"`
+	// Cluster networking configuration.
+	Networking *Networking `json:"networking,omitempty"`
 	// SKS Cluster OpenID config map
 	Oidc *SKSOidc `json:"oidc,omitempty"`
 	// Control plane Kubernetes version
@@ -14784,7 +14786,7 @@ type ListSKSClusterVersionsOpt func(url.Values)
 
 func ListSKSClusterVersionsWithIncludeDeprecated(includeDeprecated string) ListSKSClusterVersionsOpt {
 	return func(q url.Values) {
-		q.Add("includeDeprecated", fmt.Sprint(includeDeprecated))
+		q.Add("include-deprecated", fmt.Sprint(includeDeprecated))
 	}
 }
 

--- a/vendor/github.com/exoscale/egoscale/v3/schemas.go
+++ b/vendor/github.com/exoscale/egoscale/v3/schemas.go
@@ -3707,6 +3707,20 @@ type Manager struct {
 	Type ManagerType `json:"type,omitempty"`
 }
 
+// Cluster networking configuration.
+type Networking struct {
+	// CIDR Range for Pods in cluster. This must not overlap with any IP ranges assigned to pods. Max of two, comma-separated, dual-stack CIDRs is allowed.
+	// If not specified, defaults to 192.168.0.0/16.
+	ClusterCidr string `json:"cluster-cidr,omitempty"`
+	// Mask size for node cidr in cluster. It must be larger than the Pod CIDR subnet mask. Defaults to 24
+	NodeCidrMaskSizeIpv4 int64 `json:"node-cidr-mask-size-ipv4,omitempty" validate:"omitempty,gt=0"`
+	// Mask size for node cidr in cluster. It must be larger than the Pod CIDR subnet mask. Defaults to 64
+	NodeCidrMaskSizeIpv6 int64 `json:"node-cidr-mask-size-ipv6,omitempty" validate:"omitempty,gt=0"`
+	// CIDR range for service cluster IPs. This must not overlap with any IP ranges assigned to nodes or pods. Max of two, comma-separated, dual-stack CIDRs is allowed.
+	// If not specified, defaults to 10.96.0.0/12.
+	ServiceClusterIPRange string `json:"service-cluster-ip-range,omitempty"`
+}
+
 type OperationReason string
 
 const (

--- a/vendor/github.com/exoscale/egoscale/v3/version.go
+++ b/vendor/github.com/exoscale/egoscale/v3/version.go
@@ -1,4 +1,4 @@
 package v3
 
 // Version represents the current egoscale v3 version.
-const Version = "v3.1.19"
+const Version = "v3.1.20"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -220,7 +220,7 @@ github.com/exoscale/egoscale/v2
 github.com/exoscale/egoscale/v2/api
 github.com/exoscale/egoscale/v2/oapi
 github.com/exoscale/egoscale/version
-# github.com/exoscale/egoscale/v3 v3.1.19
+# github.com/exoscale/egoscale/v3 v3.1.20
 ## explicit; go 1.23.8
 github.com/exoscale/egoscale/v3
 github.com/exoscale/egoscale/v3/credentials


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Fixes a bug introduced in #684 by bumping egoscale

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

<!--
Describe the tests you did
-->

On master:
```

# instances are not actually filtered by EIP
➜  ~/exo/cli git:(master) go run . compute eip show 9237ef31-854f-4143-b015-5eb714a76f72                                                                                                                                                                                                                     25-05-28 8:52 
┼──────────────────────────┼──────────────────────────────────────────────────────────────────────────────────┼
│        ELASTIC IP        │                                                                                  │
┼──────────────────────────┼──────────────────────────────────────────────────────────────────────────────────┼
│ ID                       │ 9237ef31-854f-4143-b015-5eb714a76f72                                             │

│ Instances                │ VM-4ef116d1-3939-428a-8c70-792293a541bf VM-bd09a01c-286c-4f3c-9a8f-d9ec02de1636  │

```

With this branch:
```
➜  ~/exo/cli git:(tgrondier/sc-131071/-eip-show-shows-incorrect-instance-info) ✗ go run . compute eip show 9237ef31-854f-4143-b015-5eb714a76f72                                                                                                                                                              25-05-28 8:49 
┼──────────────────────────┼──────────────────────────────────────────┼
│        ELASTIC IP        │                                          │
┼──────────────────────────┼──────────────────────────────────────────┼
│ ID                       │ 9237ef31-854f-4143-b015-5eb714a76f72     │

│ Instances                │ VM-bd09a01c-286c-4f3c-9a8f-d9ec02de1636  │

```
