### PR TITLE
utils: Add hr-zag-1 in the list of zones (egoscale v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- utils: Add hr-zag-1 in the list of zones (egoscale v2) #723
+
 ### Bug fixes
 
 ### Improvements

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/exoscale/egoscale v0.102.4
+	github.com/exoscale/egoscale v0.102.5-0.20250630120923-800c3fe9884a
 	github.com/exoscale/egoscale/v3 v3.1.20
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
@@ -159,4 +159,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.23.10
+go 1.24
+
+toolchain go1.24.4

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,8 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/go-control-plane v0.10.1/go.mod h1:AY7fTTXNdv/aJ2O5jwpxAPOWUZ7hQAEvzN5Pf27BkQQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
-github.com/exoscale/egoscale v0.102.4 h1:GBKsZMIOzwBfSu+4ZmWka3Ejf2JLiaBDHp4CQUgvp2E=
-github.com/exoscale/egoscale v0.102.4/go.mod h1:ROSmPtle0wvf91iLZb09++N/9BH2Jo9XxIpAEumvocA=
+github.com/exoscale/egoscale v0.102.5-0.20250630120923-800c3fe9884a h1:Ahr+mBCHqDyVnaZ+HKhwIxeL8WLMMxHPi0Vf0y/yaNM=
+github.com/exoscale/egoscale v0.102.5-0.20250630120923-800c3fe9884a/go.mod h1:28QIfS/+XfbLNJFdEwqxgS7D1lyjtekLXYgvMg1P2AU=
 github.com/exoscale/egoscale/v3 v3.1.20 h1:AZw7VWblEM4+77bjFt9pHBvOQj+spqLkDVxGxK7cbUU=
 github.com/exoscale/egoscale/v3 v3.1.20/go.mod h1:A53enXfm8nhVMpIYw0QxiwQ2P6AdCF4F/nVYChNEzdE=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -33,6 +33,7 @@ var (
 		string(oapi.ZoneNameChGva2),
 		string(oapi.ZoneNameDeFra1),
 		string(oapi.ZoneNameDeMuc1),
+		string(oapi.ZoneNameHrZag1),
 	}
 )
 

--- a/vendor/github.com/exoscale/egoscale/v2/oapi/oapi.gen.go
+++ b/vendor/github.com/exoscale/egoscale/v2/oapi/oapi.gen.go
@@ -685,6 +685,8 @@ const (
 	ZoneNameDeFra1 ZoneName = "de-fra-1"
 
 	ZoneNameDeMuc1 ZoneName = "de-muc-1"
+
+	ZoneNameHrZag1 ZoneName = "hr-zag-1"
 )
 
 // IAM Access Key

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,8 +214,8 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.1
 ## explicit; go 1.16
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale v0.102.4
-## explicit; go 1.22
+# github.com/exoscale/egoscale v0.102.5-0.20250630120923-800c3fe9884a
+## explicit; go 1.24
 github.com/exoscale/egoscale/v2
 github.com/exoscale/egoscale/v2/api
 github.com/exoscale/egoscale/v2/oapi


### PR DESCRIPTION
# Description

Updating `github.com/exoscale/egoscale` dep as well as adding support for the new `hr-zag-1` in the list of default zones for egoscale v2.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

Before:
```
$ EXOSCALE_TRACE=1 exo c i list 2>&1 | grep hr-zag-1
```
Now:
```
$ EXOSCALE_TRACE=1 go run . c i list 2>&1 | grep hr-zag-1
Host: api-hr-zag-1.exoscale.com
```