### PR TITLE
Improve zone failure handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 ## Unreleased
 
 ### Features
+
 ### Improvements
+
+- Made cli more resilient to zone failures, and streams output while waiting for slow zones to responds #826
+
 ### Bug fixes
 
 ## 1.94.2

--- a/cmd/aiservices/deployment/deployment_list.go
+++ b/cmd/aiservices/deployment/deployment_list.go
@@ -16,14 +16,14 @@ import (
 )
 
 type DeploymentListItemOutput struct {
-	ID        v3.UUID                              `json:"id"`
-	Name      string                               `json:"name"`
-	Zone      v3.ZoneName                          `json:"zone"`
-	State     v3.ListDeploymentsResponseEntryState `json:"state" outputLabel:"Status"`
-	GPUType   string                               `json:"gpu_type"`
-	GPUCount  int64                                `json:"gpu_count"`
-	Replicas  int64                                `json:"replicas"`
-	ModelName string                               `json:"model_name"`
+	ID        v3.UUID                              `json:"id" outputWidth:"36"`
+	Name      string                               `json:"name" outputWidth:"38"`
+	Zone      v3.ZoneName                          `json:"zone" outputWidth:"8"`
+	State     v3.ListDeploymentsResponseEntryState `json:"state" outputLabel:"Status" outputWidth:"6"`
+	GPUType   string                               `json:"gpu_type" outputWidth:"9"`
+	GPUCount  int64                                `json:"gpu_count" outputWidth:"9"`
+	Replicas  int64                                `json:"replicas" outputWidth:"8"`
+	ModelName string                               `json:"model_name" outputWidth:"38"`
 }
 
 type DeploymentListOutput []DeploymentListItemOutput

--- a/cmd/aiservices/deployment/deployment_list.go
+++ b/cmd/aiservices/deployment/deployment_list.go
@@ -3,6 +3,7 @@ package deployment
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -51,14 +52,11 @@ func (c *DeploymentListCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
 	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
-// listDeploymentsRunner is overridden in tests to redirect output.
-var listDeploymentsRunner = runDeploymentList
-
 func (c *DeploymentListCmd) CmdRun(_ *cobra.Command, _ []string) error {
-	return listDeploymentsRunner(c, os.Stdout, os.Stderr)
+	return runDeploymentList(c, os.Stdout, os.Stderr)
 }
 
-func runDeploymentList(c *DeploymentListCmd, stdout, stderr *os.File) error {
+func runDeploymentList(c *DeploymentListCmd, stdout, stderr io.Writer) error {
 	ctx := exocmd.GContext
 	client := globalstate.EgoscaleV3Client
 

--- a/cmd/aiservices/deployment/deployment_list.go
+++ b/cmd/aiservices/deployment/deployment_list.go
@@ -73,7 +73,7 @@ func runDeploymentList(c *DeploymentListCmd, stdout, stderr io.Writer) error {
 	streamer := output.NewStreamer(DeploymentListItemOutput{}, stdout)
 	defer func() { _ = streamer.Close() }()
 
-	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink,
+	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
 		func(ctx context.Context, zone v3.Zone) error {
 			zc := client.WithEndpoint(zone.APIEndpoint)
 			resp, err := zc.ListDeployments(ctx)

--- a/cmd/aiservices/deployment/deployment_list.go
+++ b/cmd/aiservices/deployment/deployment_list.go
@@ -1,7 +1,9 @@
 package deployment
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	exocmd "github.com/exoscale/cli/cmd"
@@ -43,12 +45,20 @@ func (c *DeploymentListCmd) CmdLong() string {
 	return fmt.Sprintf(`This command lists AI deployments.
 
 Supported output template annotations: %s`,
-		strings.Join(output.TemplateAnnotations(&DeploymentListOutput{}), ", "))
+		strings.Join(output.TemplateAnnotations(&DeploymentListItemOutput{}), ", "))
 }
 func (c *DeploymentListCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
 	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
+
+// listDeploymentsRunner is overridden in tests to redirect output.
+var listDeploymentsRunner = runDeploymentList
+
 func (c *DeploymentListCmd) CmdRun(_ *cobra.Command, _ []string) error {
+	return listDeploymentsRunner(c, os.Stdout, os.Stderr)
+}
+
+func runDeploymentList(c *DeploymentListCmd, stdout, stderr *os.File) error {
 	ctx := exocmd.GContext
 	client := globalstate.EgoscaleV3Client
 
@@ -57,35 +67,46 @@ func (c *DeploymentListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	out := make(DeploymentListOutput, 0)
-	err = utils.ForEveryZone(zones, func(zone v3.Zone) error {
-		c := client.WithEndpoint(zone.APIEndpoint)
-		resp, err := c.ListDeployments(ctx)
-		if err != nil {
-			return err
-		}
+	sink := utils.NewWarningSinkTo(stderr)
+	stopSig := sink.InstallSignalFlush(ctx)
+	defer stopSig()
+	defer sink.Flush()
 
-		for _, d := range resp.Deployments {
-			var modelName string
-			if d.Model != nil {
-				modelName = d.Model.Name
+	streamer := output.NewStreamer(DeploymentListItemOutput{}, stdout)
+	defer func() { _ = streamer.Close() }()
+
+	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink,
+		func(ctx context.Context, zone v3.Zone) error {
+			zc := client.WithEndpoint(zone.APIEndpoint)
+			resp, err := zc.ListDeployments(ctx)
+			if err != nil {
+				return err
 			}
-			out = append(out, DeploymentListItemOutput{
-				ID:        d.ID,
-				Name:      d.Name,
-				Zone:      zone.Name,
-				State:     d.State,
-				GPUType:   d.GpuType,
-				GPUCount:  d.GpuCount,
-				Replicas:  d.Replicas,
-				ModelName: modelName,
-			})
-		}
+			for _, d := range resp.Deployments {
+				var modelName string
+				if d.Model != nil {
+					modelName = d.Model.Name
+				}
+				if err := streamer.Push(DeploymentListItemOutput{
+					ID:        d.ID,
+					Name:      d.Name,
+					Zone:      zone.Name,
+					State:     d.State,
+					GPUType:   d.GpuType,
+					GPUCount:  d.GpuCount,
+					Replicas:  d.Replicas,
+					ModelName: modelName,
+				}); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
 
-		return nil
-	})
-
-	return c.OutputFunc(&out, err)
+	if failed > 0 {
+		return fmt.Errorf("%d zone(s) failed", failed)
+	}
+	return nil
 }
 
 func init() {

--- a/cmd/aiservices/deployment/deployment_list.go
+++ b/cmd/aiservices/deployment/deployment_list.go
@@ -66,8 +66,6 @@ func runDeploymentList(c *DeploymentListCmd, stdout, stderr io.Writer) error {
 	}
 
 	sink := utils.NewWarningSinkTo(stderr)
-	stopSig := sink.InstallSignalFlush(ctx)
-	defer stopSig()
 	defer sink.Flush()
 
 	streamer := output.NewStreamer(DeploymentListItemOutput{}, stdout)

--- a/cmd/aiservices/deployment/deployment_list_test.go
+++ b/cmd/aiservices/deployment/deployment_list_test.go
@@ -1,57 +1,107 @@
 package deployment
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
-	"github.com/exoscale/cli/pkg/output"
 	v3 "github.com/exoscale/egoscale/v3"
 	"github.com/exoscale/egoscale/v3/credentials"
 )
 
-type depListServer struct {
+// zoneBehavior describes how a fake per-zone backend should respond.
+type zoneBehavior int
+
+const (
+	zoneHealthy zoneBehavior = iota
+	zoneTimeout
+	zoneServerError
+	zoneEmpty
+)
+
+// zoneFixture is one fake per-zone backend.
+type zoneFixture struct {
+	Name        string
+	Behavior    zoneBehavior
+	Deployments []v3.ListDeploymentsResponseEntry
 	server      *httptest.Server
-	deployments []v3.ListDeploymentsResponseEntry
-	zones       int
+	calls       atomic.Int32
 }
 
-func newDepListServer(t *testing.T) *depListServer {
-	ts := &depListServer{}
-	mux := http.NewServeMux()
-	mux.HandleFunc("/ai/deployment", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet {
-			writeJSON(t, w, http.StatusOK, v3.ListDeploymentsResponse{Deployments: ts.deployments})
-			return
+// multiZoneHarness wires together a fake control-plane server (which
+// answers /zone) and one backend server per zone fixture (which answers
+// /ai/deployment).
+type multiZoneHarness struct {
+	control *httptest.Server
+	zones   []*zoneFixture
+}
+
+func (h *multiZoneHarness) close() {
+	h.control.Close()
+	for _, z := range h.zones {
+		if z.server != nil {
+			z.server.Close()
 		}
-		w.WriteHeader(http.StatusMethodNotAllowed)
-	})
-	mux.HandleFunc("/zone", func(w http.ResponseWriter, r *http.Request) {
-		ts.zones++
-		writeJSON(t, w, http.StatusOK, v3.ListZonesResponse{Zones: []v3.Zone{{APIEndpoint: v3.Endpoint(ts.server.URL), Name: v3.ZoneName("test-zone")}}})
-	})
-	ts.server = httptest.NewServer(mux)
-	return ts
+	}
 }
 
-func depSetup(t *testing.T, url string) func() {
-	exocmd.GContext = context.Background()
-	globalstate.Quiet = true
-	creds := credentials.NewStaticCredentials("key", "secret")
-	client, err := v3.NewClient(creds)
-	if err != nil {
-		t.Fatalf("new client: %v", err)
+func newMultiZoneHarness(t *testing.T, fixtures []*zoneFixture, slowDelay time.Duration) *multiZoneHarness {
+	t.Helper()
+	h := &multiZoneHarness{zones: fixtures}
+
+	// Build per-zone backends first so we know their URLs.
+	for _, z := range fixtures {
+		zone := z // capture
+		mux := http.NewServeMux()
+		mux.HandleFunc("/ai/deployment", func(w http.ResponseWriter, r *http.Request) {
+			zone.calls.Add(1)
+			switch zone.Behavior {
+			case zoneTimeout:
+				select {
+				case <-r.Context().Done():
+				case <-time.After(slowDelay):
+				}
+				return
+			case zoneServerError:
+				http.Error(w, "boom", http.StatusInternalServerError)
+				return
+			case zoneEmpty:
+				writeJSON(t, w, http.StatusOK, v3.ListDeploymentsResponse{})
+				return
+			default:
+				writeJSON(t, w, http.StatusOK, v3.ListDeploymentsResponse{Deployments: zone.Deployments})
+			}
+		})
+		zone.server = httptest.NewServer(mux)
 	}
-	globalstate.EgoscaleV3Client = client.WithEndpoint(v3.Endpoint(url))
-	return func() {}
+
+	// Control plane: answer /zone with all fixture endpoints.
+	controlMux := http.NewServeMux()
+	controlMux.HandleFunc("/zone", func(w http.ResponseWriter, r *http.Request) {
+		zones := make([]v3.Zone, 0, len(fixtures))
+		for _, z := range fixtures {
+			zones = append(zones, v3.Zone{
+				Name:        v3.ZoneName(z.Name),
+				APIEndpoint: v3.Endpoint(z.server.URL),
+			})
+		}
+		writeJSON(t, w, http.StatusOK, v3.ListZonesResponse{Zones: zones})
+	})
+	h.control = httptest.NewServer(controlMux)
+	return h
 }
 
 func writeJSON(t *testing.T, w http.ResponseWriter, code int, v interface{}) {
+	t.Helper()
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	if err := json.NewEncoder(w).Encode(v); err != nil {
@@ -59,45 +109,210 @@ func writeJSON(t *testing.T, w http.ResponseWriter, code int, v interface{}) {
 	}
 }
 
-func TestDeploymentList(t *testing.T) {
-	ts := newDepListServer(t)
-	defer ts.server.Close()
-	defer depSetup(t, ts.server.URL)()
+func setupClient(t *testing.T, controlURL string) {
+	t.Helper()
+	exocmd.GContext = context.Background()
+	globalstate.Quiet = true
+	creds := credentials.NewStaticCredentials("key", "secret")
+	client, err := v3.NewClient(creds)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	globalstate.EgoscaleV3Client = client.WithEndpoint(v3.Endpoint(controlURL))
+}
+
+func sampleDeployments(zoneSuffix string, n int) []v3.ListDeploymentsResponseEntry {
 	now := time.Now()
-	ts.deployments = []v3.ListDeploymentsResponseEntry{
-		{ID: v3.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), Name: "d1", State: v3.ListDeploymentsResponseEntryStateReady, GpuType: "gpua5000", GpuCount: 1, Replicas: 2, ServiceLevel: "pro", DeploymentURL: "https://u", Model: &v3.ModelRef{ID: v3.UUID("11111111-1111-1111-1111-111111111111"), Name: "m1"}, CreatedAT: now, UpdatedAT: now},
-		{ID: v3.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"), Name: "d2", State: v3.ListDeploymentsResponseEntryStateCreating, GpuType: "gpua5000", GpuCount: 2, Replicas: 1, ServiceLevel: "pro", DeploymentURL: "", Model: nil, CreatedAT: now, UpdatedAT: now},
+	out := make([]v3.ListDeploymentsResponseEntry, n)
+	for i := 0; i < n; i++ {
+		out[i] = v3.ListDeploymentsResponseEntry{
+			ID:        v3.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", i)),
+			Name:      fmt.Sprintf("dep-%s-%d", zoneSuffix, i),
+			State:     v3.ListDeploymentsResponseEntryStateReady,
+			GpuType:   "gpua5000",
+			GpuCount:  1,
+			Replicas:  1,
+			CreatedAT: now,
+			UpdatedAT: now,
+		}
 	}
-	cmd := &DeploymentListCmd{CliCommandSettings: exocmd.DefaultCLICmdSettings()}
-	cmd.OutputFunc = func(out output.Outputter, err error) error {
-		if err != nil {
-			return err
-		}
-		o := out.(*DeploymentListOutput)
-		if len(*o) != 2 {
-			t.Fatalf("expected 2 deployments, got %d", len(*o))
-		}
-		for _, d := range *o {
-			if d.Zone != "test-zone" {
-				t.Errorf("expected zone %q, got %q", "test-zone", d.Zone)
-			}
-		}
-		return nil
+	return out
+}
+
+func runList(t *testing.T, zoneFilter v3.ZoneName) (stdout, stderr string, err error) {
+	t.Helper()
+	var outBuf, errBuf bytes.Buffer
+	cmd := &DeploymentListCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
+		Zone:               zoneFilter,
 	}
-	if err := cmd.CmdRun(nil, nil); err != nil {
-		t.Fatalf("deployment list: %v", err)
+	err = runDeploymentList(cmd, &outBuf, &errBuf)
+	return outBuf.String(), errBuf.String(), err
+}
+
+func TestDeploymentList_AllHealthy(t *testing.T) {
+	defer withTimeout(t, 5*time.Second)()
+	zones := []*zoneFixture{
+		{Name: "z1", Behavior: zoneHealthy, Deployments: sampleDeployments("z1", 2)},
+		{Name: "z2", Behavior: zoneHealthy, Deployments: sampleDeployments("z2", 1)},
+		{Name: "z3", Behavior: zoneEmpty},
+	}
+	h := newMultiZoneHarness(t, zones, 0)
+	defer h.close()
+	setupClient(t, h.control.URL)
+	defer withFormat(t, "json")()
+
+	stdout, stderr, err := runList(t, "")
+	if err != nil {
+		t.Fatalf("expected nil err, got %v (stderr=%s)", err, stderr)
+	}
+	if stderr != "" {
+		t.Errorf("expected empty stderr, got %q", stderr)
+	}
+
+	var rows []DeploymentListItemOutput
+	if err := json.Unmarshal([]byte(stdout), &rows); err != nil {
+		t.Fatalf("invalid json: %v\nstdout: %s", err, stdout)
+	}
+	if len(rows) != 3 {
+		t.Errorf("want 3 rows, got %d", len(rows))
+	}
+	zoneCounts := map[v3.ZoneName]int{}
+	for _, r := range rows {
+		zoneCounts[r.Zone]++
+	}
+	if zoneCounts["z1"] != 2 || zoneCounts["z2"] != 1 || zoneCounts["z3"] != 0 {
+		t.Errorf("unexpected zone distribution: %+v", zoneCounts)
 	}
 }
 
-func TestDeploymentListUsesZone(t *testing.T) {
-	ts := newDepListServer(t)
-	defer ts.server.Close()
-	defer depSetup(t, ts.server.URL)()
-	cmd := &DeploymentListCmd{CliCommandSettings: exocmd.DefaultCLICmdSettings(), Zone: v3.ZoneName("test-zone")}
-	if err := cmd.CmdRun(nil, nil); err != nil {
-		t.Fatalf("deployment list: %v", err)
+func TestDeploymentList_OneTimeout(t *testing.T) {
+	defer withTimeout(t, 200*time.Millisecond)()
+	zones := []*zoneFixture{
+		{Name: "z1", Behavior: zoneHealthy, Deployments: sampleDeployments("z1", 1)},
+		{Name: "z2", Behavior: zoneTimeout},
+		{Name: "z3", Behavior: zoneHealthy, Deployments: sampleDeployments("z3", 1)},
 	}
-	if ts.zones == 0 {
-		t.Fatalf("expected zone list endpoint to be called")
+	h := newMultiZoneHarness(t, zones, 2*time.Second)
+	defer h.close()
+	setupClient(t, h.control.URL)
+	defer withFormat(t, "json")()
+
+	start := time.Now()
+	stdout, stderr, err := runList(t, "")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected non-nil err on partial failure")
 	}
+	if !strings.Contains(err.Error(), "1 zone") {
+		t.Errorf("err should mention 1 zone, got %q", err.Error())
+	}
+	if !strings.Contains(stderr, "warning: zone z2") {
+		t.Errorf("stderr should warn about z2, got: %s", stderr)
+	}
+	if elapsed > 1*time.Second {
+		t.Errorf("must not wait for the slow zone (elapsed=%s)", elapsed)
+	}
+	var rows []DeploymentListItemOutput
+	if err := json.Unmarshal([]byte(stdout), &rows); err != nil {
+		t.Fatalf("invalid json: %v\nstdout: %s", err, stdout)
+	}
+	if len(rows) != 2 {
+		t.Errorf("want 2 healthy rows, got %d", len(rows))
+	}
+}
+
+func TestDeploymentList_OneServerError(t *testing.T) {
+	defer withTimeout(t, 5*time.Second)()
+	zones := []*zoneFixture{
+		{Name: "z1", Behavior: zoneHealthy, Deployments: sampleDeployments("z1", 1)},
+		{Name: "z2", Behavior: zoneServerError},
+	}
+	h := newMultiZoneHarness(t, zones, 0)
+	defer h.close()
+	setupClient(t, h.control.URL)
+	defer withFormat(t, "json")()
+
+	stdout, stderr, err := runList(t, "")
+	if err == nil {
+		t.Fatal("expected non-nil err")
+	}
+	if !strings.Contains(stderr, "warning: zone z2") {
+		t.Errorf("stderr should warn about z2, got: %s", stderr)
+	}
+	var rows []DeploymentListItemOutput
+	if err := json.Unmarshal([]byte(stdout), &rows); err != nil {
+		t.Fatalf("invalid json: %v\nstdout: %s", err, stdout)
+	}
+	if len(rows) != 1 {
+		t.Errorf("want 1 healthy row, got %d", len(rows))
+	}
+}
+
+func TestDeploymentList_AllFailed(t *testing.T) {
+	defer withTimeout(t, 5*time.Second)()
+	zones := []*zoneFixture{
+		{Name: "z1", Behavior: zoneServerError},
+		{Name: "z2", Behavior: zoneServerError},
+	}
+	h := newMultiZoneHarness(t, zones, 0)
+	defer h.close()
+	setupClient(t, h.control.URL)
+	defer withFormat(t, "json")()
+
+	stdout, stderr, err := runList(t, "")
+	if err == nil {
+		t.Fatal("expected non-nil err")
+	}
+	if !strings.Contains(stderr, "warning: zone z1") || !strings.Contains(stderr, "warning: zone z2") {
+		t.Errorf("stderr should warn about both zones, got: %s", stderr)
+	}
+	got := strings.TrimSpace(stdout)
+	if got != "[]" && got != "null" {
+		t.Errorf("want empty json, got %q", got)
+	}
+}
+
+func TestDeploymentList_ZoneFilter(t *testing.T) {
+	defer withTimeout(t, 5*time.Second)()
+	zones := []*zoneFixture{
+		{Name: "z1", Behavior: zoneHealthy, Deployments: sampleDeployments("z1", 1)},
+		{Name: "z2", Behavior: zoneHealthy, Deployments: sampleDeployments("z2", 1)},
+	}
+	h := newMultiZoneHarness(t, zones, 0)
+	defer h.close()
+	setupClient(t, h.control.URL)
+	defer withFormat(t, "json")()
+
+	stdout, _, err := runList(t, "z1")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	var rows []DeploymentListItemOutput
+	if err := json.Unmarshal([]byte(stdout), &rows); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Zone != "z1" {
+		t.Errorf("expected only z1 row, got %+v", rows)
+	}
+	if zones[1].calls.Load() != 0 {
+		t.Errorf("z2 should not have been queried, calls=%d", zones[1].calls.Load())
+	}
+}
+
+// withTimeout sets globalstate.RequestTimeout for the duration of a test.
+func withTimeout(t *testing.T, d time.Duration) func() {
+	t.Helper()
+	prev := globalstate.RequestTimeout
+	globalstate.RequestTimeout = d
+	return func() { globalstate.RequestTimeout = prev }
+}
+
+// withFormat sets globalstate.OutputFormat for the duration of a test.
+func withFormat(t *testing.T, f string) func() {
+	t.Helper()
+	prev := globalstate.OutputFormat
+	globalstate.OutputFormat = f
+	return func() { globalstate.OutputFormat = prev }
 }

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -41,6 +41,8 @@ variables supported:
   * EXOSCALE_API_KEY: the Exoscale client API key
   * EXOSCALE_API_SECRET: the Exoscale client API secret
   * EXOSCALE_API_TIMEOUT: the Exoscale API timeout in minutes
+  * EXOSCALE_TIMEOUT: per-zone timeout for list operations (e.g. 15s, 1m);
+    set to -1s to disable the timeout
 
 Note: to override the current profile API credentials, *both* EXOSCALE_API_KEY
 and EXOSCALE_API_SECRET variables have to be set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -158,6 +159,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&globalstate.OutputFormat, "output-format", "O", "", "Output format (table|json|text), see \"exo output --help\" for more information")
 	RootCmd.PersistentFlags().StringVar(&output.GOutputTemplate, "output-template", "", "Template to use if output format is \"text\"")
 	RootCmd.PersistentFlags().BoolVarP(&globalstate.Quiet, "quiet", "Q", false, "Quiet mode (disable non-essential command output)")
+	RootCmd.PersistentFlags().DurationVar(&globalstate.RequestTimeout, "timeout", 15*time.Second, "Per-zone timeout for list operations [env EXOSCALE_TIMEOUT]")
 	RootCmd.AddCommand(versionCmd)
 
 	// Don't attempt to load client configuration in testing mode.
@@ -175,6 +177,7 @@ func initConfig() { //nolint:gocyclo
 	envs := map[string]string{
 		"EXOSCALE_CONFIG":  "config",
 		"EXOSCALE_ACCOUNT": "use-account",
+		"EXOSCALE_TIMEOUT": "timeout",
 	}
 
 	for env, flag := range envs {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,12 @@ var RootCmd = &cobra.Command{
 	Short:         "Manage your Exoscale infrastructure easily",
 	SilenceUsage:  true,
 	SilenceErrors: true,
+	PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+		if globalstate.RequestTimeout != -time.Second && globalstate.RequestTimeout <= 0 {
+			return fmt.Errorf("--timeout must be a positive duration (e.g. 15s), or -1s to disable")
+		}
+		return nil
+	},
 }
 
 var versionCmd = &cobra.Command{
@@ -159,7 +165,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&globalstate.OutputFormat, "output-format", "O", "", "Output format (table|json|text), see \"exo output --help\" for more information")
 	RootCmd.PersistentFlags().StringVar(&output.GOutputTemplate, "output-template", "", "Template to use if output format is \"text\"")
 	RootCmd.PersistentFlags().BoolVarP(&globalstate.Quiet, "quiet", "Q", false, "Quiet mode (disable non-essential command output)")
-	RootCmd.PersistentFlags().DurationVar(&globalstate.RequestTimeout, "timeout", 15*time.Second, "Per-zone timeout for list operations [env EXOSCALE_TIMEOUT]")
+	RootCmd.PersistentFlags().DurationVar(&globalstate.RequestTimeout, "timeout", 15*time.Second, "Per-zone timeout for list operations; -1s disables timeout [env EXOSCALE_TIMEOUT]")
 	RootCmd.AddCommand(versionCmd)
 
 	// Don't attempt to load client configuration in testing mode.

--- a/pkg/globalstate/globalstate.go
+++ b/pkg/globalstate/globalstate.go
@@ -1,6 +1,8 @@
 package globalstate
 
 import (
+	"time"
+
 	v3 "github.com/exoscale/egoscale/v3"
 )
 
@@ -10,4 +12,5 @@ var (
 	Quiet                 bool
 	ConfigFolder          string
 	GitVersion, GitCommit string
+	RequestTimeout        time.Duration
 )

--- a/pkg/output/streaming.go
+++ b/pkg/output/streaming.go
@@ -171,9 +171,8 @@ func (s *tableStreamer) writeBorder() {
 }
 
 // writeRow writes "│ cell1 │ cell2 │" with one-space padding on each
-// side. Cells longer than the configured width expand the cell rather
-// than wrap or truncate, mirroring SetAutoWrapText(false) on the
-// existing table.
+// side. Values longer than the configured column width are truncated
+// with a trailing ellipsis so cells stay aligned across rows.
 func (s *tableStreamer) writeRow(cells []string) {
 	var b strings.Builder
 	b.WriteString("│")
@@ -182,12 +181,31 @@ func (s *tableStreamer) writeRow(cells []string) {
 		if i < len(s.widths) {
 			w = s.widths[i]
 		}
-		// Pad right to at least w; if c is wider, the cell expands.
+		c = truncateCell(c, w)
 		fmt.Fprintf(&b, " %-*s ", w, c)
 		b.WriteString("│")
 	}
 	b.WriteString("\n")
 	_, _ = s.w.Write([]byte(b.String()))
+}
+
+// truncateCell shortens s to fit in w runes, replacing the trailing
+// rune with '…' when truncation occurs. w<=0 returns s unchanged so
+// the column expands like before (matches old behavior for fields
+// without an outputWidth tag and a header narrower than
+// defaultTableMinWidth).
+func truncateCell(s string, w int) string {
+	if w <= 0 {
+		return s
+	}
+	rs := []rune(s)
+	if len(rs) <= w {
+		return s
+	}
+	if w == 1 {
+		return "…"
+	}
+	return string(rs[:w-1]) + "…"
 }
 
 func (s *tableStreamer) Close() error {

--- a/pkg/output/streaming.go
+++ b/pkg/output/streaming.go
@@ -1,0 +1,185 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"sync"
+	"text/template"
+
+	"github.com/exoscale/cli/pkg/globalstate"
+)
+
+// StreamingOutputter is implemented by row-typed outputs that can be
+// emitted progressively. Push is goroutine-safe; Close finalizes the
+// render (flushes JSON, etc.).
+type StreamingOutputter interface {
+	Push(row any) error
+	Close() error
+}
+
+// NewStreamer returns the right StreamingOutputter for the active
+// globalstate.OutputFormat. rowType is a zero-value of the row struct
+// used to derive table headers and the JSON envelope element type.
+// w is where the streamer writes (typically os.Stdout).
+func NewStreamer(rowType any, w io.Writer) StreamingOutputter {
+	if GOutputTemplate != "" {
+		return newTextStreamer(rowType, w, GOutputTemplate)
+	}
+	switch globalstate.OutputFormat {
+	case "json":
+		return newJSONStreamer(rowType, w)
+	case "text":
+		return newTextStreamer(rowType, w, "")
+	default:
+		return newTableStreamer(rowType, w)
+	}
+}
+
+// rowKindOf returns the underlying struct type of rowType.
+func rowKindOf(rowType any) reflect.Type {
+	t := reflect.TypeOf(rowType)
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t
+}
+
+// --- text ---
+
+type textStreamer struct {
+	mu  sync.Mutex
+	w   io.Writer
+	tpl *template.Template
+}
+
+func newTextStreamer(rowType any, w io.Writer, userTpl string) *textStreamer {
+	tpl := userTpl
+	if tpl == "" {
+		zero := reflect.New(rowKindOf(rowType)).Elem().Interface()
+		fields := TemplateAnnotations(zero)
+		for i := range fields {
+			fields[i] = "{{" + fields[i] + "}}"
+		}
+		tpl = strings.Join(fields, "\t")
+	}
+	t, err := template.New("out").Parse(tpl)
+	if err != nil {
+		// Fall back to a printf so we still produce *something* and
+		// surface the misconfiguration rather than crashing the CLI.
+		t = template.Must(template.New("out").Parse("{{.}}"))
+		fmt.Fprintf(w, "warning: invalid output template: %s\n", err)
+	}
+	return &textStreamer{w: w, tpl: t}
+}
+
+func (s *textStreamer) Push(row any) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.tpl.Execute(s.w, row); err != nil {
+		return fmt.Errorf("text stream: %w", err)
+	}
+	_, err := fmt.Fprintln(s.w)
+	return err
+}
+
+func (s *textStreamer) Close() error { return nil }
+
+// --- table ---
+
+type tableStreamer struct {
+	mu      sync.Mutex
+	w       io.Writer
+	headers []string
+	widths  []int
+	started bool
+}
+
+func newTableStreamer(rowType any, w io.Writer) *tableStreamer {
+	headers := outputTableHeaders(rowKindOf(rowType))
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = len(h)
+	}
+	return &tableStreamer{w: w, headers: headers, widths: widths}
+}
+
+func (s *tableStreamer) Push(row any) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.started {
+		s.writeHeader()
+		s.started = true
+	}
+	cells := outputTableRow(reflect.Indirect(reflect.ValueOf(row)))
+	s.writeRow(cells)
+	return nil
+}
+
+func (s *tableStreamer) writeHeader() {
+	s.writeRow(s.headers)
+	sep := make([]string, len(s.headers))
+	for i, w := range s.widths {
+		sep[i] = strings.Repeat("─", w)
+	}
+	s.writeRow(sep)
+}
+
+func (s *tableStreamer) writeRow(cells []string) {
+	parts := make([]string, len(cells))
+	for i, c := range cells {
+		w := 0
+		if i < len(s.widths) {
+			w = s.widths[i]
+		}
+		parts[i] = fmt.Sprintf("%-*s", w, c)
+	}
+	fmt.Fprintln(s.w, strings.Join(parts, "  "))
+}
+
+func (s *tableStreamer) Close() error { return nil }
+
+// --- json ---
+
+type jsonStreamer struct {
+	mu      sync.Mutex
+	w       io.Writer
+	rowType reflect.Type
+	rows    reflect.Value // []rowType
+	closed  bool
+}
+
+func newJSONStreamer(rowType any, w io.Writer) *jsonStreamer {
+	rt := rowKindOf(rowType)
+	sliceType := reflect.SliceOf(rt)
+	return &jsonStreamer{
+		w:       w,
+		rowType: rt,
+		rows:    reflect.MakeSlice(sliceType, 0, 0),
+	}
+}
+
+func (s *jsonStreamer) Push(row any) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v := reflect.Indirect(reflect.ValueOf(row))
+	if v.Type() != s.rowType {
+		return fmt.Errorf("json stream: row type mismatch: got %s want %s", v.Type(), s.rowType)
+	}
+	s.rows = reflect.Append(s.rows, v)
+	return nil
+}
+
+func (s *jsonStreamer) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	enc := json.NewEncoder(s.w)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(s.rows.Interface())
+}

--- a/pkg/output/streaming.go
+++ b/pkg/output/streaming.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"text/template"
@@ -89,28 +90,67 @@ func (s *textStreamer) Close() error { return nil }
 
 // --- table ---
 
+// Default minimum content width when neither the outputWidth tag nor the
+// header label hints at something better. Wide enough for short status
+// codes; long values just expand the cell.
+const defaultTableMinWidth = 12
+
 type tableStreamer struct {
 	mu      sync.Mutex
 	w       io.Writer
 	headers []string
-	widths  []int
+	widths  []int // content widths; cell visual width is widths[i]+2
 	started bool
+	closed  bool
 }
 
 func newTableStreamer(rowType any, w io.Writer) *tableStreamer {
-	headers := outputTableHeaders(rowKindOf(rowType))
-	widths := make([]int, len(headers))
-	for i, h := range headers {
-		widths[i] = len(h)
+	t := rowKindOf(rowType)
+	headers := outputTableHeaders(t)
+	widths := tableColumnWidths(t, headers)
+	// Match tablewriter's auto-format: uppercase headers.
+	for i := range headers {
+		headers[i] = strings.ToUpper(headers[i])
 	}
 	return &tableStreamer{w: w, headers: headers, widths: widths}
+}
+
+// tableColumnWidths derives a content width per column from the
+// outputWidth struct tag, falling back to max(header length,
+// defaultTableMinWidth).
+func tableColumnWidths(t reflect.Type, headers []string) []int {
+	widths := make([]int, len(headers))
+	col := 0
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if l, ok := f.Tag.Lookup("output"); ok && l == "-" {
+			continue
+		}
+		if w, ok := f.Tag.Lookup("outputWidth"); ok {
+			if n, err := strconv.Atoi(w); err == nil && n > 0 {
+				widths[col] = n
+				col++
+				continue
+			}
+		}
+		hw := len(headers[col])
+		if hw > defaultTableMinWidth {
+			widths[col] = hw
+		} else {
+			widths[col] = defaultTableMinWidth
+		}
+		col++
+	}
+	return widths
 }
 
 func (s *tableStreamer) Push(row any) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if !s.started {
-		s.writeHeader()
+		s.writeBorder()
+		s.writeRow(s.headers)
+		s.writeBorder()
 		s.started = true
 	}
 	cells := outputTableRow(reflect.Indirect(reflect.ValueOf(row)))
@@ -118,28 +158,50 @@ func (s *tableStreamer) Push(row any) error {
 	return nil
 }
 
-func (s *tableStreamer) writeHeader() {
-	s.writeRow(s.headers)
-	sep := make([]string, len(s.headers))
-	for i, w := range s.widths {
-		sep[i] = strings.Repeat("─", w)
+// writeBorder writes a "┼───┼───┼" line spanning all columns.
+func (s *tableStreamer) writeBorder() {
+	var b strings.Builder
+	b.WriteString("┼")
+	for _, w := range s.widths {
+		b.WriteString(strings.Repeat("─", w+2))
+		b.WriteString("┼")
 	}
-	s.writeRow(sep)
+	b.WriteString("\n")
+	_, _ = s.w.Write([]byte(b.String()))
 }
 
+// writeRow writes "│ cell1 │ cell2 │" with one-space padding on each
+// side. Cells longer than the configured width expand the cell rather
+// than wrap or truncate, mirroring SetAutoWrapText(false) on the
+// existing table.
 func (s *tableStreamer) writeRow(cells []string) {
-	parts := make([]string, len(cells))
+	var b strings.Builder
+	b.WriteString("│")
 	for i, c := range cells {
 		w := 0
 		if i < len(s.widths) {
 			w = s.widths[i]
 		}
-		parts[i] = fmt.Sprintf("%-*s", w, c)
+		// Pad right to at least w; if c is wider, the cell expands.
+		fmt.Fprintf(&b, " %-*s ", w, c)
+		b.WriteString("│")
 	}
-	fmt.Fprintln(s.w, strings.Join(parts, "  "))
+	b.WriteString("\n")
+	_, _ = s.w.Write([]byte(b.String()))
 }
 
-func (s *tableStreamer) Close() error { return nil }
+func (s *tableStreamer) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	if s.started {
+		s.writeBorder()
+	}
+	return nil
+}
 
 // --- json ---
 

--- a/pkg/output/streaming.go
+++ b/pkg/output/streaming.go
@@ -42,7 +42,7 @@ func NewStreamer(rowType any, w io.Writer) StreamingOutputter {
 // rowKindOf returns the underlying struct type of rowType.
 func rowKindOf(rowType any) reflect.Type {
 	t := reflect.TypeOf(rowType)
-	for t.Kind() == reflect.Ptr {
+	for t.Kind() == reflect.Ptr { //nolint:govet
 		t = t.Elem()
 	}
 	return t
@@ -71,7 +71,7 @@ func newTextStreamer(rowType any, w io.Writer, userTpl string) *textStreamer {
 		// Fall back to a printf so we still produce *something* and
 		// surface the misconfiguration rather than crashing the CLI.
 		t = template.Must(template.New("out").Parse("{{.}}"))
-		fmt.Fprintf(w, "warning: invalid output template: %s\n", err)
+		_, _ = fmt.Fprintf(w, "warning: invalid output template: %s\n", err)
 	}
 	return &textStreamer{w: w, tpl: t}
 }

--- a/pkg/output/streaming_test.go
+++ b/pkg/output/streaming_test.go
@@ -116,16 +116,59 @@ func TestStreamingTable(t *testing.T) {
 
 	out := buf.String()
 	lines := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
-	if len(lines) != 3 {
-		t.Fatalf("want 3 lines (header, sep, row), got %d:\n%s", len(lines), out)
+	// Expected: top border, header, header-sep, row, bottom border = 5 lines.
+	if len(lines) != 5 {
+		t.Fatalf("want 5 lines (top, header, sep, row, bottom), got %d:\n%s", len(lines), out)
 	}
-	for _, want := range []string{"Name", "Zone", "N"} {
-		if !strings.Contains(lines[0], want) {
-			t.Errorf("header missing %q: %q", want, lines[0])
+	for _, want := range []string{"NAME", "ZONE", "N"} {
+		if !strings.Contains(lines[1], want) {
+			t.Errorf("header missing %q: %q", want, lines[1])
 		}
 	}
-	if !strings.Contains(lines[2], "a") || !strings.Contains(lines[2], "z1") {
-		t.Errorf("row missing fields: %q", lines[2])
+	if !strings.Contains(lines[3], "a") || !strings.Contains(lines[3], "z1") {
+		t.Errorf("row missing fields: %q", lines[3])
+	}
+	for _, idx := range []int{0, 2, 4} {
+		if !strings.HasPrefix(lines[idx], "┼") {
+			t.Errorf("line %d should start with ┼, got %q", idx, lines[idx])
+		}
+	}
+	if !strings.HasPrefix(lines[1], "│") || !strings.HasPrefix(lines[3], "│") {
+		t.Errorf("header/row should start with │")
+	}
+}
+
+func TestStreamingTableEmpty(t *testing.T) {
+	defer withFormat(t, "")()
+	var buf bytes.Buffer
+	s := NewStreamer(streamRow{}, &buf)
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("empty stream should produce no output, got %q", buf.String())
+	}
+}
+
+func TestStreamingTable_OutputWidthTag(t *testing.T) {
+	defer withFormat(t, "")()
+	type narrowRow struct {
+		ID   string `outputWidth:"4"`
+		Name string `outputWidth:"6"`
+	}
+	var buf bytes.Buffer
+	s := NewStreamer(narrowRow{}, &buf)
+	if err := s.Push(narrowRow{ID: "x", Name: "y"}); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	// Border with widths 4 and 6 → content runs of 6 and 8 dashes
+	// (width + 2 padding spaces).
+	wantBorder := "┼" + strings.Repeat("─", 6) + "┼" + strings.Repeat("─", 8) + "┼"
+	if !strings.Contains(buf.String(), wantBorder) {
+		t.Errorf("expected border %q in output:\n%s", wantBorder, buf.String())
 	}
 }
 

--- a/pkg/output/streaming_test.go
+++ b/pkg/output/streaming_test.go
@@ -1,0 +1,168 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/exoscale/cli/pkg/globalstate"
+)
+
+type streamRow struct {
+	Name string `json:"name"`
+	Zone string `json:"zone"`
+	N    int    `json:"n"`
+}
+
+func withFormat(t *testing.T, f string) func() {
+	t.Helper()
+	prev := globalstate.OutputFormat
+	prevTpl := GOutputTemplate
+	globalstate.OutputFormat = f
+	GOutputTemplate = ""
+	return func() {
+		globalstate.OutputFormat = prev
+		GOutputTemplate = prevTpl
+	}
+}
+
+func TestStreamingJSON(t *testing.T) {
+	defer withFormat(t, "json")()
+	var buf bytes.Buffer
+	s := NewStreamer(streamRow{}, &buf)
+
+	rows := []streamRow{
+		{Name: "a", Zone: "z1", N: 1},
+		{Name: "b", Zone: "z2", N: 2},
+		{Name: "c", Zone: "z3", N: 3},
+	}
+	for _, r := range rows {
+		if err := s.Push(r); err != nil {
+			t.Fatalf("push: %v", err)
+		}
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	var got []streamRow
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("invalid json: %v\nraw: %s", err, buf.String())
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3 rows, got %d", len(got))
+	}
+	for i, r := range rows {
+		if got[i] != r {
+			t.Errorf("row %d: got %+v want %+v", i, got[i], r)
+		}
+	}
+}
+
+func TestStreamingJSONEmpty(t *testing.T) {
+	defer withFormat(t, "json")()
+	var buf bytes.Buffer
+	s := NewStreamer(streamRow{}, &buf)
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != "[]" {
+		t.Fatalf("empty stream: want '[]', got %q", got)
+	}
+}
+
+func TestStreamingText(t *testing.T) {
+	defer withFormat(t, "text")()
+	var buf bytes.Buffer
+	s := NewStreamer(streamRow{}, &buf)
+
+	if err := s.Push(streamRow{Name: "a", Zone: "z1", N: 1}); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if err := s.Push(streamRow{Name: "b", Zone: "z2", N: 2}); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 lines, got %d: %q", len(lines), buf.String())
+	}
+	if !strings.Contains(lines[0], "a") || !strings.Contains(lines[0], "z1") {
+		t.Errorf("line 0 missing fields: %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "b") || !strings.Contains(lines[1], "z2") {
+		t.Errorf("line 1 missing fields: %q", lines[1])
+	}
+}
+
+func TestStreamingTable(t *testing.T) {
+	defer withFormat(t, "")() // default = table
+	var buf bytes.Buffer
+	s := NewStreamer(streamRow{}, &buf)
+
+	if err := s.Push(streamRow{Name: "a", Zone: "z1", N: 1}); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	out := buf.String()
+	lines := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("want 3 lines (header, sep, row), got %d:\n%s", len(lines), out)
+	}
+	for _, want := range []string{"Name", "Zone", "N"} {
+		if !strings.Contains(lines[0], want) {
+			t.Errorf("header missing %q: %q", want, lines[0])
+		}
+	}
+	if !strings.Contains(lines[2], "a") || !strings.Contains(lines[2], "z1") {
+		t.Errorf("row missing fields: %q", lines[2])
+	}
+}
+
+func TestStreamingConcurrentPush(t *testing.T) {
+	defer withFormat(t, "json")()
+	var buf bytes.Buffer
+	s := NewStreamer(streamRow{}, &buf)
+
+	const N = 50
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func(i int) {
+			defer wg.Done()
+			_ = s.Push(streamRow{Name: fmt.Sprintf("n%d", i), Zone: "z", N: i})
+		}(i)
+	}
+	wg.Wait()
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	var got []streamRow
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if len(got) != N {
+		t.Fatalf("want %d rows, got %d", N, len(got))
+	}
+}
+
+func TestStreamingJSONRowTypeMismatch(t *testing.T) {
+	defer withFormat(t, "json")()
+	var buf bytes.Buffer
+	s := NewStreamer(streamRow{}, &buf)
+	type other struct{ X int }
+	if err := s.Push(other{X: 1}); err == nil {
+		t.Fatal("want type mismatch error")
+	}
+}

--- a/pkg/output/streaming_test.go
+++ b/pkg/output/streaming_test.go
@@ -150,6 +150,63 @@ func TestStreamingTableEmpty(t *testing.T) {
 	}
 }
 
+func TestStreamingTable_TruncatesLongValues(t *testing.T) {
+	defer withFormat(t, "")()
+	type row struct {
+		Name string `outputWidth:"6"`
+	}
+	var buf bytes.Buffer
+	s := NewStreamer(row{}, &buf)
+	if err := s.Push(row{Name: "abcdefghij"}); err != nil { // 10 runes into width 6
+		t.Fatalf("push: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "│ abcde… │") {
+		t.Errorf("expected truncated cell with ellipsis, got:\n%s", out)
+	}
+}
+
+func TestStreamingTable_TruncationIsRuneSafe(t *testing.T) {
+	defer withFormat(t, "")()
+	type row struct {
+		Name string `outputWidth:"4"`
+	}
+	var buf bytes.Buffer
+	s := NewStreamer(row{}, &buf)
+	// 5 runes (each multi-byte) → must not chop a rune in half.
+	if err := s.Push(row{Name: "éèàçü"}); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "│ éèà… │") {
+		t.Errorf("expected rune-safe truncation, got:\n%s", out)
+	}
+}
+
+func TestStreamingTable_FitsExactlyNoEllipsis(t *testing.T) {
+	defer withFormat(t, "")()
+	type row struct {
+		Name string `outputWidth:"4"`
+	}
+	var buf bytes.Buffer
+	s := NewStreamer(row{}, &buf)
+	if err := s.Push(row{Name: "abcd"}); err != nil { // exactly 4 runes
+		t.Fatalf("push: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if strings.Contains(buf.String(), "…") {
+		t.Errorf("exact-fit value must not be truncated, got:\n%s", buf.String())
+	}
+}
+
 func TestStreamingTable_OutputWidthTag(t *testing.T) {
 	defer withFormat(t, "")()
 	type narrowRow struct {

--- a/utils/spinner.go
+++ b/utils/spinner.go
@@ -1,0 +1,95 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"golang.org/x/term"
+
+	"github.com/exoscale/cli/pkg/globalstate"
+)
+
+// spinnerFrames are simple braille glyphs that render well in any
+// modern terminal.
+var spinnerFrames = []rune{'⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'}
+
+// Spinner draws a single rotating glyph at column 0 of stderr until
+// Stop is called. By design the spinner occupies exactly one
+// character, so concurrent writes to stdout (which start at column 0
+// after a newline) cleanly overwrite the glyph — no caption ghosts
+// past the leading '│' of a streamed table row.
+//
+// Silent if stderr isn't a TTY or globalstate.Quiet is on, so
+// callers can use Start/Stop unconditionally.
+type Spinner struct {
+	w      io.Writer
+	stop   chan struct{}
+	done   chan struct{}
+	active bool
+}
+
+func NewSpinner() *Spinner {
+	return &Spinner{
+		w:    os.Stderr,
+		stop: make(chan struct{}),
+		done: make(chan struct{}),
+	}
+}
+
+// SetWriter overrides the writer the spinner draws on. Must be called
+// before Start. If w is not an *os.File pointing at a TTY, Start is
+// a no-op.
+func (s *Spinner) SetWriter(w io.Writer) {
+	s.w = w
+}
+
+func (s *Spinner) Start() {
+	if globalstate.Quiet {
+		return
+	}
+	f, ok := s.w.(*os.File)
+	if !ok || !term.IsTerminal(int(f.Fd())) {
+		return
+	}
+	s.active = true
+	go s.run()
+}
+
+// Stop erases the glyph and returns once the drawing goroutine has
+// exited. Safe to call multiple times and safe to call when Start was
+// a no-op.
+func (s *Spinner) Stop() {
+	if !s.active {
+		return
+	}
+	s.active = false
+	close(s.stop)
+	<-s.done
+}
+
+func (s *Spinner) run() {
+	defer close(s.done)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	frame := 0
+	draw := func() {
+		// Single char + \r: occupies col 0, cursor returns to col 0.
+		// Any subsequent stdout byte at col 0 overwrites the glyph
+		// cleanly, so streamed rows don't leave caption ghosts.
+		fmt.Fprintf(s.w, "%c\r", spinnerFrames[frame%len(spinnerFrames)])
+	}
+	draw()
+	for {
+		select {
+		case <-s.stop:
+			// Wipe col 0 with a space, then return to col 0.
+			fmt.Fprint(s.w, " \r")
+			return
+		case <-ticker.C:
+			frame++
+			draw()
+		}
+	}
+}

--- a/utils/spinner.go
+++ b/utils/spinner.go
@@ -78,14 +78,14 @@ func (s *Spinner) run() {
 		// Single char + \r: occupies col 0, cursor returns to col 0.
 		// Any subsequent stdout byte at col 0 overwrites the glyph
 		// cleanly, so streamed rows don't leave caption ghosts.
-		fmt.Fprintf(s.w, "%c\r", spinnerFrames[frame%len(spinnerFrames)])
+		_, _ = fmt.Fprintf(s.w, "%c\r", spinnerFrames[frame%len(spinnerFrames)])
 	}
 	draw()
 	for {
 		select {
 		case <-s.stop:
 			// Wipe col 0 with a space, then return to col 0.
-			fmt.Fprint(s.w, " \r")
+			_, _ = fmt.Fprint(s.w, " \r")
 			return
 		case <-ticker.C:
 			frame++

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -11,6 +11,9 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 
@@ -234,6 +237,35 @@ func ForEveryZone(zones []v3.Zone, f func(zone v3.Zone) error) error {
 	}
 
 	return meg.Wait().ErrorOrNil()
+}
+
+// ForEveryZoneAsync runs f concurrently per zone with a per-zone timeout
+// derived from ctx. Per-zone errors are buffered into sink as warnings
+// and never abort the other zones. Returns the number of zones that
+// failed.
+func ForEveryZoneAsync(
+	ctx context.Context,
+	zones []v3.Zone,
+	timeout time.Duration,
+	sink *WarningSink,
+	f func(ctx context.Context, zone v3.Zone) error,
+) int {
+	var wg sync.WaitGroup
+	var failed atomic.Int32
+	for _, zone := range zones {
+		wg.Add(1)
+		go func(zone v3.Zone) {
+			defer wg.Done()
+			zCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			if err := f(zCtx, zone); err != nil {
+				failed.Add(1)
+				sink.Add("zone %s: %v", zone.Name, err)
+			}
+		}(zone)
+	}
+	wg.Wait()
+	return int(failed.Load())
 }
 
 // ParseInstanceType returns an v3.InstanceType with family and name.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -243,13 +243,25 @@ func ForEveryZone(zones []v3.Zone, f func(zone v3.Zone) error) error {
 // derived from ctx. Per-zone errors are buffered into sink as warnings
 // and never abort the other zones. Returns the number of zones that
 // failed.
+//
+// If showSpinner is true, a single rotating glyph is drawn on stderr
+// for the full duration of the fanout (until every zone has either
+// returned or timed out). Silent on non-TTY stderr and under
+// globalstate.Quiet, so callers can pass true unconditionally.
 func ForEveryZoneAsync(
 	ctx context.Context,
 	zones []v3.Zone,
 	timeout time.Duration,
 	sink *WarningSink,
+	showSpinner bool,
 	f func(ctx context.Context, zone v3.Zone) error,
 ) int {
+	if showSpinner {
+		spinner := NewSpinner()
+		spinner.Start()
+		defer spinner.Stop()
+	}
+
 	var wg sync.WaitGroup
 	var failed atomic.Int32
 	for _, zone := range zones {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -268,9 +268,14 @@ func ForEveryZoneAsync(
 		wg.Add(1)
 		go func(zone v3.Zone) {
 			defer wg.Done()
-			zCtx, cancel := context.WithTimeout(ctx, timeout)
-			defer cancel()
-			if err := f(zCtx, zone); err != nil {
+			if timeout > 0 {
+				zCtx, cancel := context.WithTimeout(ctx, timeout)
+				defer cancel()
+				if err := f(zCtx, zone); err != nil {
+					failed.Add(1)
+					sink.Add("zone %s: %v", zone.Name, err)
+				}
+			} else if err := f(ctx, zone); err != nil {
 				failed.Add(1)
 				sink.Add("zone %s: %v", zone.Name, err)
 			}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -64,6 +64,20 @@ func TestWarningSink_ConcurrentAdd(t *testing.T) {
 	}
 }
 
+func TestSpinner_StartStopOnNonTTYIsNoop(t *testing.T) {
+	var buf bytes.Buffer
+	// Real Spinner with a non-TTY writer: Start should be a silent
+	// no-op so scripted runs don't get spinner spam.
+	s := NewSpinner()
+	s.SetWriter(&buf)
+	s.Start()
+	time.Sleep(50 * time.Millisecond)
+	s.Stop()
+	if buf.Len() != 0 {
+		t.Errorf("non-TTY spinner should produce no output, got %q", buf.String())
+	}
+}
+
 func TestWarningSink_FlushIsIdempotent(t *testing.T) {
 	var buf bytes.Buffer
 	s := NewWarningSinkTo(&buf)
@@ -111,7 +125,7 @@ func TestForEveryZoneAsync_FastZoneNotBlockedBySlow(t *testing.T) {
 	sink := NewWarningSinkTo(&buf)
 
 	start := time.Now()
-	failed := ForEveryZoneAsync(context.Background(), zones, timeout, sink,
+	failed := ForEveryZoneAsync(context.Background(), zones, timeout, sink, false,
 		func(ctx context.Context, zone v3.Zone) error {
 			zc := client.WithEndpoint(zone.APIEndpoint)
 			_, err := zc.ListDeployments(ctx)
@@ -163,4 +177,3 @@ func TestWarningSink_SignalFlush(t *testing.T) {
 	cancel()
 	assert.Contains(t, buf.String(), "from-signal")
 }
-

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -4,11 +4,16 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	v3 "github.com/exoscale/egoscale/v3"
+	"github.com/exoscale/egoscale/v3/credentials"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -66,6 +71,69 @@ func TestWarningSink_FlushIsIdempotent(t *testing.T) {
 	s.Flush()
 	s.Flush()
 	assert.Equal(t, "warning: once\n", buf.String())
+}
+
+func TestForEveryZoneAsync_FastZoneNotBlockedBySlow(t *testing.T) {
+	// Server A returns immediately. Server B blocks longer than the
+	// per-zone timeout. We assert that A's work landed and B counted
+	// as failed without holding up the whole call.
+	const timeout = 200 * time.Millisecond
+	const slowDelay = 800 * time.Millisecond
+
+	fastSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"deployments":[]}`))
+	}))
+	defer fastSrv.Close()
+
+	slowSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-time.After(slowDelay):
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"deployments":[]}`))
+	}))
+	defer slowSrv.Close()
+
+	creds := credentials.NewStaticCredentials("key", "secret")
+	client, err := v3.NewClient(creds)
+	assert.NoError(t, err)
+
+	zones := []v3.Zone{
+		{Name: v3.ZoneName("fast"), APIEndpoint: v3.Endpoint(fastSrv.URL)},
+		{Name: v3.ZoneName("slow"), APIEndpoint: v3.Endpoint(slowSrv.URL)},
+	}
+
+	var fastDone atomic.Bool
+	var buf bytes.Buffer
+	sink := NewWarningSinkTo(&buf)
+
+	start := time.Now()
+	failed := ForEveryZoneAsync(context.Background(), zones, timeout, sink,
+		func(ctx context.Context, zone v3.Zone) error {
+			zc := client.WithEndpoint(zone.APIEndpoint)
+			_, err := zc.ListDeployments(ctx)
+			if err != nil {
+				return err
+			}
+			if zone.Name == "fast" {
+				fastDone.Store(true)
+			}
+			return nil
+		})
+	elapsed := time.Since(start)
+
+	assert.True(t, fastDone.Load(), "fast zone should have completed")
+	assert.Equal(t, 1, failed, "exactly one zone should have failed (slow)")
+	assert.Equal(t, 1, sink.Len(), "sink should hold one warning")
+
+	// Should have taken roughly the timeout, not slowDelay.
+	assert.Less(t, elapsed, slowDelay, "must not wait for the slow zone")
+
+	sink.Flush()
+	assert.Contains(t, buf.String(), "zone slow")
 }
 
 func TestWarningSink_SignalFlush(t *testing.T) {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,6 +1,11 @@
 package utils
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
 	"testing"
 
 	v3 "github.com/exoscale/egoscale/v3"
@@ -28,3 +33,66 @@ func TestParseInstanceType(t *testing.T) {
 		})
 	}
 }
+
+func TestWarningSink_ConcurrentAdd(t *testing.T) {
+	var buf bytes.Buffer
+	s := NewWarningSinkTo(&buf)
+
+	const N = 50
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func(i int) {
+			defer wg.Done()
+			s.Add("zone-%d failed", i)
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, N, s.Len())
+	s.Flush()
+	assert.Equal(t, 0, s.Len(), "Flush should drain")
+
+	out := buf.String()
+	for i := 0; i < N; i++ {
+		assert.Contains(t, out, fmt.Sprintf("warning: zone-%d failed", i))
+	}
+}
+
+func TestWarningSink_FlushIsIdempotent(t *testing.T) {
+	var buf bytes.Buffer
+	s := NewWarningSinkTo(&buf)
+	s.Add("once")
+	s.Flush()
+	s.Flush()
+	assert.Equal(t, "warning: once\n", buf.String())
+}
+
+func TestWarningSink_SignalFlush(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("SIGINT semantics differ on Windows")
+	}
+
+	var buf bytes.Buffer
+	s := NewWarningSinkTo(&buf)
+	s.Add("from-signal")
+
+	// Cancel via context so the goroutine exits before re-raising
+	// SIGINT into the test runner. We only assert that the signal path
+	// reaches Flush; we don't actually deliver the signal to avoid
+	// killing the test process.
+	ctx, cancel := context.WithCancel(context.Background())
+	stop := s.InstallSignalFlush(ctx)
+	defer stop()
+
+	// Simulate the signal path manually: send SIGINT, but stop the
+	// listener immediately afterwards so the re-raise is suppressed.
+	// Easier: just synthesize the Flush directly — InstallSignalFlush's
+	// guarantee is "Flush is called on signal", which we cover by
+	// testing Flush() and signal.Notify wiring separately.
+	s.Flush()
+
+	cancel()
+	assert.Contains(t, buf.String(), "from-signal")
+}
+

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -148,32 +147,4 @@ func TestForEveryZoneAsync_FastZoneNotBlockedBySlow(t *testing.T) {
 
 	sink.Flush()
 	assert.Contains(t, buf.String(), "zone slow")
-}
-
-func TestWarningSink_SignalFlush(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("SIGINT semantics differ on Windows")
-	}
-
-	var buf bytes.Buffer
-	s := NewWarningSinkTo(&buf)
-	s.Add("from-signal")
-
-	// Cancel via context so the goroutine exits before re-raising
-	// SIGINT into the test runner. We only assert that the signal path
-	// reaches Flush; we don't actually deliver the signal to avoid
-	// killing the test process.
-	ctx, cancel := context.WithCancel(context.Background())
-	stop := s.InstallSignalFlush(ctx)
-	defer stop()
-
-	// Simulate the signal path manually: send SIGINT, but stop the
-	// listener immediately afterwards so the re-raise is suppressed.
-	// Easier: just synthesize the Flush directly — InstallSignalFlush's
-	// guarantee is "Flush is called on signal", which we cover by
-	// testing Flush() and signal.Notify wiring separately.
-	s.Flush()
-
-	cancel()
-	assert.Contains(t, buf.String(), "from-signal")
 }

--- a/utils/warnings.go
+++ b/utils/warnings.go
@@ -1,0 +1,83 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+// WarningSink buffers per-zone warnings so they don't interleave with
+// streamed stdout output. Flush is called explicitly (via defer) at the
+// end of the command, or implicitly on SIGINT/SIGTERM via
+// InstallSignalFlush.
+type WarningSink struct {
+	mu   sync.Mutex
+	msgs []string
+	out  io.Writer
+}
+
+// NewWarningSink returns a sink that writes to os.Stderr on Flush.
+func NewWarningSink() *WarningSink {
+	return &WarningSink{out: os.Stderr}
+}
+
+// NewWarningSinkTo returns a sink that writes to w on Flush. Used in tests.
+func NewWarningSinkTo(w io.Writer) *WarningSink {
+	return &WarningSink{out: w}
+}
+
+// Add buffers a formatted warning. Safe to call from multiple goroutines.
+func (s *WarningSink) Add(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	s.mu.Lock()
+	s.msgs = append(s.msgs, msg)
+	s.mu.Unlock()
+}
+
+// Len returns the number of buffered warnings.
+func (s *WarningSink) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.msgs)
+}
+
+// Flush writes every buffered warning to the sink's writer and clears
+// the buffer. Safe to call multiple times.
+func (s *WarningSink) Flush() {
+	s.mu.Lock()
+	msgs := s.msgs
+	s.msgs = nil
+	s.mu.Unlock()
+	for _, m := range msgs {
+		fmt.Fprintf(s.out, "warning: %s\n", m)
+	}
+}
+
+// InstallSignalFlush installs a SIGINT/SIGTERM handler that flushes the
+// sink before the process exits. Returns a cancel function that the
+// caller should defer to remove the handler.
+func (s *WarningSink) InstallSignalFlush(ctx context.Context) func() {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		select {
+		case sig := <-ch:
+			s.Flush()
+			signal.Stop(ch)
+			// Re-raise so the default handler terminates the process
+			// with the conventional exit code.
+			_ = syscall.Kill(syscall.Getpid(), sig.(syscall.Signal))
+		case <-ctx.Done():
+		case <-done:
+		}
+	}()
+	return func() {
+		signal.Stop(ch)
+		close(done)
+	}
+}

--- a/utils/warnings.go
+++ b/utils/warnings.go
@@ -50,6 +50,6 @@ func (s *WarningSink) Flush() {
 	s.msgs = nil
 	s.mu.Unlock()
 	for _, m := range msgs {
-		fmt.Fprintf(s.out, "warning: %s\n", m)
+		_, _ = fmt.Fprintf(s.out, "warning: %s\n", m)
 	}
 }

--- a/utils/warnings.go
+++ b/utils/warnings.go
@@ -1,13 +1,10 @@
 package utils
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 )
 
 // WarningSink buffers per-zone warnings so they don't interleave with
@@ -54,30 +51,5 @@ func (s *WarningSink) Flush() {
 	s.mu.Unlock()
 	for _, m := range msgs {
 		fmt.Fprintf(s.out, "warning: %s\n", m)
-	}
-}
-
-// InstallSignalFlush installs a SIGINT/SIGTERM handler that flushes the
-// sink before the process exits. Returns a cancel function that the
-// caller should defer to remove the handler.
-func (s *WarningSink) InstallSignalFlush(ctx context.Context) func() {
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
-	done := make(chan struct{})
-	go func() {
-		select {
-		case sig := <-ch:
-			s.Flush()
-			signal.Stop(ch)
-			// Re-raise so the default handler terminates the process
-			// with the conventional exit code.
-			_ = syscall.Kill(syscall.Getpid(), sig.(syscall.Signal))
-		case <-ctx.Done():
-		case <-done:
-		}
-	}()
-	return func() {
-		signal.Stop(ch)
-		close(done)
 	}
 }


### PR DESCRIPTION
# Description

Last Friday the network in ZAG1 went down and `exo ai deployment list` (and every other multi-zone list) stopped responding for everyone. This bricked the whole command, because the fanout waited on every zone and a single error nuked the buffered output before render.
This PR is a proposal to fix that, scoped to `exo ai deployment list` as the proving ground. The plan is to migrate the rest of the listers in follow-ups now that the helpers are in place.

Shortcut story: [sc-177228](https://app.shortcut.com/exoscale/story/177228/improve-zone-failure-handling)

## What changed

<img width="1102" height="126" alt="Screenshot 2026-04-27 at 17 16 41" src="https://github.com/user-attachments/assets/099083a9-39e6-4fe6-b574-e7ca10c99a29" />

<br>
<img width="1079" height="179" alt="Screenshot 2026-04-27 at 17 17 00" src="https://github.com/user-attachments/assets/50b7bbaa-aeba-412d-b8b6-938c7c8e918f" />
<br>
<img width="1160" height="242" alt="Screenshot 2026-04-27 at 17 23 32" src="https://github.com/user-attachments/assets/fbc8b02a-daaa-4571-a682-6f17a7701951" />
<br>

- New `utils.ForEveryZoneAsync` replacement for `ForEveryZone`, with a per-zone timeout and a buffered warning sink instead of multierror. One bad zone produces a stderr warning and returns. Comes with a `--timeout` global flag (default 15s, env `EXOSCALE_TIMEOUT`).
- Streaming output. Rows render progressively as each zone returns rather than after the slowest one finishes. Table + text stream row-by-row; JSON stays buffered (one valid array). New `output.StreamingOutputter` interface in `pkg/output/streaming.go`.
- Bordered streaming table. Matches the existing tablewriter look (same `┼` `│` `─` glyphs, same one-space cell padding, uppercase headers). Column widths are pre-specified per row-struct field via a new `outputWidth:"36"` struct tag. We can't auto-size when we don't know how many rows are coming.
- Warnings are buffered. Per-zone errors collect in a `WarningSink` and flush at the end (or on Ctrl+C), so streamed rows don't get interleaved with stderr noise.
- Liveness glyph. A single rotating braille char on stderr while the `utils.ForEveryZoneAsync` is running, so the user knows things aren't hung even when fast zones have already streamed and we're still waiting on a slow one. Silent on non-TTY and under `--quiet`. 
- Exit code 1 on partial failure, so scripts can tell.

## Testing

- Unit tests for the new helpers
- Manually verified against preprod (3 of 4 zones currently down). With this branch you get the healthy zone's rows immediately and three `warning: zone X: ...` lines on stderr at the end.

## Reviewer notes

- Review commit by commit - the history is pretty clean
- The streamed table will look slightly different from the `tablewriter`-rendered one if a value is wider than its declared `outputWidth` the cell trims the content. I hesitated between that and letting the content expand, but this seemed the better tradeoff, it's more readable.
- The single-glyph spinner can theoretically interleave bytes with a row write if stderr/stdout are racing, but the glyph is one char and ticks every 100ms. In practice the row's leading `│` cleanly covers it.


## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block, and add the Pull Request #number for each bit you add to the `CHANGELOG.md`)
* [x] Testing
