### PR TITLE
Bump egoscale v3.1.25 (retryable HTTP client)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - dbaas: add confirmation prompt for update command to warn about potential service restart
+- Bump egoscale v3.1.25 (retryable HTTP client) #743
 
 ### Bug fixes
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/exoscale/egoscale v0.102.5-0.20250630120923-800c3fe9884a
-	github.com/exoscale/egoscale/v3 v3.1.23
+	github.com/exoscale/egoscale/v3 v3.1.25
 	github.com/exoscale/openapi-cli-generator v1.1.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/hashicorp/go-multierror v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
 github.com/exoscale/egoscale v0.102.5-0.20250630120923-800c3fe9884a h1:Ahr+mBCHqDyVnaZ+HKhwIxeL8WLMMxHPi0Vf0y/yaNM=
 github.com/exoscale/egoscale v0.102.5-0.20250630120923-800c3fe9884a/go.mod h1:28QIfS/+XfbLNJFdEwqxgS7D1lyjtekLXYgvMg1P2AU=
-github.com/exoscale/egoscale/v3 v3.1.23 h1:OYVM9nDA4YmJnukEd1bzHE0xuX7HMdHH84jH4TRUERw=
-github.com/exoscale/egoscale/v3 v3.1.23/go.mod h1:A53enXfm8nhVMpIYw0QxiwQ2P6AdCF4F/nVYChNEzdE=
+github.com/exoscale/egoscale/v3 v3.1.25 h1:Xy4LdmElaUXdf72vCt8gv9DCivKUlmW5Ar5ATInwWU8=
+github.com/exoscale/egoscale/v3 v3.1.25/go.mod h1:TJCI0OG3Lz2rnleRB0xwiOFg82uNCCytRqw7TxPoIvc=
 github.com/exoscale/openapi-cli-generator v1.1.0 h1:fYjmPqHR5vxlOBrbvde7eo7bISNQIFxsGn4A5/acwKA=
 github.com/exoscale/openapi-cli-generator v1.1.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/v3/operations.go
+++ b/vendor/github.com/exoscale/egoscale/v3/operations.go
@@ -9430,7 +9430,7 @@ func (c Client) ListEvents(ctx context.Context, opts ...ListEventsOpt) ([]Event,
 	}
 
 	bodyresp := []Event{}
-	if err := prepareJSONResponse(response, bodyresp); err != nil {
+	if err := prepareJSONResponse(response, &bodyresp); err != nil {
 		return nil, fmt.Errorf("ListEvents: prepare Json response: %w", err)
 	}
 
@@ -14024,7 +14024,7 @@ func (c Client) ListSKSClusterDeprecatedResources(ctx context.Context, id UUID) 
 	}
 
 	bodyresp := []SKSClusterDeprecatedResource{}
-	if err := prepareJSONResponse(response, bodyresp); err != nil {
+	if err := prepareJSONResponse(response, &bodyresp); err != nil {
 		return nil, fmt.Errorf("ListSKSClusterDeprecatedResources: prepare Json response: %w", err)
 	}
 

--- a/vendor/github.com/exoscale/egoscale/v3/version.go
+++ b/vendor/github.com/exoscale/egoscale/v3/version.go
@@ -1,4 +1,4 @@
 package v3
 
 // Version represents the current egoscale v3 version.
-const Version = "v3.1.23"
+const Version = "v3.1.25"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -220,7 +220,7 @@ github.com/exoscale/egoscale/v2
 github.com/exoscale/egoscale/v2/api
 github.com/exoscale/egoscale/v2/oapi
 github.com/exoscale/egoscale/version
-# github.com/exoscale/egoscale/v3 v3.1.23
+# github.com/exoscale/egoscale/v3 v3.1.25
 ## explicit; go 1.23.8
 github.com/exoscale/egoscale/v3
 github.com/exoscale/egoscale/v3/credentials


### PR DESCRIPTION
# Description

Bumps egoscale client to include [retryable HTTP client](https://github.com/exoscale/egoscale/pull/710).

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

<!--
Describe the tests you did
-->
