### PR TITLE
feat(sks): add IPv6 support in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - chores: add git version/commit in user agent header #769
 - Prompting for validation before deleting deployments and models (dedicated-inference)
 - Ability to delete multiple deployments and models at once (dedicated-inference)
+- Add IPv6 public IP assignment support for SKS Nodepools #774
 
 ## 1.88.0
 

--- a/cmd/compute/sks/sks_create.go
+++ b/cmd/compute/sks/sks_create.go
@@ -58,6 +58,7 @@ type sksCreateCmd struct {
 	NodepoolSecurityGroups       []string          `cli-flag:"nodepool-security-group" cli-usage:"default Nodepool Security Group NAME|ID (can be specified multiple times)"`
 	NodepoolSize                 int64             `cli-usage:"default Nodepool size. If 0, no default Nodepool will be added to the cluster."`
 	NodepoolTaints               []string          `cli-flag:"nodepool-taint" cli-usage:"Kubernetes taint to apply to default Nodepool Nodes (format: KEY=VALUE:EFFECT, can be specified multiple times)"`
+	NodepoolIPv6                 bool              `cli-flag:"nodepool-ipv6" cli-usage:"assign IPv6 Public IPs to default Nodepool Nodes"`
 	OIDCClientID                 string            `cli-flag:"oidc-client-id" cli-usage:"OpenID client ID"`
 	OIDCGroupsClaim              string            `cli-flag:"oidc-groups-claim" cli-usage:"OpenID JWT claim to use as the user's group"`
 	OIDCGroupsPrefix             string            `cli-flag:"oidc-groups-prefix" cli-usage:"OpenID prefix prepended to group claims"`
@@ -224,29 +225,32 @@ func (c *sksCreateCmd) CmdRun(cmd *cobra.Command, _ []string) error { //nolint:g
 			nodepoolName = c.NodepoolName
 		}
 
-		nodepoolReq, err := createNodepoolRequest(
-			ctx,
-			client,
-			CreateNodepoolOpts{
-				Name:               nodepoolName,
-				Description:        c.NodepoolDescription,
-				DiskSize:           c.NodepoolDiskSize,
-				InstancePrefix:     c.NodepoolInstancePrefix,
-				Size:               c.NodepoolSize,
-				InstanceType:       c.NodepoolInstanceType,
-				Labels:             c.NodepoolLabels,
-				AntiAffinityGroups: c.NodepoolAntiAffinityGroups,
-				DeployTarget:       c.NodepoolDeployTarget,
-				PrivateNetworks:    c.NodepoolPrivateNetworks,
-				SecurityGroups:     c.NodepoolSecurityGroups,
-				Taints:             c.NodepoolTaints,
-				KubeletImageGC: &v3.KubeletImageGC{
-					MinAge:        c.NodepoolImageGcMinAge,
-					LowThreshold:  c.NodepoolImageGcLowThreshold,
-					HighThreshold: c.NodepoolImageGcHighThreshold,
-				},
+		opts := CreateNodepoolOpts{
+			Name:               nodepoolName,
+			Description:        c.NodepoolDescription,
+			DiskSize:           c.NodepoolDiskSize,
+			InstancePrefix:     c.NodepoolInstancePrefix,
+			Size:               c.NodepoolSize,
+			InstanceType:       c.NodepoolInstanceType,
+			Labels:             c.NodepoolLabels,
+			AntiAffinityGroups: c.NodepoolAntiAffinityGroups,
+			DeployTarget:       c.NodepoolDeployTarget,
+			PrivateNetworks:    c.NodepoolPrivateNetworks,
+			SecurityGroups:     c.NodepoolSecurityGroups,
+			Taints:             c.NodepoolTaints,
+			KubeletImageGC: &v3.KubeletImageGC{
+				MinAge:        c.NodepoolImageGcMinAge,
+				LowThreshold:  c.NodepoolImageGcLowThreshold,
+				HighThreshold: c.NodepoolImageGcHighThreshold,
 			},
-		)
+		}
+
+		if c.NodepoolIPv6 {
+			v := v3.PublicIPAssignmentDual
+			opts.PublicIPAssignment = &v
+		}
+
+		nodepoolReq, err := createNodepoolRequest(ctx, client, opts)
 		if err != nil {
 			return err
 		}

--- a/cmd/compute/sks/sks_nodepool.go
+++ b/cmd/compute/sks/sks_nodepool.go
@@ -60,6 +60,7 @@ type CreateNodepoolOpts struct {
 	SecurityGroups     []string
 	Taints             []string
 	KubeletImageGC     *v3.KubeletImageGC
+	PublicIPAssignment *v3.PublicIPAssignment
 }
 
 func createNodepoolRequest(
@@ -76,6 +77,10 @@ func createNodepoolRequest(
 		Size:           opts.Size,
 		Labels:         opts.Labels,
 		KubeletImageGC: opts.KubeletImageGC,
+	}
+
+	if opts.PublicIPAssignment != nil {
+		nodepoolReq.PublicIPAssignment = v3.CreateSKSNodepoolRequestPublicIPAssignment(*opts.PublicIPAssignment)
 	}
 
 	aaGroups, err := lookupAntiAffinityGroups(ctx, client, opts.AntiAffinityGroups)

--- a/cmd/compute/sks/sks_nodepool_show.go
+++ b/cmd/compute/sks/sks_nodepool_show.go
@@ -24,6 +24,7 @@ type sksNodepoolShowOutput struct {
 	InstanceType         string            `json:"instance_type"`
 	Template             string            `json:"template"`
 	DiskSize             int64             `json:"disk_size"`
+	IPv6                 bool              `json:"ipv6_enabled" outputLabel:"IPv6"`
 	AntiAffinityGroups   []string          `json:"anti_affinity_groups"`
 	SecurityGroups       []string          `json:"security_groups"`
 	PrivateNetworks      []string          `json:"private_networks"`
@@ -99,6 +100,11 @@ func (c *sksNodepoolShowCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		return errors.New("nodepool not found")
 	}
 
+	ipv6Enabled := false
+	if nodepool.PublicIPAssignment == v3.SKSNodepoolPublicIPAssignmentDual {
+		ipv6Enabled = true
+	}
+
 	out := sksNodepoolShowOutput{
 		AddOns: func() (v []string) {
 			if nodepool.Addons != nil {
@@ -124,6 +130,7 @@ func (c *sksNodepoolShowCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		PrivateNetworks: make([]string, 0),
 		Size:            nodepool.Size,
 		State:           string(nodepool.State),
+		IPv6:            ipv6Enabled,
 		Taints: func() (v []string) {
 			if nodepool.Taints != nil {
 				v = make([]string, 0)

--- a/cmd/compute/sks/sks_nodepool_update.go
+++ b/cmd/compute/sks/sks_nodepool_update.go
@@ -34,6 +34,7 @@ type sksNodepoolUpdateCmd struct {
 	SecurityGroups     []string    `cli-flag:"security-group" cli-usage:"Nodepool Security Group NAME|ID (can be specified multiple times)"`
 	Taints             []string    `cli-flag:"taint" cli-usage:"Kubernetes taint to apply to Nodepool Nodes (format: KEY=VALUE:EFFECT, can be specified multiple times)"`
 	Zone               v3.ZoneName `cli-short:"z" cli-usage:"SKS cluster zone"`
+	IPv6               bool        `cli-flag:"ipv6" cli-usage:"Enable public IPv6 assignment to Nodepool nodes"`
 }
 
 func (c *sksNodepoolUpdateCmd) CmdAliases() []string { return nil }
@@ -188,6 +189,15 @@ func (c *sksNodepoolUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error { //
 			(updateReq.Taints)[key] = *taint
 		}
 
+		updated = true
+	}
+
+	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.IPv6)) {
+		if c.IPv6 {
+			updateReq.PublicIPAssignment = v3.UpdateSKSNodepoolRequestPublicIPAssignmentDual
+		} else {
+			updateReq.PublicIPAssignment = v3.UpdateSKSNodepoolRequestPublicIPAssignmentInet4
+		}
 		updated = true
 	}
 


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

<!--
Describe the tests you did
-->

```
❯ ./bin/exo compute sks nodepool get pouf paf
┼─────────────────────────┼──────────────────────────────────────┼
│      SKS NODEPOOL       │                                      │
┼─────────────────────────┼──────────────────────────────────────┼
│ ID                      │ 1c880dab-7fae-45d9-9919-1444f579d8b7 │
│ Name                    │ paf                                  │
│ Description             │                                      │
│ Creation Date           │ 2025-12-22 16:47:16 +0000 UTC        │
│ Instance Pool ID        │ a8bcba5e-e705-4707-bb3f-5245fac03dae │
│ Instance Prefix         │ pool                                 │
│ Instance Type           │ standard.small                       │
│ Template                │ sks-node-1.35.0-standard             │
│ Disk Size               │ 50                                   │
│ IPv6                    │ false                                │
...
❯ ./bin/exo compute sks nodepool update pouf paf --ipv6=true                                          
 ✔ Updating Nodepool "paf"... 12s
┼─────────────────────────┼──────────────────────────────────────┼
│      SKS NODEPOOL       │                                      │
┼─────────────────────────┼──────────────────────────────────────┼
│ ID                      │ 1c880dab-7fae-45d9-9919-1444f579d8b7 │
│ Name                    │ paf                                  │
│ Description             │                                      │
│ Creation Date           │ 2025-12-22 16:47:16 +0000 UTC        │
│ Instance Pool ID        │ a8bcba5e-e705-4707-bb3f-5245fac03dae │
│ Instance Prefix         │ pool                                 │
│ Instance Type           │ standard.small                       │
│ Template                │ sks-node-1.35.0-standard             │
│ Disk Size               │ 50                                   │
│ IPv6                    │ true                                 │
```

Recyling an instance then:

<img width="1837" height="655" alt="image" src="https://github.com/user-attachments/assets/d8212e51-6b92-41a9-99e5-c888847c679a" />
