### PR TITLE
feat(compute): add `--reverse-dns` flag to create command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - sks: add `rotate-karpenter-credentials` command #797
 - sks: add `active-nodepool-templates` command #797
 - new command `exo ai deployment instance-type` that allows showing what GPU is usable in which zone #809
+- instance create: add support for setting a reverse dns with the `--reverse-dns` flag
 
 ### Bug fixes
 
@@ -30,6 +31,7 @@
 - test(testscript): add validation handling in PTY-based interactive flows #801
 - test(testscript): add API testscript runner with per-scenario resource lifecycle #804
 - test(testscript): make PTY inputs deterministic via event-driven @wait: synchronisation #804
+- test(testscript): add create reverse-DNS coverage for compute instances
 
 ## 1.93.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - sks: add `rotate-karpenter-credentials` command #797
 - sks: add `active-nodepool-templates` command #797
 - new command `exo ai deployment instance-type` that allows showing what GPU is usable in which zone #809
-- instance create: add support for setting a reverse dns with the `--reverse-dns` flag
+- instance create: add support for setting a reverse dns with the `--reverse-dns` flag #816
 
 ### Bug fixes
 

--- a/cmd/compute/instance/instance_create.go
+++ b/cmd/compute/instance/instance_create.go
@@ -44,6 +44,7 @@ type instanceCreateCmd struct {
 	Labels                map[string]string `cli-flag:"label" cli-usage:"instance label (format: key=value)"`
 	PrivateNetworks       []string          `cli-flag:"private-network" cli-usage:"instance Private Network NAME|ID (can be specified multiple times)"`
 	PublicIPAssignment    string            `cli-flag:"public-ip" cli-usage:"Configures public IP assignment of the Instances (none|inet4|dual). (default: inet4)"`
+	ReverseDNS            string            `cli-usage:"Reverse DNS Domain"`
 	SSHKeys               []string          `cli-flag:"ssh-key" cli-usage:"SSH key to deploy on the instance (can be specified multiple times)"`
 	Protection            bool              `cli-flag:"protection" cli-usage:"enable delete protection"`
 	SecurityGroups        []string          `cli-flag:"security-group" cli-usage:"instance Security Group NAME|ID (can be specified multiple times)"`
@@ -252,6 +253,8 @@ func (c *instanceCreateCmd) CmdRun(cmd *cobra.Command, _ []string) error { //nol
 		instanceReq.ApplicationConsistentSnapshotEnabled = &c.AppConsistentSnapshot
 	}
 
+	updateRDNS := cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.ReverseDNS))
+
 	var instanceID v3.UUID
 	utils.DecorateAsyncOperation(fmt.Sprintf("Creating instance %q...", c.Name), func() {
 		var op *v3.Operation
@@ -276,6 +279,17 @@ func (c *instanceCreateCmd) CmdRun(cmd *cobra.Command, _ []string) error { //nol
 				return
 			}
 			_, err = client.Wait(ctx, op)
+			if err != nil {
+				return
+			}
+		}
+
+		if updateRDNS {
+			op, err = client.UpdateReverseDNSInstance(ctx, instanceID, v3.UpdateReverseDNSInstanceRequest{DomainName: c.ReverseDNS})
+			if err != nil {
+				return
+			}
+			_, err = client.Wait(ctx, op, v3.OperationStateSuccess)
 			if err != nil {
 				return
 			}

--- a/tests/e2e/scenarios/with-api/compute/instance_create_reverse_dns.txtar
+++ b/tests/e2e/scenarios/with-api/compute/instance_create_reverse_dns.txtar
@@ -1,0 +1,14 @@
+# Test: exo compute instance create supports --reverse-dns
+# Full lifecycle: create a dedicated instance with reverse DNS, verify it, then delete it.
+# TEST_ZONE and TEST_RUN_ID are injected by the API test runner.
+
+exec exo --zone $TEST_ZONE --output-format json compute instance create cli-e2e-rdns-$TEST_RUN_ID --instance-type standard.tiny --template 'Linux Ubuntu 22.04 LTS 64-bit' --disk-size 10 --reverse-dns rdns-$TEST_RUN_ID.example.org
+
+json-setenv INSTANCE_ID id stdout
+
+wait-instance-state $TEST_ZONE $INSTANCE_ID running 300
+
+exec exo --zone $TEST_ZONE --output-format json compute instance show $INSTANCE_ID
+stdout '"reverse_dns":"rdns-[a-z0-9-]+\.example\.org\."'
+
+exec exo --zone $TEST_ZONE compute instance delete --force $INSTANCE_ID

--- a/tests/e2e/scenarios/without-api/compute_instance_create_flags.txtar
+++ b/tests/e2e/scenarios/without-api/compute_instance_create_flags.txtar
@@ -1,0 +1,6 @@
+# Test: compute instance create --help shows the reverse DNS flag
+
+exec exo compute instance create --help
+stdout '--reverse-dns'
+stdout '--instance-type'
+stdout '--template'


### PR DESCRIPTION
> [!NOTE]
>  **Disclosure**: 
> - AI assistance was used to implement this feature
> - Manual review and testing was done

# Description

Closes #564

This PR adds a `--reverse-dns` flag to the `compute instance create` command.

The implementation follows the same approach already used by `compute instance update`: after the instance is created and the operation completes successfully, the CLI applies reverse DNS through the dedicated reverse-DNS API endpoint before returning the final instance output.

Test coverage was added for both the CLI surface and the API-backed lifecycle:
- a without-API testscript scenario checks that `compute instance create --help` exposes `--reverse-dns`
- a with-API testscript scenario creates an instance with reverse DNS, verifies it via `compute instance show`, then deletes it
One API detail worth noting is that the returned reverse DNS value includes a trailing dot, so the API test matches that behavior.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block, and add the Pull Request #number for each bit you add to the `CHANGELOG.md`)
* [x] Testing

## Testing

- `go build -mod=vendor -o bin/exo .`
- `go test ./cmd/...`
- `go test -C tests/e2e -run 'TestScriptsLocal/compute_instance_create_flags' -v`
- `go test -C tests/e2e -tags=api -run 'TestScriptsAPI/instance_create_reverse_dns' -v`

