### PR TITLE
fix(sks): remove debug statement

### DIFF
--- a/cmd/compute/sks/sks_kubeconfig.go
+++ b/cmd/compute/sks/sks_kubeconfig.go
@@ -139,7 +139,6 @@ func (c *sksKubeconfigCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	}
 
 	generateResp, err := client.GenerateSKSClusterKubeconfig(ctx, cluster.ID, req)
-	fmt.Println(generateResp)
 
 	if err != nil {
 		return fmt.Errorf("error retrieving kubeconfig: %w", err)


### PR DESCRIPTION
# Description

When requesting a kubeconfig for a SKS cluster, a first line is emitted as the base64 encoded response which breaks the API.

```shell
➜ exo compute sks kubeconfig 004b54b2-90ff-43ce-b0bd-adeb034062b9 admin | tee kubeconfig.yml
  &{YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6CiAgLSBjbHVzdGVyOgogICAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVZENha05EUVNzMlowRjNTVUpCWjBsVlJUbFROVmxOVVdWMk4xaGlRa0p0U0V4SllWWlRiWFZvVERKRmQwUlJXVXBMYjFwSmFIWmpUa0ZSUlV3S1FsRkJkMWRFUlV4TlFXdEhRVEZWUlVKb1RVTlJNR2Q0UkZSQlRFSm5UbFpDUVdOTlFrVmtWMUZVU1hoRlZFRlFRbWRPVmtKQmIwMURSVlkwWWpOT2FncFpWM2hzVFZGM2QwTm5XVVJXVVZGTVJFRk9WRk14VFhoSFZFRllRbWRPVmtKQlRVMUZSMDUyWW01U2VXSXlkM1JqUjNob1ltMVZkRmt5UlhkSlFtTk9DazFxVlhkT2FrVjVUVlJWZWs5RVFYcFhhR2RRVFdwQk0wNVVRVEZOZWtWNFRsUk5ORTFFYUdGTlJtZDRRM3BCU2tKblRsWkNRVmxVUVd0T1NVMVJNSGNLUTNkWlJGWlJVVWhFUVZKSVZtdEZlVTFTUlhkRWQxbEVWbEZSUzBSQmFFWmxSemw2V1RKR2MxcFVSVTFOUVc5SFFURlZSVU4zZDBSVk1IUlVUVkpyZHdwR2QxbEVWbEZSUkVSQ1FtcGlNalV3WTIwNWMweFlRbk5aVnpWc1RGZE9hRTFKU1VOSmFrRk9RbWRyY1docmFVYzVkekJDUVZGRlJrRkJUME5CWnpoQkNrMUpTVU5EWjB0RFFXZEZRWFE0UlhrMWNXOVZWa00yTW0xbFFYSmlTeXMyZWpoM1QybzVSSGxEVGpGR05YazNhalJtYWs5T1dIVm1RMmRQVG1wRE5tMEtlRXRaY0dWcFFXbFRkaTlzYWtobE9UbFZabVpzWVhwalVTOU5UbmN6Vm1ZeWIzcE1aelZvT1dVeGFWRjBlVU0xTDJWVWIzUmtWV2w0VWt4dlZURjZOQXBtVTNKSlNUTkhXVzFUVW1nM2JVMURlVTlKYUc5NlYxTmtSbTQ0VHpCaFNWSTBSbGhCZFc5WlRGZEpVbGgyUzJobmVFeHpiazVoZVV0d2MwWXZObWRxQ21GNmVYVnhRbmhuS3pNeGJYUjBUamRFYkZsTFFVSnZTV2N6WkhWb1NFUk5hMFl6VkVVMVprSXdlbWhKVWxSQmNuaGthQ3Q2WW10NmJYbDVZek52TDJvS2VuRlhORmMzY25ndlJTczNiRFIwYUZaNWFHeHNOVVJyZUdSNFRXRjRaSEpYZDNnNGJHeDBVa1ZEVjBJcmJsaHVXa3h6U21reVoxWXZWWFZPYWxWWlp3cElOMVJQY0RWcGVWQlVhM0ZvWlhKVWQzaHVTSHByZFN0bmJYQnVWMGhqYkd3d1dYUnBNbmxqVGprMmFHNVVZeTl5V2sxV2IxZFVkSGhYUWtWeE1reGpDbWwyUW1seGJrWkZUREZKYldGMlVVWnFPVVJJVUdaTlF5OTZiM2hXVnpsclJFSTNPVGREZG01blNqVnBPSFkxVkV0Mk5GaE9SREl4YzBRM1EyWXZaR3dLTjNGR01HbzVRVkpVY1hjeGMyTnphV2NyVVZJdmFYaHRRaXRoWVdWb1UzcEpUbFIyYm5oRmJrWjZWMkZyUzBnek9GaFpaVXA0TUhobE1HY3djSGh5ZHdwQ1JXeEJiekpWVXl0SFREVXpaVEJSU1drNWNVeGtiRXQ2VmpNMGFIQXJjR3RSWjNSamQwWjRaRk5TWWxKblVWVmpjbTF3YkdNd2NYbE9lRkpOZEhZM0NscHpla0UyY1c5bVEzUmtXSFZRY0d4Vkx6QkRUVlp1Y2pKa1kyaEdaRk1yTlZGcVNVOUZaQ3RPT0ZWc00wdGxVbUkyV0hSeVExVkpia2hIUlhKT1JDOEtNbVZ4YUVKaFJWaG1hVTlYZVdsdGRWRjVZVVV2U25Bck5rRTVWblJ2UkdsUlRTczNUR1JyVG1odGVFdE5URTlKYUc1RVNHbG9hME5CZDBWQlFXRlBRZ3A0VkVOQ2QycENPVUpuVGxaSVUwMUZaR3BDTUc5V2VXdFhha0paVFZGemQwTlJXVVJXVVZGSFJYZEtSRk5FUlU1TlFYTkhRVEZWUlVKM2QwVlNNVnBDQ2sxcVJWSk5RVGhIUVRGVlJVTm5kMGxTV0doMll6Sk9hR0pIVlhoRVJFRkxRbWRPVmtKQmMwMUJNVTVNVlhwRldrMUNZMGRCTVZWRlFYZDNVVmt5T1hVS1pFaEtkbUpETVhkaVIwWjFXbE14YWxsWlNWVkZPVk0xV1UxUlpYWTNXR0pDUW0xSVRFbGhWbE50ZFdoTU1rVjNTRkZaUkZaU01FOUNRbGxGUmtGb1RRcFpSbmhXZWtaR2VWUTRZekprVEZwWU1uUnNWVTFTUzNCTlFrbEhRVEZWWkVWM1JVSXZkMUZKVFVGWlFrRm1PRU5CVVVGM1JHZFpSRlpTTUZCQlVVZ3ZDa0pCVVVSQlowVkhUVUV3UjBOVGNVZFRTV0l6UkZGRlFrTjNWVUZCTkVsRFFWRkNNVVEwUzJKSFUzcEphVEU0VmtKNFJYQXZZWFZQYVVwd1dFVkVNbThLYjBrd01EQndVa3gxVGtsamVVWkVZeXR3Y0dvNEwxQklVbk5ITW1SSEszZEdXa05aWm1GcVFrd3ZNbXhNYVRkdk1tdFhOVlE0UVdwc1JqZEdTMmd3U0FwQ05rUTFWMVpUYjFVeGVuVXZNRkJZU0dnMEwxQkNVRlZFVm1Sa1NFeDRXV0V2S3pSUWNEQkRkV3B5YVZsSlNUTnJTREZrUVhKUVVUTnZRMk5tU2pseUNtZG9kVzFvYm00elZEVXhZbGcxU25aeWVucElSRGxzWjNoVk1VNHlORU5yTDJkR1dqaEJUM0pQVFRoeFRsUldRVGRhV2tzNFRtSTBaRGRHV0hFeE0zTUtVbTVOT0hCNWRWbE5TREJtTnpWd016Vk1lbXB1VldSTVVTOVlZM0l2VWpSUGJqQklSRmsyUkVWV2VFOU1hV2RrWWsxV0wxWlhVbHBJTTNoUE0yOTJWZ28yYzJWUGNVb3JRVGhMUnpOVE9FZHFOMmw0T1VaVlNYWjFSbTB6U25aVWNYVXlNMHR3ZUdaelVFWlBZa3hrU1hndmEyNDNhWEJCV0doV2QyWXJUekZ5Q25Sd01ucHJjeko1VTNWS1Z5OTBiV1paVjJkMU5VbG5hMHBvWmtFeFVYZE1OMDFpS3k5NGJVWnRablJNWkRCVFowdFlSVmgwTm1walZFUlpjM04wVmpVS1UwVldWbEpGZDJoM2FIWXhVRWt5V1hSSU1sbERVRVlyZDB4NlJXSkxRMmhPWWtFM1pXb3ljbUZwTUhRMVpVcGxhVTFZVFhocVNIcFhWR2hWYzA1MU5BcFFLM2RzZUhObGVHeGFhRGxxTjFWME9Vd3JNV2RxY0VWQ01rOU1Oek0yTHpOdFdWVjVSbUZQV0VReGJWWnlVakkyWWs5alFqVlRaRUZPVVhSbldDdHdDbkZNY1ZCb1UxTkNlbTlxUXpCemMxTkRlRUo1ZW5sdk4wWlVVaXM1Y2pWNllrbGxhRWRSV0drdlJXZHZTMnBGVVhaRGF6aHJaR3RNY0Rkc2VFUXhlWGdLZEVveWVHNDJNMUZ0UlcxNlJEaE9aVUVyU214TFFuTnVXV2gyVkd0elVXSklWVlJ2UXpOSWJsQk9XWEEzYldkNVdEZ3lVR3hVWjNsWU5ISmFjbFpUY0FwVk0yaGlSa2ROTm5OWFdXVnNVVDA5Q2kwdExTMHRSVTVFSUVORlVsUkpSa2xEUVZSRkxTMHRMUzBLCiAgICAgIHNlcnZlcjogaHR0cHM6Ly8wMDRiNTRiMi05MGZmLTQzY2UtYjBiZC1hZGViMDM0MDYyYjkucHBza3MtY2gtZ3ZhLTIuZXhvLmlvOjQ0MwogICAgbmFtZTogMDA0YjU0YjItOTBmZi00M2NlLWIwYmQtYWRlYjAzNDA2MmI5CmNvbnRleHRzOgogIC0gY29udGV4dDoKICAgICAgY2x1c3RlcjogMDA0YjU0YjItOTBmZi00M2NlLWIwYmQtYWRlYjAzNDA2MmI5CiAgICAgIHVzZXI6IGFkbWluCiAgICAgIAogICAgbmFtZTogMDA0YjU0YjItOTBmZi00M2NlLWIwYmQtYWRlYjAzNDA2MmI5CmN1cnJlbnQtY29udGV4dDogMDA0YjU0YjItOTBmZi00M2NlLWIwYmQtYWRlYjAzNDA2MmI5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6CiAgLSBuYW1lOiBhZG1pbgogICAgdXNlcjoKICAgICAgY2xpZW50LWNlcnRpZmljYXRlLWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVVp5VkVORFFUVlhaMEYzU1VKQlowbFZWemczU1ZCUlJuVXhOM1Z2UTFaS04zZGFkVTAxUlhGaUwyNW5kMFJSV1VwTGIxcEphSFpqVGtGUlJVd0tRbEZCZDFaRVJVeE5RV3RIUVRGVlJVSm9UVU5STUdkNFJGUkJURUpuVGxaQ1FXTk5Ra1ZrVjFGVVNYaEZWRUZRUW1kT1ZrSkJiMDFEUlZZMFlqTk9hZ3BaVjNoc1RWRjNkME5uV1VSV1VWRk1SRUZPVkZNeFRYaEdWRUZVUW1kT1ZrSkJUVTFFUnpsM1dsaEthR1JIT1hsamVURnFXVlJCWlVaM01IbE9WRUV5Q2sxcVRYaE5SRUY0VGtSb1lVWjNNSGxPVkVFelRXcE5lRTFFUVhoT1ZFNWhUVVpOZUVONlFVcENaMDVXUWtGWlZFRnJUa2xOVVRCM1EzZFpSRlpSVVVnS1JFRlNTRlpyUlhsTlVtTjNSbEZaUkZaUlVVdEVRVFY2WlZoT01GcFhNRFppVjBaNlpFZFdlV042UlUxTlFXOUhRVEZWUlVOM2QwUlZNSFJVVFZFMGR3cEVRVmxFVmxGUlJFUkJWbWhhUnpGd1ltcERRMEZwU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5TVkJCUkVORFFXZHZRMmRuU1VKQlN6VlFDbGd5UkVGTlUwMVVSMEp6ZVhWT1NYQklRVFZHYXpKcGREVkNiVkpQWTNNMlFsYzVVVFZKTjJZNVpVWk1SbUpZWkVaRlYzZDJVMFJLVVRGdWRFWk1hbWNLVUU5S1JVbEtkbWhsWldNNFpFZDJWMVJQWldaNlJITnBaRmRKYVVwQ1R6SkRUVGhDTkdjMGVUTTJPVzQwTUhWdWRqbDVZM1VyZFZKbWRuQldRamxCVUFwWlZUSXlSSGtyZG01VlVGQkdhVFJHVm1aWE1HWXJRbkJxYm5WQ1EwbEdWMUozWkVwMk5VbzJVVVo2ZUVSV1FXbFROa2RGVWpGaE1uQkpRVU5uY2tSMkNubGlTRzlhYjFoSFpVMXlaa3RZZWpKclVYY3piRXhwV0ZKWlRXY3hhazFtTDFsUU9UbGxabmREV0M5a01WSkRRVWRITjBSVlFYRXlNM012V0Zad2NTc0tPVmRFUjJSWWJYbEVZV3Q1Ums1cVpuWjVhRmRRTTBKdlowRXlhek5PVm5WRWFVaHpWVXB5U0ZaemRURnpPRFpNUTBSbGFHSXpUMjFzWm5wdFRHczNUd3BRYkV4b1dqZGhjalJKUzFCUk5HeEpXbloyVjBOVmNFODNObVZMVFhSVmVraGxkRWtyZGs1NVJsSnpTV3RHTVhSbWNsVkRVRVpMYmxNd1UwTXZlR2Q2Q2poNGJrcEVjell6ZUdvMFptaEtSVkZaVm5ZdldWRTViRUV2VVZOUk1YRnNWeXQ2U21aaE0wUjNibkZzTUVjMGRETjVlblpDUzNKeVkwcGpUR2M0YldrS01sa3ZWR3dyWm1GWmRIbGhaMmN3YzBGSVEwSjZXQzlhUW5RMlpIVlRTRkJITDFodFJFaDJUbE5tWldkWVptVkdNblV3YTJ0WllWbEhja1Z3ZDFKMFVBbzFPRGN2YlhObmRrTlROR1JUVjNaTmF6aFhlR2cwUlhwak5FaDVUMWg0VmxkS1JubFRMMU5wWkRaU00zUnlhMDFGT0hRNVRWZFRRalZSVkRWbFVGQTBDblJYWWtwMkswNVJhbGw0TUdoWEwycEJUMmxRYVcxaksyOWpjVGhLVm1ZMldtNWljRkZUUTNkR2EzaGxUa3hKVFdWeVZuVTBka2xxUjNJMU5sQkdVQ3NLU0VsTmJWTXplRmRhUzBoMVdVZHZibVp4U1VSblZITlNPSEJVYjI5V2NVeEhSRXhDYzJZcmFFRm5UVUpCUVVkcVpVUkNNazFDT0VkQk1WVmtTWGRSV1FwTlFtRkJSa2xxUVU1Uk5GVmFPSEI1VjBnd2J6UmtkSFpWWW5Kc04wTnRLMDFDTUVkQk1WVmtSR2RSVjBKQ1UyZDVWVTVIUlU5SVpqbEtUbEpyUW5JekNuUkliVE14U3poR2RYcEJUVUpuVGxaSVVrMUNRV1k0UlVGcVFVRk5RVFJIUVRGVlpFUjNSVUl2ZDFGRlFYZEpSbTlFUVZkQ1owNVdTRk5WUWtGbU9FVUtSRVJCUzBKblozSkNaMFZHUWxGalJFRnFRVTVDWjJ0eGFHdHBSemwzTUVKQlVYTkdRVUZQUTBGblJVRk9SRzlQUjBwbUszbHphRkJXTkRObWFVMVJhUXBOVUVsc1EyUnVUVGxDVEVod2VXeFFXR1ZWTjBkWWNGSlVNRXhLU0RocGVYcGxURXhSTlhwTU9WUm5UMjlLYm1wYVFrWlJNMUV4UW10NVZWSXdTSFpUQ2xsWFRIRkVlRk4yTVRSWk4zUjBiRTVEY0V0dVZGRnplbGM0TmxKalVrWktWVXRvYjJ0VFlrOUJORW9yYjBWWlQwaEdVemt3TUU1bk5UWTNZbWt6ZFRrS04zVTRZV1ozZFVSa2JWVlVUSFJQYlRZM1JrOHdVVkpsZDNGd2NFazFhMUZYWmpaR2NXSnVXbEUwUmpkcFkwbHhUMjFhWVM5c1FtdElTVEZNVmpodFNRcEVhaTlwUjIxUk5VWndia1paZGpOa1duWm9WVE5VVERCVWJtVjFSR1JCVkhjdlZWWlJlWEY2VTBvd0swOXJiVE5MYzJjdlJGZHpSRXN2V21relJtTm1DblZuZFZkc2NuTkdjVk5PVEZwT1dEbE5TVmQ0YzFSMFkwMTBkWFJCUW1KUmVEUllPRkZ4YkhCNWJuTTNUR3hJVm01d1l5OXhabE5DYlcxMWFIUXlRM0FLYkVjNGRYWllVa2xZU2tWNU1GTjVRbFl4ZG5KbVJEZDRjV0pITTIxMk1HVnVhR0ZtVDFvNGIweHNiRW94VW5GMFVESXpkRVkwZFc4NVJUZFhMMkpEVGdwU2RIVTJjbnBuZVN0NUwzQTRSSHBRVmpNck1IUkVhVWRYUkZNM2MyMUNaMUIwWVdKdVVTdElUU3RwVURWcGRIcFJhbnBxU1hCVlRpOUxRVTVzWkd0U0NpODRhRVY2WTFWTmNYQmhZM2g0UVhCWFkzWnlTMloyU2s1S2REbDZNblJ4U0dSTFpTdFhWVkpxTWpKNVNqWjFjRElyV21KcGR6YzFWWE5LWkU4M2Rub0tjRFpFUVRjNGFFOUhZekJyV21aS2FXWllWMWxUZVdVM1RXeDNiVEozWmpFd09HTTJaMXB6UTNsaU9UWkRkRmN3TDFwdVoyb3dZMEZGUTNCWllscFFkd28yYURCcE1GUnNTVWcxWlZOblJGZHVabVJCTjIxWFRHNUxhMVZLT0VwNFZWRTBWMkZCV2tOM1YzSnJXbFE1YVZKWWRYTjVhR2hrV0ZWQk5UVlZXR2t4Q2tacFRIZHFjVEI0Y0RoUVRVbHBNa3dyUWtWWGNEbEpQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICAgIGNsaWVudC1rZXktZGF0YTogTFMwdExTMUNSVWRKVGlCU1UwRWdVRkpKVmtGVVJTQkxSVmt0TFMwdExRcE5TVWxLUzBGSlFrRkJTME5CWjBWQmNtczVabGxOUVhoSmVFMVpSM3BMTkRCcGEyTkVhMWRVWVVzemEwZGFSVFY1ZW05R1lqRkVhMnAwTHpFMFZYTldDblJrTUZWU1lrTTVTVTFzUkZkbE1GVjFUMEU0Tkd0UloyMHJSalUxZW5nd1lUbGFUVFUxTDAxUGVVb3hXV2xKYTBVM1dVbDZkMGhwUkdwTVpuSXlabW9LVXpabEx6TktlVGMyTlVZcksyeFZTREJCT1doVVlsbFFURFlyWkZFNE9GZE1aMVpXT1dKU0x6UkhiVTlsTkVWSloxWmFTRUl3YlM5cmJuQkJXRkJGVGdwVlEwcE1iMWxTU0ZaeVlXdG5RVXREYzA4dlNuTmxhRzFvWTFvMGVYUTRjR1pRWVZKRVJHVlZkVXBrUm1kNVJGZE5lQzg1Wnk4ek1UVXZRVXBtT1ROV0NrVkpRVmxpYzA1UlEzSmlaWG81WkZkdGNqY3hXVTFhTVdWaVNVNXhWRWxWTWs0ckwwdEdXUzlqUjJsQlJHRlVZekZYTkU5SlpYaFJiWE5rVjNrM1Yzb0tlbTl6U1U0MlJuWmpObUZXTDA5WmRWUnpOQ3RWZFVadWRIRjJaMmR2T1VScFZXaHRLemxaU2xOck4zWndORzk1TVZSTlpEWXdhalk0TTBsV1IzZHBVUXBZVnpFcmRGRkpPRlZ4WkV4U1NVd3ZSMFJRZWtkamEwOTZjbVpIVUdnclJXdFNRbWhYTHpsb1JESlZSRGxDU2tSWGNWWmlOMDFzT1hKalVFTmxjVmhSQ21KcE0yWk1UemhGY1hWMGQyeDNkVVI1WVV4YWFqbFBXRFU1Y0drelNuRkRSRk4zUVdOSlNFNW1PV3RITTNBeU5VbGpPR0k1WlZsTlpUZ3hTamsyUW1RS09UUllZVGRUVTFKb2NHZGhjMU51UWtjd0wyNTZkaXRoZVVNNFNreG9NVXBoT0hsVWVHSkhTR2RVVG5wblprazFaa1pXV1d0WVNrdzVTMG96Y0VobE1ncDFVWGRVZVRNd2VGcEpTR3hDVUd3ME9DOXBNVnB6YlM4ME1VTk9ha2hUUm1JclRVRTJTU3RMV25vMmFIbHlkMnhXTDNCdFpIVnNRa2xNUVZkVVJqUXdDbk5uZURaMFZ6ZHBPR2xOWVhadWJ6aFZMelJqWjNsYVRHWkdXbXR2WlRWbllXbGtLMjluVDBKUGVFaDViRTlwYUZkdmMxbE5jMGQ0THpaRlEwRjNSVUVLUVZGTFEwRm5RVzU2SzBGdlkwY3diM0JwTVUweFVEVnhibVJKV0VodFVVaE9hVkpTYUVvMWRrbE9OM0EyUlRsNmNFbHdOM1pTVFVZeVUzUlBjVmx1WndvMllXTlZOMGhZWkhKbVYzQTVhMW9yV1M5aVkxUnBORWhFVldrcldraDVXV2wzZGtaalMyWk9lWEprYWxaSWNFWndUeTgzUmpVM1QwRnJMM0psZFRkbENqVklibU5uYW5oS1JrdEpNRkpvT1dNeFJqY3lhRVk1Tnk5dFRDdFFaelIzSzNSeU9ITlhSalJpVUZSSVNVNTRPQzgyWjJkemFuWkpjMFJUVnk5UFpuY0tWV05JY25KUFkyUnpNemRrVVVGbVpXbFNSRUYzVlhsM1EyNDNhR2t2V2xCWVRtMVlSa0pLYjFabFpXOHhTVWh6VTJsS1dsUndhbWczYldadFRVaDZhQXBJV21oNFdIa3dZMHBtTlZWaWNTdGFURzlaTlZCVlQwOXllbVo0V21oWFUxQnZVREF5WkVaSlprSXdSazlZZWtab1ZEYzFVWGhUUVRKaVpEQlJWVFUzQ2pKNlNVcHpObU5wTHpZNGVtSmxSWEV3TUVoNFppOW5PR0pGYkRnelZWbFhNa1JFYzB4RE1VSkxWVlpKU0RKdGNWRktWelF5UzBKemFVOUhObXhoS3prS1lTdHFSRllyVW5sYWVVWk5WVzFMZVhaVlQwbDJVMU0wYzB4UWVEQTVWekJwY1doUlYzZEZTVzVSTlU1WlJFNUdNMDR2WmtwbWExVk9ialV4TUc0NGF3cFdVRzltTmpsd0t6SmxiRFIwU3pkcEwxQlRWek42ZW1KTmMyUnhabm96U205cFNtbHNVQ3NyV0U5UFkySXlSMlZ3Um04MmRtTlllRk5HWmpKTE56WkRDak5pVlRKMGFqSlNlbXRyWjA1dVFsQm1iVUpqV0dGd1pXY3pTVXBuVGpWMVowWTRObU56ZVRSQlFrMTNORWhRTnk5eFNFVTJaMjlZZUVsa05HUlBkVklLV25GVWFtUnlTblZhYUhkblVqSmxXRVJEUml0MWExQktSbE5JZEdvMmJYQnlaVmRZVm5kRloxSndlVXhSTjNvM2VuZGFVSEpKU21sbmNHMHdjRlJ1WWdwVWFUSjJWRVEyTW5Zd1UwODRlRUptWVhacksweFdOa1ZUZWxWRVozQm9ORzFKUkVsRlNrSm5ka2xqYVZwNlNtSnRVVXREUVZGRlFUYzRVV295ZWt4VUNuYzVUVGcxYkUxV1IwcHpVMlZ5VFZoNmNHNVlWbTAyTTNFMFNUSk5ZVFp4VVdnd2FuZDRUV0l3VTBOSmFISk5lV2RrU1ZSeFdYaE9UVGM0UTFWaVFrd0tTM1pqU1RaalZYUlpZbFpDTDFGUGNESkpjRTVhVldrMFltdHZVR2RPZUdOT1dIRjVaV2hGTmpKM2JXRllOWGg0ZEhZdk0zVjFXazgzV1ZwQlJVOUZMd3B5WTNGVEwzb3lSalZXWVRkRU5uUlVSVE5HUjB4NWJFWkhTbXN5WmxkR00xQnhXR1ZXY0c1TVdISkRhMWwzVVVOeFlqVnhObmR0V1RSaGIzSmFMMnRtQ2xWSFZWa3JNak5SYnpSallVdFZWMFJ6TUVWRVFVRnpOMnhzV1ZveGRsRnNSWEJSVFZSaFZUTmFSVmhMZFhSTWNEYzJTMGRtYzFOWFpGVkNVekZ5T0RnS01qaHpVMjVTUzFoTVRtWjRSRmd6VFdsMk9WTXdTVmQ1Vm5salFWZExaamhGYmpaNlZYUkhkMGRVV2pOcWFpOHdPRVJDTm5OcmFWWktSbWhEVmt0dmRncDRTa00REDACTED}
^^ this line is the debug statement
apiVersion: v1
clusters:
  - cluster:
      certificate-authority-data: REDACTED
      server: https://004b54b2-90ff-43ce-b0bd-adeb034062b9.ppsks-ch-gva-2.exo.io:443
    name: 004b54b2-90ff-43ce-b0bd-adeb034062b9
contexts:
  - context:
      cluster: 004b54b2-90ff-43ce-b0bd-adeb034062b9
      user: admin

    name: 004b54b2-90ff-43ce-b0bd-adeb034062b9
current-context: 004b54b2-90ff-43ce-b0bd-adeb034062b9
kind: Config
preferences: {}
users:
  - name: admin
    user:
      client-certificate-data: REDACTED
      client-key-data: REDACTED
```

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

Automated by GHA.