### PR TITLE
Fix EIPv6 address family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- Fix EIPv6 address family #740
+
 ## 1.85.4
 
 ### Improvements

--- a/cmd/compute/elastic_ip/elastic_ip_create.go
+++ b/cmd/compute/elastic_ip/elastic_ip_create.go
@@ -86,7 +86,7 @@ func (c *elasticIPCreateCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	}
 
 	if c.IPv6 {
-		elasticIP.Addressfamily = "inetv6"
+		elasticIP.Addressfamily = "inet6"
 	}
 
 	op, err := client.CreateElasticIP(ctx, elasticIP)


### PR DESCRIPTION
# Description

Corrects the EIPv6 parameter when creating elastic IP (regression [here](https://github.com/exoscale/cli/commit/46509a77c88694c1fc6a00e9042f9a24dde84cb2)).

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

Before:
```bash
$ exo version
exo 1.85.4 23cf25de (egoscale 0.102.3)
$ exo c eip create --ipv6
error: CreateElasticIP: http response: Bad Request: Invalid value `:inetv6` at 'addressfamily' (description: `Elastic IP address family`): should be one of :inet4, :inet6
```

Now:
```bash
$ go run . c eip create --ipv6
 ✔ Creating Elastic IP... 3s
┼────────────────┼──────────────────────────────────────┼
│   ELASTIC IP   │                                      │
┼────────────────┼──────────────────────────────────────┼
│ ID             │ a6272372-10f8-4f53-888e-e5cf2832de6e │
│ IP Address     │ 2a04:c43:e00:a127:500:1:0:1          │
│ Address Family │ inet6                                │
│ CIDR           │ 2a04:c43:e00:a127:500:1::/96         │
│ Description    │                                      │
│ Zone           │ ch-gva-2                             │
│ Type           │ manual                               │
│ Reverse DNS    │                                      │
│ Instances      │                                      │
┼────────────────┼──────────────────────────────────────┼
```