### PR TITLE
fix: prevent traversal path during sos download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - fix(nlb): API error swallowed on load-balancer update (e.g. duplicate name conflict reported as "operation is nil") #806
 - fix(config): panic when used without a default account set #798
 - Fix bad flag ref in `dns add NS` #812
+- fix: prevent traversal path during sos download #823
 
 ### Documentation
 

--- a/cmd/storage/storage_download.go
+++ b/cmd/storage/storage_download.go
@@ -95,7 +95,12 @@ Examples:
 
 		objects := make([]*s3types.Object, 0)
 		if err := storage.ForEachObject(exocmd.GContext, bucket, prefix, recursive, func(o *s3types.Object) error {
-			objects = append(objects, o)
+
+			if o.Key != nil && !sos.IsTraversalPath(*o.Key) {
+				objects = append(objects, o)
+			} else if o.Key != nil {
+				fmt.Printf("warning: Skipping file %s. File references a parent directory\n", *o.Key)
+			}
 			return nil
 		}); err != nil {
 			return fmt.Errorf("error listing objects: %s", err)

--- a/pkg/storage/sos/object.go
+++ b/pkg/storage/sos/object.go
@@ -806,3 +806,18 @@ func (o *ShowObjectOutput) ToTable() {
 		return buf.String()
 	}()})
 }
+
+func IsTraversalPath(key string) bool {
+	path := strings.Split(key, "/")
+
+	traversal := -1
+	for _, elem := range path {
+		if elem == ".." {
+			traversal -= 1
+		} else {
+			traversal += 1
+		}
+	}
+
+	return traversal < 0
+}

--- a/pkg/storage/sos/object.go
+++ b/pkg/storage/sos/object.go
@@ -808,16 +808,6 @@ func (o *ShowObjectOutput) ToTable() {
 }
 
 func IsTraversalPath(key string) bool {
-	path := strings.Split(key, "/")
-
-	traversal := -1
-	for _, elem := range path {
-		if elem == ".." {
-			traversal -= 1
-		} else {
-			traversal += 1
-		}
-	}
-
-	return traversal < 0
+	cleaned := path.Clean(key)
+	return strings.HasPrefix(cleaned, "..")
 }

--- a/pkg/storage/sos/object_test.go
+++ b/pkg/storage/sos/object_test.go
@@ -600,6 +600,10 @@ func Test_IsTraversalPath(t *testing.T) {
 			path:   "a/b/../../test.txt",
 			expect: false,
 		},
+		{
+			path:   "../a/b/test.txt",
+			expect: true,
+		},
 	}
 
 	for _, ut := range tests {

--- a/pkg/storage/sos/object_test.go
+++ b/pkg/storage/sos/object_test.go
@@ -578,3 +578,33 @@ func TestUploadFiles(t *testing.T) {
 		})
 	}
 }
+
+func Test_IsTraversalPath(t *testing.T) {
+	tests := []struct {
+		path   string
+		expect bool
+	}{
+		{
+			path:   "test.txt",
+			expect: false,
+		},
+		{
+			path:   "../test.txt",
+			expect: true,
+		},
+		{
+			path:   "a/b/../../../test.text",
+			expect: true,
+		},
+		{
+			path:   "a/b/../../test.txt",
+			expect: false,
+		},
+	}
+
+	for _, ut := range tests {
+		t.Run(ut.path, func(t *testing.T) {
+			assert.Equal(t, ut.expect, sos.IsTraversalPath(ut.path))
+		})
+	}
+}


### PR DESCRIPTION
# Description
Prevent path traversal issue during sos download.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block, and add the Pull Request #number for each bit you add to the `CHANGELOG.md`)
* [x] Testing

## Testing
```Bash
$> exo storage upload a.txt sos://my-bucket-123456/../a.txt
$> exo storage upload b.txt sos://my-bucket-123456/b.txt
$> mkdir /tmp/test
$> go run main.go storage download -r sos://my-bucket-123456 /tmp/test/ 
warning: Skipping file ../a.txt. File references a parent directory
b.txt     [==============================================================================] 3.13 KiB / 3.13 KiB | 0s
```
