### PR TITLE
fix(storage): fix purge infinite loop and select race on locked buckets

### DIFF
--- a/cmd/storage/storage_purge.go
+++ b/cmd/storage/storage_purge.go
@@ -80,21 +80,26 @@ var storagePurgeCmd = &cobra.Command{
 
 		deletedChan, errChan := storage.DeleteObjectVersions(exocmd.GContext, bucket, prefix)
 
-		for {
+		for deletedChan != nil || errChan != nil {
 			select {
 			case err, ok := <-errChan:
-				if ok {
-					fmt.Printf("Error happened: %v\n", err)
-				} else {
-					fmt.Println("Purge completed")
-					return nil
+				if !ok {
+					errChan = nil
+					continue
 				}
-			case deletedElt := <-deletedChan:
+				fmt.Printf("Error: %v\n", err)
+			case deletedElt, ok := <-deletedChan:
+				if !ok {
+					deletedChan = nil
+					continue
+				}
 				if verbose {
 					fmt.Println("deleted:", aws.ToString(deletedElt.Key))
 				}
 			}
 		}
+		fmt.Println("Purge completed")
+		return nil
 	},
 }
 

--- a/pkg/storage/sos/object.go
+++ b/pkg/storage/sos/object.go
@@ -49,12 +49,21 @@ func (c *Client) DeleteObjectVersions(ctx context.Context, bucket, prefix string
 		defer close(errChan)
 
 		batchSize := int32(1000)
+		var keyMarker, versionIDMarker string
 		for {
-			list, err := c.S3Client.ListObjectVersions(ctx, &s3.ListObjectVersionsInput{
+			input := &s3.ListObjectVersionsInput{
 				Bucket:  &bucket,
 				MaxKeys: batchSize,
 				Prefix:  &prefix,
-			})
+			}
+			if keyMarker != "" {
+				input.KeyMarker = &keyMarker
+			}
+			if versionIDMarker != "" {
+				input.VersionIdMarker = &versionIDMarker
+			}
+
+			list, err := c.S3Client.ListObjectVersions(ctx, input)
 			if err != nil {
 				errChan <- err
 				return
@@ -89,6 +98,23 @@ func (c *Client) DeleteObjectVersions(ctx context.Context, bucket, prefix string
 			}
 			for _, derror := range deleteResult.Errors {
 				errChan <- fmt.Errorf("delete error: %v", derror)
+			}
+
+			// If no objects were successfully deleted (e.g. all are compliance-locked),
+			// stop to avoid looping forever on the same objects.
+			if len(deleteResult.Deleted) == 0 {
+				return
+			}
+
+			// Advance pagination only when the list was truncated; otherwise the next
+			// ListObjectVersions call from the top of the loop is sufficient (deleted
+			// objects from this batch will no longer appear).
+			if list.IsTruncated {
+				keyMarker = aws.ToString(list.NextKeyMarker)
+				versionIDMarker = aws.ToString(list.NextVersionIdMarker)
+			} else {
+				keyMarker = ""
+				versionIDMarker = ""
 			}
 		}
 	}()

--- a/pkg/storage/sos/object_test.go
+++ b/pkg/storage/sos/object_test.go
@@ -612,3 +612,167 @@ func Test_IsTraversalPath(t *testing.T) {
 		})
 	}
 }
+
+// drainDeleteObjectVersions collects all results from the channels returned by
+// DeleteObjectVersions and returns the deleted objects and errors.
+func drainDeleteObjectVersions(deletedChan <-chan types.DeletedObject, errChan <-chan error) ([]types.DeletedObject, []error) {
+	var deleted []types.DeletedObject
+	var errs []error
+	for deletedChan != nil || errChan != nil {
+		select {
+		case d, ok := <-deletedChan:
+			if !ok {
+				deletedChan = nil
+				continue
+			}
+			deleted = append(deleted, d)
+		case e, ok := <-errChan:
+			if !ok {
+				errChan = nil
+				continue
+			}
+			errs = append(errs, e)
+		}
+	}
+	return deleted, errs
+}
+
+func TestDeleteObjectVersions_HappyPath(t *testing.T) {
+	bucket := "test-bucket"
+	listCalls := 0
+
+	client := sos.Client{
+		S3Client: &MockS3API{
+			mockListObjectVersions: func(_ context.Context, params *s3.ListObjectVersionsInput, _ ...func(*s3.Options)) (*s3.ListObjectVersionsOutput, error) {
+				listCalls++
+				if listCalls > 1 {
+					// Second call: nothing left.
+					return &s3.ListObjectVersionsOutput{}, nil
+				}
+				return &s3.ListObjectVersionsOutput{
+					IsTruncated: false,
+					Versions: []types.ObjectVersion{
+						{Key: aws.String("obj1"), VersionId: aws.String("v1")},
+						{Key: aws.String("obj2"), VersionId: aws.String("v2")},
+					},
+				}, nil
+			},
+			mockDeleteObjects: func(_ context.Context, params *s3.DeleteObjectsInput, _ ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error) {
+				return &s3.DeleteObjectsOutput{
+					Deleted: []types.DeletedObject{
+						{Key: aws.String("obj1"), VersionId: aws.String("v1")},
+						{Key: aws.String("obj2"), VersionId: aws.String("v2")},
+					},
+				}, nil
+			},
+		},
+	}
+
+	deleted, errs := drainDeleteObjectVersions(client.DeleteObjectVersions(context.Background(), bucket, "/"))
+	assert.Empty(t, errs)
+	assert.Len(t, deleted, 2)
+	assert.Equal(t, 2, listCalls, "should list twice: once for the batch, once to confirm empty")
+}
+
+// TestDeleteObjectVersions_ComplianceLock reproduces the customer bug: objects
+// under compliance retention cause DeleteObjects to return per-object errors
+// with an empty Deleted slice. Before the fix the goroutine looped forever
+// re-listing the same objects.
+func TestDeleteObjectVersions_ComplianceLock(t *testing.T) {
+	bucket := "locked-bucket"
+	listCalls := 0
+	deleteCalls := 0
+
+	client := sos.Client{
+		S3Client: &MockS3API{
+			mockListObjectVersions: func(_ context.Context, _ *s3.ListObjectVersionsInput, _ ...func(*s3.Options)) (*s3.ListObjectVersionsOutput, error) {
+				listCalls++
+				return &s3.ListObjectVersionsOutput{
+					IsTruncated: false,
+					Versions: []types.ObjectVersion{
+						{Key: aws.String("locked-obj"), VersionId: aws.String("v1")},
+					},
+				}, nil
+			},
+			mockDeleteObjects: func(_ context.Context, _ *s3.DeleteObjectsInput, _ ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error) {
+				deleteCalls++
+				// S3 returns HTTP 200 but with a per-object error; Deleted is empty.
+				return &s3.DeleteObjectsOutput{
+					Errors: []types.Error{
+						{
+							Key:       aws.String("locked-obj"),
+							VersionId: aws.String("v1"),
+							Code:      aws.String("ObjectLocked"),
+							Message:   aws.String("Object is under compliance retention"),
+						},
+					},
+				}, nil
+			},
+		},
+	}
+
+	deleted, errs := drainDeleteObjectVersions(client.DeleteObjectVersions(context.Background(), bucket, "/"))
+	assert.Empty(t, deleted)
+	assert.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Error(), "delete error:")
+	// Without the fix these would keep climbing; with the fix exactly one
+	// list+delete attempt is made before giving up.
+	assert.Equal(t, 1, listCalls, "should stop after first failed batch")
+	assert.Equal(t, 1, deleteCalls, "should stop after first failed batch")
+}
+
+// TestDeleteObjectVersions_Pagination verifies that a truncated
+// ListObjectVersions response is followed up with the correct KeyMarker and
+// VersionIdMarker on the next call. Before the fix pagination markers were
+// never forwarded, so only the first page was ever processed.
+func TestDeleteObjectVersions_Pagination(t *testing.T) {
+	bucket := "big-bucket"
+	listCalls := 0
+
+	client := sos.Client{
+		S3Client: &MockS3API{
+			mockListObjectVersions: func(_ context.Context, params *s3.ListObjectVersionsInput, _ ...func(*s3.Options)) (*s3.ListObjectVersionsOutput, error) {
+				listCalls++
+				switch listCalls {
+				case 1:
+					// First page: truncated.
+					assert.Empty(t, aws.ToString(params.KeyMarker))
+					assert.Empty(t, aws.ToString(params.VersionIdMarker))
+					return &s3.ListObjectVersionsOutput{
+						IsTruncated:         true,
+						NextKeyMarker:       aws.String("obj1"),
+						NextVersionIdMarker: aws.String("v1"),
+						Versions: []types.ObjectVersion{
+							{Key: aws.String("obj1"), VersionId: aws.String("v1")},
+						},
+					}, nil
+				case 2:
+					// Second page: markers must be set.
+					assert.Equal(t, "obj1", aws.ToString(params.KeyMarker))
+					assert.Equal(t, "v1", aws.ToString(params.VersionIdMarker))
+					return &s3.ListObjectVersionsOutput{
+						IsTruncated: false,
+						Versions: []types.ObjectVersion{
+							{Key: aws.String("obj2"), VersionId: aws.String("v2")},
+						},
+					}, nil
+				default:
+					// Third call: empty, signals end.
+					return &s3.ListObjectVersionsOutput{}, nil
+				}
+			},
+			mockDeleteObjects: func(_ context.Context, params *s3.DeleteObjectsInput, _ ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error) {
+				deleted := make([]types.DeletedObject, 0, len(params.Delete.Objects))
+				for _, o := range params.Delete.Objects {
+					deleted = append(deleted, types.DeletedObject{Key: o.Key, VersionId: o.VersionId})
+				}
+				return &s3.DeleteObjectsOutput{Deleted: deleted}, nil
+			},
+		},
+	}
+
+	deleted, errs := drainDeleteObjectVersions(client.DeleteObjectVersions(context.Background(), bucket, "/"))
+	assert.Empty(t, errs)
+	assert.Len(t, deleted, 2, "both pages should be processed")
+	assert.Equal(t, 3, listCalls, "should call list three times: page1, page2, confirm empty")
+}


### PR DESCRIPTION
Fixes `exo storage purge` hanging/looping silently on buckets with object lock compliance retention.

3 issues fixed:

1. **Infinite loop** (`pkg/storage/sos/object.go`)
When `DeleteObjects` returns HTTP 200 but with per-object errors (objects are compliance-locked), `deleteResult.Deleted` is empty but the goroutine looped back and re-listed the same objects forever. Now returns early when no objects were deleted in a batch.

2. **Missing pagination** (`pkg/storage/sos/object.go`)
`ListObjectVersions` was always called without `KeyMarker`/`VersionIdMarker`, so for buckets with more than 1000 versions, only the first page was ever processed. Pagination markers are now tracked and forwarded correctly.

3. **Select race on closed channel** (`cmd/storage/storage_purge.go`)
`case deletedElt := <-deletedChan` had no `ok` check. Once `deletedChan` closed, the scheduler could keep selecting it (zero value, silently dropped when not verbose) and never reach the `errChan` close that exits the loop. Fixed using the nil-channel pattern.