### PR TITLE
fix(nlb): surface API error on load-balancer update instead of "operation is nil"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bug fixes
 
+- fix(nlb): API error swallowed on load-balancer update (e.g. duplicate name conflict reported as "operation is nil") #806
 - fix(config): panic when used without a default account set #798
 
 ### Documentation

--- a/cmd/compute/load_balancer/nlb_update.go
+++ b/cmd/compute/load_balancer/nlb_update.go
@@ -82,6 +82,9 @@ func (c *nlbUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error {
 	if updated {
 
 		op, err := client.UpdateLoadBalancer(ctx, n.ID, nlbRequest)
+		if err != nil {
+			return err
+		}
 
 		utils.DecorateAsyncOperation(
 			fmt.Sprintf("Updating Network Load Balancer %q...", c.NetworkLoadBalancer),

--- a/tests/e2e/scenarios/with-api/compute/nlb_update.txtar
+++ b/tests/e2e/scenarios/with-api/compute/nlb_update.txtar
@@ -1,0 +1,34 @@
+# Test: exo compute load-balancer update handles API errors and succeeds on valid updates
+# Full lifecycle: create two NLBs, update name and description, test conflict error, delete both.
+# TEST_ZONE and TEST_RUN_ID are injected by the API test runner.
+
+# Setup: create the primary NLB
+exec exo --output-format json compute load-balancer create ${TEST_RUN_ID}-nlb-a --zone ${TEST_ZONE}
+stdout ${TEST_RUN_ID}-nlb-a
+
+# Setup: create a second NLB whose name will be used for the conflict test
+exec exo --output-format json compute load-balancer create ${TEST_RUN_ID}-nlb-b --zone ${TEST_ZONE}
+stdout ${TEST_RUN_ID}-nlb-b
+
+# Update description and verify it is reflected in show output
+exec exo --output-format json compute load-balancer update ${TEST_RUN_ID}-nlb-a --description 'hello e2e' --zone ${TEST_ZONE}
+
+exec exo --output-format json compute load-balancer show ${TEST_RUN_ID}-nlb-a --zone ${TEST_ZONE}
+stdout 'hello e2e'
+
+# Update name and verify the NLB is reachable under the new name
+exec exo --output-format json compute load-balancer update ${TEST_RUN_ID}-nlb-a --name ${TEST_RUN_ID}-nlb-a-renamed --zone ${TEST_ZONE}
+
+exec exo --output-format json compute load-balancer show ${TEST_RUN_ID}-nlb-a-renamed --zone ${TEST_ZONE}
+stdout ${TEST_RUN_ID}-nlb-a-renamed
+
+# Rename back so teardown can reference it by the original name
+exec exo --output-format json compute load-balancer update ${TEST_RUN_ID}-nlb-a-renamed --name ${TEST_RUN_ID}-nlb-a --zone ${TEST_ZONE}
+
+# Conflict: renaming to an already-existing name must surface the API error, not "operation is nil"
+! exec exo --output-format json compute load-balancer update ${TEST_RUN_ID}-nlb-a --name ${TEST_RUN_ID}-nlb-b --zone ${TEST_ZONE}
+stderr 'already exists'
+
+# Teardown: delete both NLBs
+exec exo compute load-balancer delete --force ${TEST_RUN_ID}-nlb-a --zone ${TEST_ZONE}
+exec exo compute load-balancer delete --force ${TEST_RUN_ID}-nlb-b --zone ${TEST_ZONE}


### PR DESCRIPTION
# Description

When `exo compute load-balancer update` is called with parameters that the API rejects (for example renaming an NLB to a name that already exists), the command printed a success spinner and then crashed with an opaque error:

```
 + Updating Network Load Balancer "new-name"... 0s
error: operation is nil
```

The root cause was a missing error check after `client.UpdateLoadBalancer`. The call returns `(nil, error)` on failure, but the code passed the nil operation directly into the `DecorateAsyncOperation` closure where `client.Wait` panicked. The real API message (for example `Load balancer with name new-name already exists, the name must be unique`) was never shown to the user.

The fix matches the pattern already used by `nlb_service_update.go` and `nlb_create.go`: check the error from the API call before handing the operation to the wait helper.

Changes:

* Added missing `if err != nil { return err }` guard after `client.UpdateLoadBalancer` in `cmd/compute/load_balancer/nlb_update.go`.
* Added `tests/e2e/scenarios/with-api/compute/nlb_update.txtar`, an API-driven testscript scenario that covers description update, name rename, and the duplicate-name conflict path. Depends on the testscript runner introduced in #804.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block, and add the Pull Request #number for each bit you add to the `CHANGELOG.md`)
* [x] Testing

## Testing

Covered by the e2e scenario (requires API credentials, runs under `-tags=api`).