### PR TITLE
fix: (dbaas) timestamp parsing crash (when getting logs)

### DIFF
--- a/cmd/dbaas/dbaas_logs.go
+++ b/cmd/dbaas/dbaas_logs.go
@@ -123,7 +123,7 @@ func (c *dbaasServiceLogsCmd) CmdRun(cmd *cobra.Command, _ []string) error {
 	}
 
 	for i, log := range res.Logs {
-		ts, err := time.Parse("2006-01-02T15:04:05.000000", log.Time)
+		ts, err := time.Parse("2006-01-02T15:04:05.999999Z", log.Time)
 		if err != nil {
 			return fmt.Errorf("unable to parse log timestamp: %w", err)
 		}


### PR DESCRIPTION
# Description

Fetching log on dbaas crashed when getting logs:

```
➜  exoscale-cli git:(master) $ exo dbaas get my-experiment
error: unable to parse log timestamp: parsing time "2025-07-18T09:07:53Z" as "2006-01-02T15:04:05.000000": cannot parse "Z" as ".000000"
```

now:

```
exoscale-cli git:(master) ✗ ./cli dbaas get my-experiment
[... not so pretty table border ...]
│ 2025-07-18 09:09:22 +0000 UTC │ my-experiment-1 │ postgresql-16.service │ [12-1] pid=1661,user=postgres,db=defaultdb,app=system-stats,client=[local] LOG:  disconnection: session time: 0:00:00.095 user=postgres database=defaultdb host=[local]     │
...
```

<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

<!--
Describe the tests you did
-->
