### PR TITLE
Fix  for the Disk size for DBaaS

### DIFF
--- a/cmd/dbaas/dbaas_type_show.go
+++ b/cmd/dbaas/dbaas_type_show.go
@@ -178,7 +178,7 @@ func (c *dbaasTypeShowCmd) CmdRun(_ *cobra.Command, _ []string) error { //nolint
 				Nodes:      dt.Plans[i].NodeCount,
 				NodeCPUs:   dt.Plans[i].NodeCPUCount,
 				NodeMemory: dt.Plans[i].NodeMemory,
-				DiskSpace:  dt.Plans[i].NodeMemory,
+				DiskSpace:  dt.Plans[i].DiskSpace,
 				Authorized: utils.DefaultBool(dt.Plans[i].Authorized, false),
 			}
 		}


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

the command ***dbaas type show [db] --plans*** showed Disk Space and Memory with the same value.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

before:
```
┼──────────────────┼─────────┼────────┼─────────────┼────────────┼────────────┼
│       NAME       │ # NODES │ # CPUS │ NODE MEMORY │ DISK SPACE │ AUTHORIZED │
┼──────────────────┼─────────┼────────┼─────────────┼────────────┼────────────┼
│ startup-8        │ 1       │ 4      │ 8.6 GB      │ 8.6 GB     │ true       │
│ startup-64       │ 1       │ 12     │ 69 GB       │ 69 GB      │ false      │
│ startup-4        │ 1       │ 2      │ 4.3 GB      │ 4.3 GB     │ true       │
│ startup-32       │ 1       │ 8      │ 34 GB       │ 34 GB      │ true       │
│ startup-225      │ 1       │ 24     │ 242 GB      │ 242 GB     │ false      │
│ startup-16       │ 1       │ 4      │ 17 GB       │ 17 GB      │ true       │
│ startup-128      │ 1       │ 16     │ 137 GB      │ 137 GB     │ false      │
│ so-startup-64    │ 1       │ 12     │ 69 GB       │ 69 GB      │ false      │
│ so-startup-32    │ 1       │ 8      │ 34 GB       │ 34 GB      │ false      │
│ so-startup-225   │ 1       │ 24     │ 242 GB      │ 242 GB     │ false      │
│ so-startup-128   │ 1       │ 16     │ 137 GB      │ 137 GB     │ false      │
│ so-premium-64    │ 3       │ 12     │ 69 GB       │ 69 GB      │ false      │
│ so-premium-32    │ 3       │ 8      │ 34 GB       │ 34 GB      │ false      │
│ so-premium-225   │ 3       │ 24     │ 242 GB      │ 242 GB     │ false      │
│ so-premium-128   │ 3       │ 16     │ 137 GB      │ 137 GB     │ false      │
│ so-business-64   │ 2       │ 12     │ 69 GB       │ 69 GB      │ false      │
│ so-business-32   │ 2       │ 8      │ 34 GB       │ 34 GB      │ false      │
│ so-business-225  │ 2       │ 24     │ 242 GB      │ 242 GB     │ false      │
│ so-business-128  │ 2       │ 16     │ 137 GB      │ 137 GB     │ false      │
│ premium-8        │ 3       │ 4      │ 8.6 GB      │ 8.6 GB     │ true       │
│ premium-64       │ 3       │ 12     │ 69 GB       │ 69 GB      │ false      │
│ premium-4        │ 3       │ 2      │ 4.3 GB      │ 4.3 GB     │ true       │
│ premium-32       │ 3       │ 8      │ 34 GB       │ 34 GB      │ true       │
│ premium-225      │ 3       │ 24     │ 242 GB      │ 242 GB     │ false      │
│ premium-16       │ 3       │ 4      │ 17 GB       │ 17 GB      │ true       │
│ premium-128      │ 3       │ 16     │ 137 GB      │ 137 GB     │ false      │
│ hobbyist-2       │ 1       │ 2      │ 2.1 GB      │ 2.1 GB     │ true       │
│ cpu-startup-64   │ 1       │ 32     │ 69 GB       │ 69 GB      │ false      │
│ cpu-startup-32   │ 1       │ 16     │ 34 GB       │ 34 GB      │ false      │
│ cpu-startup-16   │ 1       │ 8      │ 17 GB       │ 17 GB      │ false      │
│ cpu-startup-128  │ 1       │ 40     │ 137 GB      │ 137 GB     │ false      │
│ cpu-premium-64   │ 3       │ 32     │ 69 GB       │ 69 GB      │ false      │
│ cpu-premium-32   │ 3       │ 16     │ 34 GB       │ 34 GB      │ false      │
│ cpu-premium-16   │ 3       │ 8      │ 17 GB       │ 17 GB      │ false      │
│ cpu-premium-128  │ 3       │ 40     │ 137 GB      │ 137 GB     │ false      │
│ cpu-business-64  │ 2       │ 32     │ 69 GB       │ 69 GB      │ false      │
│ cpu-business-32  │ 2       │ 16     │ 34 GB       │ 34 GB      │ false      │
│ cpu-business-16  │ 2       │ 8      │ 17 GB       │ 17 GB      │ false      │
│ cpu-business-128 │ 2       │ 40     │ 137 GB      │ 137 GB     │ false      │
│ business-8       │ 2       │ 4      │ 8.6 GB      │ 8.6 GB     │ true       │
│ business-64      │ 2       │ 12     │ 69 GB       │ 69 GB      │ false      │
│ business-4       │ 2       │ 2      │ 4.3 GB      │ 4.3 GB     │ true       │
│ business-32      │ 2       │ 8      │ 34 GB       │ 34 GB      │ true       │
│ business-225     │ 2       │ 24     │ 242 GB      │ 242 GB     │ false      │
│ business-16      │ 2       │ 4      │ 17 GB       │ 17 GB      │ true       │
│ business-128     │ 2       │ 16     │ 137 GB      │ 137 GB     │ false      │
┼──────────────────┼─────────┼────────┼─────────────┼────────────┼────────────┼
```

After:
```
┼──────────────────┼─────────┼────────┼─────────────┼────────────┼────────────┼
│       NAME       │ # NODES │ # CPUS │ NODE MEMORY │ DISK SPACE │ AUTHORIZED │
┼──────────────────┼─────────┼────────┼─────────────┼────────────┼────────────┼
│ startup-8        │ 1       │ 4      │ 8.6 GB      │ 188 GB     │ true       │
│ startup-64       │ 1       │ 12     │ 69 GB       │ 805 GB     │ false      │
│ startup-4        │ 1       │ 2      │ 4.3 GB      │ 86 GB      │ true       │
│ startup-32       │ 1       │ 8      │ 34 GB       │ 537 GB     │ true       │
│ startup-225      │ 1       │ 24     │ 242 GB      │ 1.4 TB     │ false      │
│ startup-16       │ 1       │ 4      │ 17 GB       │ 376 GB     │ true       │
│ startup-128      │ 1       │ 16     │ 137 GB      │ 1.1 TB     │ false      │
│ so-startup-64    │ 1       │ 12     │ 69 GB       │ 2.1 TB     │ false      │
│ so-startup-32    │ 1       │ 8      │ 34 GB       │ 1.0 TB     │ false      │
│ so-startup-225   │ 1       │ 24     │ 242 GB      │ 7.2 TB     │ false      │
│ so-startup-128   │ 1       │ 16     │ 137 GB      │ 4.1 TB     │ false      │
│ so-premium-64    │ 3       │ 12     │ 69 GB       │ 2.1 TB     │ false      │
│ so-premium-32    │ 3       │ 8      │ 34 GB       │ 1.0 TB     │ false      │
│ so-premium-225   │ 3       │ 24     │ 242 GB      │ 7.2 TB     │ false      │
│ so-premium-128   │ 3       │ 16     │ 137 GB      │ 4.1 TB     │ false      │
│ so-business-64   │ 2       │ 12     │ 69 GB       │ 2.1 TB     │ false      │
│ so-business-32   │ 2       │ 8      │ 34 GB       │ 1.0 TB     │ false      │
│ so-business-225  │ 2       │ 24     │ 242 GB      │ 7.2 TB     │ false      │
│ so-business-128  │ 2       │ 16     │ 137 GB      │ 4.1 TB     │ false      │
│ premium-8        │ 3       │ 4      │ 8.6 GB      │ 188 GB     │ true       │
│ premium-64       │ 3       │ 12     │ 69 GB       │ 805 GB     │ false      │
│ premium-4        │ 3       │ 2      │ 4.3 GB      │ 86 GB      │ true       │
│ premium-32       │ 3       │ 8      │ 34 GB       │ 537 GB     │ true       │
│ premium-225      │ 3       │ 24     │ 242 GB      │ 1.4 TB     │ false      │
│ premium-16       │ 3       │ 4      │ 17 GB       │ 376 GB     │ true       │
│ premium-128      │ 3       │ 16     │ 137 GB      │ 1.1 TB     │ false      │
│ hobbyist-2       │ 1       │ 2      │ 2.1 GB      │ 8.6 GB     │ true       │
│ cpu-startup-64   │ 1       │ 32     │ 69 GB       │ 913 GB     │ false      │
│ cpu-startup-32   │ 1       │ 16     │ 34 GB       │ 698 GB     │ false      │
│ cpu-startup-16   │ 1       │ 8      │ 17 GB       │ 483 GB     │ false      │
│ cpu-startup-128  │ 1       │ 40     │ 137 GB      │ 1.2 TB     │ false      │
│ cpu-premium-64   │ 3       │ 32     │ 69 GB       │ 913 GB     │ false      │
│ cpu-premium-32   │ 3       │ 16     │ 34 GB       │ 698 GB     │ false      │
│ cpu-premium-16   │ 3       │ 8      │ 17 GB       │ 483 GB     │ false      │
│ cpu-premium-128  │ 3       │ 40     │ 137 GB      │ 1.2 TB     │ false      │
│ cpu-business-64  │ 2       │ 32     │ 69 GB       │ 913 GB     │ false      │
│ cpu-business-32  │ 2       │ 16     │ 34 GB       │ 698 GB     │ false      │
│ cpu-business-16  │ 2       │ 8      │ 17 GB       │ 483 GB     │ false      │
│ cpu-business-128 │ 2       │ 40     │ 137 GB      │ 1.2 TB     │ false      │
│ business-8       │ 2       │ 4      │ 8.6 GB      │ 188 GB     │ true       │
│ business-64      │ 2       │ 12     │ 69 GB       │ 805 GB     │ false      │
│ business-4       │ 2       │ 2      │ 4.3 GB      │ 86 GB      │ true       │
│ business-32      │ 2       │ 8      │ 34 GB       │ 537 GB     │ true       │
│ business-225     │ 2       │ 24     │ 242 GB      │ 1.4 TB     │ false      │
│ business-16      │ 2       │ 4      │ 17 GB       │ 376 GB     │ true       │
│ business-128     │ 2       │ 16     │ 137 GB      │ 1.1 TB     │ false      │
┼──────────────────┼─────────┼────────┼─────────────┼────────────┼────────────┼
```
