### PR TITLE
fix(e2e): drain PTY output before closing master fd

### DIFF
--- a/tests/e2e/testscript_test.go
+++ b/tests/e2e/testscript_test.go
@@ -139,8 +139,11 @@ func runInPTY(ts *testscript.TestScript, cmd *exec.Cmd, inputs <-chan ptyInput) 
 	}
 
 	_ = cmd.Wait()
+	// Drain before closing ptm: prevents a data-loss race with the collector goroutine.
+	// Child exit closes the slave fd, ptm.Read returns EIO, and <-outCh unblocks safely.
+	out := <-outCh
 	_ = ptm.Close()
-	return <-outCh
+	return out
 }
 
 // cmdExecPTY mirrors the built-in exec but runs the binary inside a PTY.


### PR DESCRIPTION
`runInPTY` closed the PTY master before draining `outCh`, racing with the collector goroutine. If `ptm.Read` was in-flight during `ptm.Close`, buffered bytes were silently dropped.

Fix: drain `outCh` first. After child exit the kernel closes the slave, so `ptm.Read` returns EIO once all buffered data is consumed, with no risk of deadlock.

Became visible with `add_cancel_during_secret` after #810 moved `os.Exit` to a signal goroutine, tightening the write-to-close window.

Tested: 20 consecutive `TestScriptsLocal` runs, all 22 subtests passed. Without the fix, ~2/5 runs failed on a loaded machine.