### PR TITLE
fix: print API error message instead of operation nil

### DIFF
--- a/cmd/compute/sks/sks_nodepool_update.go
+++ b/cmd/compute/sks/sks_nodepool_update.go
@@ -203,6 +203,9 @@ func (c *sksNodepoolUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error { //
 
 	if updated {
 		op, err := client.UpdateSKSNodepool(ctx, cluster.ID, nodepool.ID, updateReq)
+		if err != nil {
+			return err
+		}
 		utils.DecorateAsyncOperation(fmt.Sprintf("Updating Nodepool %q...", c.Nodepool), func() {
 			_, err = client.Wait(ctx, op, v3.OperationStateSuccess)
 		})


### PR DESCRIPTION
# Description
Exactly like in https://github.com/exoscale/cli/pull/806, it returns `operation is nil` when update a SKSNodePool when it is called with parameters that the API rejects.

`exo compute sks nodepool update itops-test itops-test-workers --label managed_uptime=standard --label dont_manage_until=2026-05-06 --label test=test/test`

<img width="1853" height="92" alt="image" src="https://github.com/user-attachments/assets/886a404f-1f67-4be0-8ec5-feec56148dac" />

At the opposite of https://github.com/exoscale/cli/pull/806, I didn't add a e2e test because I encountered the issue while trying to add a `/` in a label of a SKS Nodepool but at the end I would like that it works (I made a support ticket for this), so if I make a E2E test for it now, it might not pass anymore once `/` are accepted on the API Side.


## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block, and add the Pull Request #number for each bit you add to the `CHANGELOG.md`)
* [ ] Testing

## Testing

<img width="1882" height="63" alt="image" src="https://github.com/user-attachments/assets/23505c22-5b55-4ae3-b1bf-9d994972d06d" />

Now returns the BAD Request response from the API.


