### PR TITLE
fix config setup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- Fix a bug with setting config from scratch #767
+
 ## 1.88.0
 
 ### Features

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -220,15 +220,17 @@ func getAccountByName(name string) *account.Account {
 }
 
 func chooseZone(client *v3.Client, zones []string) (string, error) {
-	if len(zones) == 0 {
-		ctx := exocmd.GContext
+	if zones == nil {
 
+		ctx := exocmd.GContext
+		var err error
 		zonesResp, err := client.ListZones(ctx)
 		if err != nil {
 			return "", err
 		}
 
 		zones = make([]string, len(zonesResp.Zones))
+
 		for i, z := range zonesResp.Zones {
 			zones[i] = string(z.Name)
 		}
@@ -241,6 +243,7 @@ func chooseZone(client *v3.Client, zones []string) (string, error) {
 	prompt := promptui.Select{
 		Label: "Default zone",
 		Items: zones,
+		Size:  len(zones),
 	}
 
 	_, result, err := prompt.Run()

--- a/cmd/config/config_add.go
+++ b/cmd/config/config_add.go
@@ -126,20 +126,15 @@ func promptAccountInformation() (*account.Account, error) {
 	}
 	account.DefaultZone, err = chooseZone(client, nil)
 	if err != nil {
-		// Fallback: use the global client if it's available
-		if globalstate.EgoscaleV3Client != nil {
-			defaultZone, gErr := chooseZone(globalstate.EgoscaleV3Client, utils.AllZones)
-			if gErr != nil {
-				return nil, gErr
+		for {
+			defaultZone, err := chooseZone(globalstate.EgoscaleV3Client, utils.AllZones)
+			if err != nil {
+				return nil, err
 			}
 			if defaultZone != "" {
 				account.DefaultZone = defaultZone
-			} else {
-				return nil, fmt.Errorf("no zone selected")
+				break
 			}
-		} else {
-			// No global client to fall back to; return the original error
-			return nil, err
 		}
 	}
 


### PR DESCRIPTION
# Description
when there is no config at all and you try to add a config, it returns a runtime error: invalid memory address or nil pointer dereference

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa310e9]

goroutine 1 [running]:
github.com/exoscale/cli/cmd/config.promptAccountInformation()
    /cli/cmd/config/config_add.go:130 +0x849
github.com/exoscale/cli/cmd/config.addConfigAccount(0x0?)
    /cli/cmd/config/config_add.go:55 +0xab
github.com/exoscale/cli/cmd/config.configCmdRun(0x1739980, {0xf98a15?, 0x4?, 0xf98875?})
    /cli/cmd/config/config.go:75 +0x5ba
github.com/spf13/cobra.(*Command).execute(0x1739980, {0x176db20, 0x0, 0x0})
    /cli/vendor/github.com/spf13/cobra/command.go:856 +0x6aa
github.com/spf13/cobra.(*Command).ExecuteC(0x1735b00)
    /cli/vendor/github.com/spf13/cobra/command.go:974 +0x38d
github.com/spf13/cobra.(*Command).Execute(...)
    /cli/vendor/github.com/spf13/cobra/command.go:902
github.com/exoscale/cli/cmd.Execute({0xf97dd4?, 0x0?}, {0xf97dd7?, 0xc000002380?})
    /cli/cmd/root.go:81 +0x1d6
main.main()
    /cli/main.go:35 +0x3c
exit status 2
```

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

```
go run main.go config
No Exoscale CLI configuration found

In order to set up your configuration profile, you will need to retrieve
Exoscale API credentials from your organization's IAM:

    https://portal.exoscale.com/iam/keys

[+] API Key [none]: EXO
[+] Secret Key [none]: EydlkL
[+] Name [none]: test-config
Use the arrow keys to navigate: ↓ ↑ → ←
? Default zone:
  ▸ ch-gva-2
    ch-dk-2
    at-vie-1
    de-fra-1
    bg-sof-1
    de-muc-1
    at-vie-2
    hr-zag-1
    
 ===>>>
✔ ch-gva-2

====

go run main.go config
Use the arrow keys to navigate: ↓ ↑ → ←
? Configured accounts (* = default account):
  ▸ test-config*
    <Configure a new account>
    
===>>>
✔ test-config*
```

```
go run main.go compute security-group list
┼──────────────────────────────────────┼────────────────────┼────────────┼
│                  ID                  │        NAME        │ VISIBILITY │
┼──────────────────────────────────────┼────────────────────┼────────────┼
│ cd9f5925-4073-432c-9220-25e8436de58f │ default            │ private    │
│ a93f7361-26d7-4fad-98dc-d3890d528175 │ sks-security-group │ private    │
│ 6b745f48-5dd3-4148-8cbd-323cd99d2b86 │ ts                 │ private    │
│ 3fdec798-8858-401f-b62d-21d75a7e79f8 │ load-balancer-http │ private    │
│ fd0dd015-3c21-49b2-a035-087de4c0a35a │ iperf              │ private    │
│ b6ceec07-caa0-44d4-bd8b-30879becfc10 │ 443                │ private    │
│ 66e8a103-adf4-4573-8389-0cd0f79c9ca1 │ eighty             │ private    │
│ 38c0ab02-550a-4e97-986b-1189807c3bb6 │ 8444               │ private    │
│ 39d404f3-e0e8-4f48-a0f5-a174f80fe6e2 │ 8444_e             │ private    │
┼──────────────────────────────────────┼────────────────────┼────────────┼
```