### PR TITLE
Fix panic in sks nodepool update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - database: get (logs) crashed upon decoding first line #739
 - database: remove all redis resources #735
 
+### Bug fixes
+
+- Fix panic in sks nodepool update #738
+
 ## 1.85.3
 
 ### Improvements

--- a/cmd/compute/sks/sks_nodepool_update.go
+++ b/cmd/compute/sks/sks_nodepool_update.go
@@ -177,7 +177,7 @@ func (c *sksNodepoolUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error { //
 	}
 
 	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.Taints)) {
-		if nodepool.Taints == nil {
+		if updateReq.Taints == nil {
 			updateReq.Taints = v3.SKSNodepoolTaints{}
 		}
 		for _, t := range c.Taints {


### PR DESCRIPTION
# Description

Fixes the bug with incorrect empty map initialization.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

Before:
```sh
$ go run . c sks nodepool update 2929386e-6f35-494e-82f1-e7d73bbff227 c816545d-5252-4b3c-a324-6ac4834bd7d3 --taint dedicated=special-user:NoSchedule                      
panic: assignment to entry in nil map                                                                                                                                                        
                                                                                                                                                                                             
goroutine 1 [running]:                                                                                                                                                                       
github.com/exoscale/cli/cmd/compute/sks.(*sksNodepoolUpdateCmd).CmdRun(0xc000389d40, 0xc000954008, {0xc0003db4c0?, 0xd22fa0?, 0xc000053c90?})                                                
        /home/aryon/Workspace/git/github.com/exoscale/cli/cmd/compute/sks/sks_nodepool_update.go:188 +0x115a                                                                                 
github.com/spf13/cobra.(*Command).execute(0xc000954008, {0xc0003db440, 0x4, 0x4})                                                                                                            
        /home/aryon/Workspace/git/github.com/exoscale/cli/vendor/github.com/spf13/cobra/command.go:856 +0x6aa                                                                                
github.com/spf13/cobra.(*Command).ExecuteC(0x29a6440)                                                                                                                                        
        /home/aryon/Workspace/git/github.com/exoscale/cli/vendor/github.com/spf13/cobra/command.go:974 +0x38d                                                                                
github.com/spf13/cobra.(*Command).Execute(...)
        /home/aryon/Workspace/git/github.com/exoscale/cli/vendor/github.com/spf13/cobra/command.go:902
github.com/exoscale/cli/cmd.Execute({0x1861eb2?, 0x0?}, {0x1861eb5?, 0xc000002380?})
        /home/aryon/Workspace/git/github.com/exoscale/cli/cmd/root.go:81 +0x1d6
main.main()
        /home/aryon/Workspace/git/github.com/exoscale/cli/main.go:35 +0x3c
exit status 2
```
Now:
```sh
$ go run . c sks nodepool update 2929386e-6f35-494e-82f1-e7d73bbff227 c816545d-5252-4b3c-a324-6ac4834bd7d3 --taint dedicated=very-special-user:NoSchedule
 ✔ Updating Nodepool "c816545d-5252-4b3c-a324-6ac4834bd7d3"... 6s                             
┼─────────────────────────┼────────────────────────────────────────┼
│      SKS NODEPOOL       │                                        │                          
┼─────────────────────────┼────────────────────────────────────────┼
│ ID                      │ c816545d-5252-4b3c-a324-6ac4834bd7d3   │
│ Name                    │ my-test-nodepool                       │                        
│ Description             │                                        │                          
│ Creation Date           │ 2025-07-17 09:41:02 +0000 UTC          │
│ Instance Pool ID        │ ab051840-c937-4477-9417-0f8e8fcda736   │
│ Instance Prefix         │ pool                                   │                                                                                                                         
│ Instance Type           │ standard.medium                        │
│ Template                │ sks-node-1.33.2-standard               │
│ Disk Size               │ 50                                     │         
│ Anti Affinity Groups    │ n/a                                    │
│ Security Groups         │ sks-security-group                     │
│ Private Networks        │ n/a                                    │
│ Version                 │ 1.33.2                                 │
│ Size                    │ 2                                      │                                                                                                                         
│ State                   │ running                                │                                                                                                                         
│ Taints                  │ dedicated=very-special-user:NoSchedule │                         
│ Labels                  │ n/a                                    │                         
│ Add Ons                 │ n/a                                    │                          
│ Image GC Min            │ 2m                                     │
│ Image Gc Low Threshold  │ 80                                     │
│ Image Gc High Threshold │ 85                                     │
┼─────────────────────────┼────────────────────────────────────────┼ 
```