### PR TITLE
feat: add a warning in case the object doesn't exists before generating the presign url

### DIFF
--- a/pkg/storage/sos/object.go
+++ b/pkg/storage/sos/object.go
@@ -167,7 +167,7 @@ func (c *Client) GenPresignedURL(ctx context.Context, method, bucket, key string
 			var apiErr smithy.APIError
 			if errors.As(err, &apiErr) {
 				if apiErr.ErrorCode() == "NotFound" {
-					fmt.Printf("⚠️ The object %s/%s does not exist. The Presigned URL will return 404 ⚠️\n\n", bucket, key)
+					fmt.Fprintf(os.Stderr, "The object %s/%s does not exist. The Presigned URL will return 404\n\n", bucket, key)
 				}
 			}
 		}


### PR DESCRIPTION
# Description
It happened sometimes that when I want to generate a presigned url, I make a typo in the object name / path.

And it is only when I sent the link to someone or when I want to download the object, that I notice that the URL returns 404. 
I would prefer to notice it when I generate the URL. 

This MR adds a warning message when the object doesn't exists. For the moment, only a warning, I could return the error and no presigned url at all if you prefer. 

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

<!--
Describe the tests you did
-->
