### PR TITLE
storage: Introduce new `purge` call

### DIFF
--- a/cmd/storage/storage_purge.go
+++ b/cmd/storage/storage_purge.go
@@ -1,0 +1,105 @@
+package storage
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/spf13/cobra"
+
+	exocmd "github.com/exoscale/cli/cmd"
+	"github.com/exoscale/cli/pkg/storage/sos"
+	"github.com/exoscale/cli/utils"
+)
+
+var storagePurgeCmd = &cobra.Command{
+	Use:     "purge sos://BUCKET/[OBJECT|PREFIX/]",
+	Aliases: []string{"purge"},
+	Short:   "Purge objects and their versions",
+	Long: `This command purges objects and object versions stored in a bucket.
+
+    exo storage purge sos://my-bucket/
+    exo storage purge sos://my-bucket/some-prefix/
+`,
+
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if len(args) != 1 {
+			exocmd.CmdExitOnUsageError(cmd, "invalid arguments")
+		}
+
+		args[0] = strings.TrimPrefix(args[0], sos.BucketPrefix)
+
+		if !strings.Contains(args[0], "/") {
+			args[0] += "/"
+		}
+	},
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var (
+			bucket string
+			prefix string
+		)
+
+		parts := strings.SplitN(args[0], "/", 2)
+		bucket = parts[0]
+		if len(parts) > 1 {
+			prefix = parts[1]
+
+			// Special case: the caller wants to target objects at the root of
+			// the bucket, in this case the prefix is empty so we set the key
+			// to a symbolic value that shall be removed later on.
+			if prefix == "" {
+				prefix = "/"
+			}
+		}
+
+		verbose, err := cmd.Flags().GetBool("verbose")
+		if err != nil {
+			return err
+		}
+
+		force, err := cmd.Flags().GetBool("force")
+		if err != nil {
+			return err
+		}
+
+		if !force {
+			if !utils.AskQuestion(exocmd.GContext, fmt.Sprintf("Are you sure you want to delete %s%s/%s?",
+				sos.BucketPrefix, bucket, prefix)) {
+				return nil
+			}
+		}
+
+		storage, err := sos.NewStorageClient(
+			exocmd.GContext,
+			sos.ClientOptZoneFromBucket(exocmd.GContext, bucket),
+		)
+		if err != nil {
+			return fmt.Errorf("unable to initialize storage client: %w", err)
+		}
+
+		deletedChan, errChan := storage.DeleteObjectVersions(exocmd.GContext, bucket, prefix)
+
+		for {
+			select {
+			case err, ok := <-errChan:
+				if ok {
+					fmt.Printf("Error happened: %v\n", err)
+				} else {
+					fmt.Println("Purge completed")
+					return nil
+				}
+			case deletedElt := <-deletedChan:
+				if verbose {
+					fmt.Println("deleted:", aws.ToString(deletedElt.Key))
+				}
+			}
+		}
+	},
+}
+
+func init() {
+	storagePurgeCmd.Flags().BoolP("force", "f", false, exocmd.CmdFlagForceHelp)
+	storagePurgeCmd.Flags().BoolP("verbose", "v", false, "output deleted objects")
+	storageCmd.AddCommand(storagePurgeCmd)
+}

--- a/pkg/storage/sos/object.go
+++ b/pkg/storage/sos/object.go
@@ -32,6 +32,68 @@ import (
 	"github.com/exoscale/cli/utils"
 )
 
+func (c *Client) DeleteObjectVersions(ctx context.Context, bucket, prefix string) (<-chan types.DeletedObject, <-chan error) {
+	deletedChan := make(chan types.DeletedObject)
+	errChan := make(chan error)
+
+	// The "/" value can be used at command-level to mean that we want to
+	// list from the root of the bucket, but the actual bucket root is an
+	// empty prefix.
+	if prefix == "/" {
+		prefix = ""
+	}
+
+	go func() {
+		defer close(deletedChan)
+		defer close(errChan)
+
+		batchSize := int32(1000)
+		for {
+			list, err := c.S3Client.ListObjectVersions(ctx, &s3.ListObjectVersionsInput{
+				Bucket:  &bucket,
+				MaxKeys: batchSize,
+			})
+			if err != nil {
+				errChan <- err
+				return
+			}
+			if len(list.Versions) == 0 && len(list.DeleteMarkers) == 0 {
+				return
+			}
+			objects := make([]types.ObjectIdentifier, 0, len(list.Versions))
+			for _, element := range list.Versions {
+				objects = append(objects, types.ObjectIdentifier{
+					Key:       element.Key,
+					VersionId: element.VersionId,
+				})
+			}
+			for _, element := range list.DeleteMarkers {
+				objects = append(objects, types.ObjectIdentifier{
+					Key:       element.Key,
+					VersionId: element.VersionId,
+				})
+			}
+
+			deleteResult, err := c.S3Client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+				Bucket: &bucket,
+				Delete: &types.Delete{Objects: objects},
+			})
+			if err != nil {
+				errChan <- err
+				return
+			}
+			for _, deleted := range deleteResult.Deleted {
+				deletedChan <- deleted
+			}
+			for _, derror := range deleteResult.Errors {
+				errChan <- fmt.Errorf("delete error: %v", derror)
+			}
+		}
+	}()
+
+	return deletedChan, errChan
+}
+
 func (c *Client) DeleteObjects(ctx context.Context, bucket, prefix string, recursive bool) ([]types.DeletedObject, error) {
 	deleteList := make([]types.ObjectIdentifier, 0)
 	err := c.ForEachObject(ctx, bucket, prefix, recursive, func(o *types.Object) error {


### PR DESCRIPTION


# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Adding `exo storage purge` which removes all objects, versions and delete markers, from a given bucket with an optional prefix. This simplifies the bucket deletion process (purge bucket, then delete) when versioning was enabled since most tools do not support it.

I did not reuse `c.ForEachObject` on purpose since it is reads the entire contents of the bucket before moving forward. Note that no parallelism was added in this version, but adding some would greatly improve the performance of purges.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

<!--
Describe the tests you did
-->
