### PR TITLE
Migrate most list APIs to failure-resilient streaming utilities

### DIFF
--- a/cmd/aiservices/deployment/deployment_list.go
+++ b/cmd/aiservices/deployment/deployment_list.go
@@ -69,7 +69,11 @@ func runDeploymentList(c *DeploymentListCmd, stdout, stderr io.Writer) error {
 	defer sink.Flush()
 
 	streamer := output.NewStreamer(DeploymentListItemOutput{}, stdout)
-	defer func() { _ = streamer.Close() }()
+	defer func() {
+		if err := streamer.Close(); err != nil {
+			_, _ = fmt.Fprintf(stderr, "error: %s\n", err)
+		}
+	}()
 
 	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
 		func(ctx context.Context, zone v3.Zone) error {

--- a/cmd/aiservices/deployment/deployment_list.go
+++ b/cmd/aiservices/deployment/deployment_list.go
@@ -17,7 +17,7 @@ import (
 
 type DeploymentListItemOutput struct {
 	ID        v3.UUID                              `json:"id" outputWidth:"36"`
-	Name      string                               `json:"name" outputWidth:"38"`
+	Name      string                               `json:"name" outputWidth:"70"`
 	Zone      v3.ZoneName                          `json:"zone" outputWidth:"8"`
 	State     v3.ListDeploymentsResponseEntryState `json:"state" outputLabel:"Status" outputWidth:"6"`
 	GPUType   string                               `json:"gpu_type" outputWidth:"9"`

--- a/cmd/aiservices/deployment/instance_type_list.go
+++ b/cmd/aiservices/deployment/instance_type_list.go
@@ -58,7 +58,11 @@ func runInstanceTypeList(c *InstanceTypeListCmd, stdout, stderr io.Writer) error
 	defer sink.Flush()
 
 	streamer := output.NewStreamer(InstanceTypeListItemOutput{}, stdout)
-	defer func() { _ = streamer.Close() }()
+	defer func() {
+		if err := streamer.Close(); err != nil {
+			_, _ = fmt.Fprintf(stderr, "error: %s\n", err)
+		}
+	}()
 
 	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
 		func(ctx context.Context, zone v3.Zone) error {

--- a/cmd/aiservices/deployment/instance_type_list.go
+++ b/cmd/aiservices/deployment/instance_type_list.go
@@ -1,8 +1,10 @@
 package deployment
 
 import (
+	"context"
 	"fmt"
-	"sort"
+	"io"
+	"os"
 	"strings"
 
 	exocmd "github.com/exoscale/cli/cmd"
@@ -14,16 +16,10 @@ import (
 )
 
 type InstanceTypeListItemOutput struct {
-	Family     string `json:"family"`
-	Authorized bool   `json:"authorized"`
-	Zone       string `json:"zone"`
+	Family     string `json:"family" outputWidth:"16"`
+	Authorized bool   `json:"authorized" outputWidth:"10"`
+	Zone       string `json:"zone" outputWidth:"8"`
 }
-
-type InstanceTypeListOutput []InstanceTypeListItemOutput
-
-func (o *InstanceTypeListOutput) ToJSON()  { output.JSON(o) }
-func (o *InstanceTypeListOutput) ToText()  { output.Text(o) }
-func (o *InstanceTypeListOutput) ToTable() { output.Table(o) }
 
 type InstanceTypeListCmd struct {
 	exocmd.CliCommandSettings `cli-cmd:"-"`
@@ -39,12 +35,17 @@ func (c *InstanceTypeListCmd) CmdLong() string {
 	return fmt.Sprintf(`This command lists AI instance types.
 
 Supported output template annotations: %s`,
-		strings.Join(output.TemplateAnnotations(&InstanceTypeListOutput{}), ", "))
+		strings.Join(output.TemplateAnnotations(&InstanceTypeListItemOutput{}), ", "))
 }
 func (c *InstanceTypeListCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
 	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
+
 func (c *InstanceTypeListCmd) CmdRun(_ *cobra.Command, _ []string) error {
+	return runInstanceTypeList(c, os.Stdout, os.Stderr)
+}
+
+func runInstanceTypeList(c *InstanceTypeListCmd, stdout, stderr io.Writer) error {
 	ctx := exocmd.GContext
 	client := globalstate.EgoscaleV3Client
 
@@ -53,45 +54,39 @@ func (c *InstanceTypeListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	out := make(InstanceTypeListOutput, 0)
-	err = utils.ForEveryZone(zones, func(zone v3.Zone) error {
-		zoneClient := client.WithEndpoint(zone.APIEndpoint)
-		resp, err := zoneClient.ListAIInstanceTypes(ctx)
-		if err != nil {
-			return err
-		}
+	sink := utils.NewWarningSinkTo(stderr)
+	defer sink.Flush()
 
-		for _, it := range resp.InstanceTypes {
-			authorized := false
-			if it.Authorized != nil {
-				authorized = *it.Authorized
+	streamer := output.NewStreamer(InstanceTypeListItemOutput{}, stdout)
+	defer func() { _ = streamer.Close() }()
+
+	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
+		func(ctx context.Context, zone v3.Zone) error {
+			zc := client.WithEndpoint(zone.APIEndpoint)
+			resp, err := zc.ListAIInstanceTypes(ctx)
+			if err != nil {
+				return err
 			}
-			out = append(out, InstanceTypeListItemOutput{
-				Family:     it.Family,
-				Authorized: authorized,
-				Zone:       string(zone.Name),
-			})
-		}
+			for _, it := range resp.InstanceTypes {
+				authorized := false
+				if it.Authorized != nil {
+					authorized = *it.Authorized
+				}
+				if err := streamer.Push(InstanceTypeListItemOutput{
+					Family:     it.Family,
+					Authorized: authorized,
+					Zone:       string(zone.Name),
+				}); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
 
-		return nil
-	})
-
-	sortInstanceTypeListOutput(out)
-
-	return c.OutputFunc(&out, err)
-}
-
-// sortInstanceTypeListOutput sorts by zone then by family alphabetically.
-func sortInstanceTypeListOutput(out InstanceTypeListOutput) {
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].Zone < out[j].Zone {
-			return true
-		}
-		if out[i].Zone > out[j].Zone {
-			return false
-		}
-		return out[i].Family < out[j].Family
-	})
+	if failed > 0 {
+		return fmt.Errorf("%d zone(s) failed", failed)
+	}
+	return nil
 }
 
 func init() {

--- a/cmd/aiservices/deployment/instance_type_list_test.go
+++ b/cmd/aiservices/deployment/instance_type_list_test.go
@@ -65,8 +65,9 @@ func TestInstanceTypeList(t *testing.T) {
 	defer func() { globalstate.OutputFormat = "" }()
 
 	cmd := &InstanceTypeListCmd{CliCommandSettings: exocmd.DefaultCLICmdSettings()}
-	var outBuf bytes.Buffer
-	if err := runInstanceTypeList(cmd, &outBuf, nil); err != nil {
+	var outBuf, errBuf bytes.Buffer
+	if err := runInstanceTypeList(cmd, &outBuf, &errBuf); err != nil {
+		t.Errorf("%s", errBuf.String())
 		t.Fatalf("instance type list: %v", err)
 	}
 

--- a/cmd/aiservices/deployment/instance_type_list_test.go
+++ b/cmd/aiservices/deployment/instance_type_list_test.go
@@ -1,6 +1,7 @@
 package deployment
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 
 	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
-	"github.com/exoscale/cli/pkg/output"
 	v3 "github.com/exoscale/egoscale/v3"
 	"github.com/exoscale/egoscale/v3/credentials"
 )
@@ -61,49 +61,26 @@ func TestInstanceTypeList(t *testing.T) {
 		{Family: "gpu-a100", Authorized: &trueVal},
 	}
 
+	globalstate.OutputFormat = "json"
+	defer func() { globalstate.OutputFormat = "" }()
+
 	cmd := &InstanceTypeListCmd{CliCommandSettings: exocmd.DefaultCLICmdSettings()}
-	cmd.OutputFunc = func(out output.Outputter, err error) error {
-		if err != nil {
-			return err
-		}
-		o := out.(*InstanceTypeListOutput)
-		if len(*o) != 2 {
-			t.Fatalf("expected 2 instance types, got %d", len(*o))
-		}
-		if (*o)[0].Family != "gpu-a100" {
-			t.Errorf("expected first family gpu-a100, got %s", (*o)[0].Family)
-		}
-		if (*o)[1].Family != "gpu-a5000" {
-			t.Errorf("expected second family gpu-a5000, got %s", (*o)[1].Family)
-		}
-		return nil
-	}
-	if err := cmd.CmdRun(nil, nil); err != nil {
+	var outBuf bytes.Buffer
+	if err := runInstanceTypeList(cmd, &outBuf, nil); err != nil {
 		t.Fatalf("instance type list: %v", err)
 	}
-}
 
-func TestInstanceTypeListSortByZoneAndFamily(t *testing.T) {
-	out := InstanceTypeListOutput{
-		{Family: "gpu-a100", Authorized: true, Zone: "ch-gva-2"},
-		{Family: "gpu-a5000", Authorized: true, Zone: "ch-dk-2"},
-		{Family: "gpu-a100", Authorized: true, Zone: "ch-dk-2"},
-		{Family: "gpu-h100", Authorized: true, Zone: "ch-gva-2"},
+	var rows []InstanceTypeListItemOutput
+	if err := json.Unmarshal(outBuf.Bytes(), &rows); err != nil {
+		t.Fatalf("invalid json: %v\nstdout: %s", err, outBuf.String())
 	}
-
-	sortInstanceTypeListOutput(out)
-
-	if out[0].Zone != "ch-dk-2" || out[0].Family != "gpu-a100" {
-		t.Errorf("expected ch-dk-2/gpu-a100 first, got %s/%s", out[0].Zone, out[0].Family)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 instance types, got %d", len(rows))
 	}
-	if out[1].Zone != "ch-dk-2" || out[1].Family != "gpu-a5000" {
-		t.Errorf("expected ch-dk-2/gpu-a5000 second, got %s/%s", out[1].Zone, out[1].Family)
-	}
-	if out[2].Zone != "ch-gva-2" || out[2].Family != "gpu-a100" {
-		t.Errorf("expected ch-gva-2/gpu-a100 third, got %s/%s", out[2].Zone, out[2].Family)
-	}
-	if out[3].Zone != "ch-gva-2" || out[3].Family != "gpu-h100" {
-		t.Errorf("expected ch-gva-2/gpu-h100 fourth, got %s/%s", out[3].Zone, out[3].Family)
+	for _, r := range rows {
+		if r.Zone != "test-zone" {
+			t.Errorf("expected zone test-zone, got %s", r.Zone)
+		}
 	}
 }
 
@@ -123,7 +100,7 @@ func TestInstanceTypeListUsesZone(t *testing.T) {
 
 func TestInstanceTypeListOutputToJSON(t *testing.T) {
 	trueVal := true
-	out := InstanceTypeListOutput{
+	out := []InstanceTypeListItemOutput{
 		{Family: "gpu-a100", Authorized: trueVal, Zone: "ch-gva-2"},
 		{Family: "gpu-a5000", Authorized: false, Zone: "ch-gva-2"},
 	}

--- a/cmd/aiservices/model/model_list.go
+++ b/cmd/aiservices/model/model_list.go
@@ -61,7 +61,11 @@ func runModelList(c *ModelListCmd, stdout, stderr io.Writer) error {
 	defer sink.Flush()
 
 	streamer := output.NewStreamer(ModelListItemOutput{}, stdout)
-	defer func() { _ = streamer.Close() }()
+	defer func() {
+		if err := streamer.Close(); err != nil {
+			_, _ = fmt.Fprintf(stderr, "error: %s\n", err)
+		}
+	}()
 
 	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
 		func(ctx context.Context, zone v3.Zone) error {

--- a/cmd/aiservices/model/model_list.go
+++ b/cmd/aiservices/model/model_list.go
@@ -18,7 +18,7 @@ import (
 
 type ModelListItemOutput struct {
 	ID        v3.UUID                         `json:"id" outputWidth:"36"`
-	Name      string                          `json:"name" outputWidth:"38"`
+	Name      string                          `json:"name" outputWidth:"70"`
 	Zone      v3.ZoneName                     `json:"zone" outputWidth:"8"`
 	State     v3.ListModelsResponseEntryState `json:"state" outputLabel:"Status" outputWidth:"14"`
 	ModelSize string                          `json:"model_size" outputLabel:"Size" outputWidth:"12"`

--- a/cmd/aiservices/model/model_list.go
+++ b/cmd/aiservices/model/model_list.go
@@ -1,7 +1,10 @@
 package model
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	"github.com/dustin/go-humanize"
@@ -14,18 +17,12 @@ import (
 )
 
 type ModelListItemOutput struct {
-	ID        v3.UUID                         `json:"id"`
-	Name      string                          `json:"name"`
-	Zone      v3.ZoneName                     `json:"zone"`
-	State     v3.ListModelsResponseEntryState `json:"state" outputLabel:"Status"`
-	ModelSize string                          `json:"model_size" outputLabel:"Size"`
+	ID        v3.UUID                         `json:"id" outputWidth:"36"`
+	Name      string                          `json:"name" outputWidth:"38"`
+	Zone      v3.ZoneName                     `json:"zone" outputWidth:"8"`
+	State     v3.ListModelsResponseEntryState `json:"state" outputLabel:"Status" outputWidth:"14"`
+	ModelSize string                          `json:"model_size" outputLabel:"Size" outputWidth:"12"`
 }
-
-type ModelListOutput []ModelListItemOutput
-
-func (o *ModelListOutput) ToJSON()  { output.JSON(o) }
-func (o *ModelListOutput) ToText()  { output.Text(o) }
-func (o *ModelListOutput) ToTable() { output.Table(o) }
 
 type ModelListCmd struct {
 	exocmd.CliCommandSettings `cli-cmd:"-"`
@@ -41,12 +38,17 @@ func (c *ModelListCmd) CmdLong() string {
 	return fmt.Sprintf(`This command lists AI models.
 
 Supported output template annotations: %s`,
-		strings.Join(output.TemplateAnnotations(&ModelListOutput{}), ", "))
+		strings.Join(output.TemplateAnnotations(&ModelListItemOutput{}), ", "))
 }
 func (c *ModelListCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
 	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
+
 func (c *ModelListCmd) CmdRun(_ *cobra.Command, _ []string) error {
+	return runModelList(c, os.Stdout, os.Stderr)
+}
+
+func runModelList(c *ModelListCmd, stdout, stderr io.Writer) error {
 	ctx := exocmd.GContext
 	client := globalstate.EgoscaleV3Client
 
@@ -55,32 +57,41 @@ func (c *ModelListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	out := make(ModelListOutput, 0)
-	err = utils.ForEveryZone(zones, func(zone v3.Zone) error {
-		c := client.WithEndpoint(zone.APIEndpoint)
-		resp, err := c.ListModels(ctx)
-		if err != nil {
-			return err
-		}
+	sink := utils.NewWarningSinkTo(stderr)
+	defer sink.Flush()
 
-		for _, m := range resp.Models {
-			var size string
-			if m.ModelSize != 0 {
-				size = humanize.IBytes(uint64(m.ModelSize))
+	streamer := output.NewStreamer(ModelListItemOutput{}, stdout)
+	defer func() { _ = streamer.Close() }()
+
+	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
+		func(ctx context.Context, zone v3.Zone) error {
+			zc := client.WithEndpoint(zone.APIEndpoint)
+			resp, err := zc.ListModels(ctx)
+			if err != nil {
+				return err
 			}
-			out = append(out, ModelListItemOutput{
-				ID:        m.ID,
-				Name:      m.Name,
-				Zone:      zone.Name,
-				State:     m.State,
-				ModelSize: size,
-			})
-		}
+			for _, m := range resp.Models {
+				var size string
+				if m.ModelSize != 0 {
+					size = humanize.IBytes(uint64(m.ModelSize))
+				}
+				if err := streamer.Push(ModelListItemOutput{
+					ID:        m.ID,
+					Name:      m.Name,
+					Zone:      zone.Name,
+					State:     m.State,
+					ModelSize: size,
+				}); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
 
-		return nil
-	})
-
-	return c.OutputFunc(&out, err)
+	if failed > 0 {
+		return fmt.Errorf("%d zone(s) failed", failed)
+	}
+	return nil
 }
 
 func init() {

--- a/cmd/aiservices/model/model_list_test.go
+++ b/cmd/aiservices/model/model_list_test.go
@@ -1,7 +1,9 @@
 package model
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"path"
@@ -11,7 +13,6 @@ import (
 
 	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
-	"github.com/exoscale/cli/pkg/output"
 	v3 "github.com/exoscale/egoscale/v3"
 	"github.com/exoscale/egoscale/v3/credentials"
 )
@@ -73,6 +74,17 @@ func setupModelList(t *testing.T, ts *modelListTestServer) func() {
 	return func() { ts.server.Close() }
 }
 
+func runModelListTest(t *testing.T, zoneFilter v3.ZoneName) (stdout, stderr string, err error) {
+	t.Helper()
+	var outBuf, errBuf bytes.Buffer
+	cmd := &ModelListCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
+		Zone:               zoneFilter,
+	}
+	err = runModelList(cmd, &outBuf, &errBuf)
+	return outBuf.String(), errBuf.String(), err
+}
+
 func TestModelList(t *testing.T) {
 	ts := newModelListTestServer(t)
 	defer setupModelList(t, ts)()
@@ -81,30 +93,30 @@ func TestModelList(t *testing.T) {
 		{ID: v3.UUID("11111111-1111-1111-1111-111111111111"), Name: "m1", State: v3.ListModelsResponseEntryStateReady, ModelSize: 0, CreatedAT: now, UpdatedAT: now},
 		{ID: v3.UUID("22222222-2222-2222-2222-222222222222"), Name: "m2", State: v3.ListModelsResponseEntryStateCreating, ModelSize: 1024 * 1024 * 1024, CreatedAT: now, UpdatedAT: now},
 	}
-	cmd := &ModelListCmd{CliCommandSettings: exocmd.DefaultCLICmdSettings()}
-	cmd.OutputFunc = func(out output.Outputter, err error) error {
-		if err != nil {
-			return err
-		}
-		o := out.(*ModelListOutput)
-		if len(*o) != 2 {
-			t.Fatalf("expected 2 models, got %d", len(*o))
-		}
-		for _, m := range *o {
-			if m.Zone != "test-zone" {
-				t.Errorf("expected zone %q, got %q", "test-zone", m.Zone)
-			}
-			if m.Name == "m1" && m.ModelSize != "" {
-				t.Errorf("expected m1 size empty, got %q", m.ModelSize)
-			}
-			if m.Name == "m2" && m.ModelSize != "1.0 GiB" {
-				t.Errorf("expected m2 size 1.0 GiB, got %q", m.ModelSize)
-			}
-		}
-		return nil
-	}
-	if err := cmd.CmdRun(nil, nil); err != nil {
+	defer withFormat(t, "json")()
+
+	stdout, _, err := runModelListTest(t, "")
+	if err != nil {
 		t.Fatalf("model list: %v", err)
+	}
+
+	var rows []ModelListItemOutput
+	if err := json.Unmarshal([]byte(stdout), &rows); err != nil {
+		t.Fatalf("invalid json: %v\nstdout: %s", err, stdout)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(rows))
+	}
+	for _, m := range rows {
+		if m.Zone != "test-zone" {
+			t.Errorf("expected zone %q, got %q", "test-zone", m.Zone)
+		}
+		if m.Name == "m1" && m.ModelSize != "" {
+			t.Errorf("expected m1 size empty, got %q", m.ModelSize)
+		}
+		if m.Name == "m2" && m.ModelSize != "1.0 GiB" {
+			t.Errorf("expected m2 size 1.0 GiB, got %q", m.ModelSize)
+		}
 	}
 }
 
@@ -128,16 +140,19 @@ func TestModelListOutput_ToJSON(t *testing.T) {
 		{ID: v3.UUID("11111111-1111-1111-1111-111111111111"), Name: "m1", State: v3.ListModelsResponseEntryStateReady, ModelSize: 1000, CreatedAT: now, UpdatedAT: now},
 		{ID: v3.UUID("22222222-2222-2222-2222-222222222222"), Name: "m2", State: v3.ListModelsResponseEntryStateCreating, ModelSize: 0, CreatedAT: now, UpdatedAT: now},
 	}
-	cmd := &ModelListCmd{CliCommandSettings: exocmd.DefaultCLICmdSettings()}
-	cmd.OutputFunc = func(out output.Outputter, err error) error {
-		if err != nil {
-			return err
-		}
-		out.ToJSON()
-		return nil
-	}
-	if err := cmd.CmdRun(nil, nil); err != nil {
+	defer withFormat(t, "json")()
+
+	stdout, _, err := runModelListTest(t, "")
+	if err != nil {
 		t.Fatalf("model list: %v", err)
+	}
+
+	var rows []ModelListItemOutput
+	if err := json.Unmarshal([]byte(stdout), &rows); err != nil {
+		t.Fatalf("invalid json: %v\nstdout: %s", err, stdout)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(rows))
 	}
 }
 
@@ -147,4 +162,32 @@ func TestModelListCmd_CmdShort(t *testing.T) {
 	if short == "" {
 		t.Fatal("CmdShort() returned empty string")
 	}
+}
+
+func TestModelList_ZoneEmpty(t *testing.T) {
+	ts := newModelListTestServer(t)
+	defer setupModelList(t, ts)()
+	defer withFormat(t, "json")()
+	ts.models = nil
+
+	stdout, _, err := runModelListTest(t, "")
+	if err != nil {
+		t.Fatalf("model list: %v", err)
+	}
+
+	var rows []ModelListItemOutput
+	if err := json.Unmarshal([]byte(stdout), &rows); err != nil {
+		t.Fatalf("invalid json: %v\nstdout: %s", err, stdout)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected 0 models, got %d", len(rows))
+	}
+}
+
+// withFormat sets globalstate.OutputFormat for the duration of a test.
+func withFormat(t *testing.T, f string) func() {
+	t.Helper()
+	prev := globalstate.OutputFormat
+	globalstate.OutputFormat = f
+	return func() { globalstate.OutputFormat = prev }
 }

--- a/cmd/aiservices/model/model_list_test.go
+++ b/cmd/aiservices/model/model_list_test.go
@@ -132,30 +132,6 @@ func TestModelListUsesZone(t *testing.T) {
 	}
 }
 
-func TestModelListOutput_ToJSON(t *testing.T) {
-	ts := newModelListTestServer(t)
-	defer setupModelList(t, ts)()
-	now := time.Now()
-	ts.models = []v3.ListModelsResponseEntry{
-		{ID: v3.UUID("11111111-1111-1111-1111-111111111111"), Name: "m1", State: v3.ListModelsResponseEntryStateReady, ModelSize: 1000, CreatedAT: now, UpdatedAT: now},
-		{ID: v3.UUID("22222222-2222-2222-2222-222222222222"), Name: "m2", State: v3.ListModelsResponseEntryStateCreating, ModelSize: 0, CreatedAT: now, UpdatedAT: now},
-	}
-	defer withFormat(t, "json")()
-
-	stdout, _, err := runModelListTest(t, "")
-	if err != nil {
-		t.Fatalf("model list: %v", err)
-	}
-
-	var rows []ModelListItemOutput
-	if err := json.Unmarshal([]byte(stdout), &rows); err != nil {
-		t.Fatalf("invalid json: %v\nstdout: %s", err, stdout)
-	}
-	if len(rows) != 2 {
-		t.Fatalf("expected 2 models, got %d", len(rows))
-	}
-}
-
 func TestModelListCmd_CmdShort(t *testing.T) {
 	cmd := &ModelListCmd{CliCommandSettings: exocmd.DefaultCLICmdSettings()}
 	short := cmd.CmdShort()

--- a/cmd/compute/deploy_target/deploy_target_list.go
+++ b/cmd/compute/deploy_target/deploy_target_list.go
@@ -19,7 +19,7 @@ import (
 type deployTargetListItemOutput struct {
 	Zone v3.ZoneName `json:"zone" outputWidth:"8"`
 	ID   v3.UUID     `json:"id" outputWidth:"36"`
-	Name string      `json:"name" outputWidth:"38"`
+	Name string      `json:"name" outputWidth:"70"`
 	Type string      `json:"type" outputWidth:"16"`
 }
 

--- a/cmd/compute/deploy_target/deploy_target_list.go
+++ b/cmd/compute/deploy_target/deploy_target_list.go
@@ -1,7 +1,9 @@
 package deploy_target
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -15,17 +17,11 @@ import (
 )
 
 type deployTargetListItemOutput struct {
-	Zone v3.ZoneName `json:"zone"`
-	ID   v3.UUID     `json:"id"`
-	Name string      `json:"name"`
-	Type string      `json:"type"`
+	Zone v3.ZoneName `json:"zone" outputWidth:"8"`
+	ID   v3.UUID     `json:"id" outputWidth:"36"`
+	Name string      `json:"name" outputWidth:"38"`
+	Type string      `json:"type" outputWidth:"16"`
 }
-
-type deployTargetListOutput []deployTargetListItemOutput
-
-func (o *deployTargetListOutput) ToJSON()  { output.JSON(o) }
-func (o *deployTargetListOutput) ToText()  { output.Text(o) }
-func (o *deployTargetListOutput) ToTable() { output.Table(o) }
 
 type deployTargetListCmd struct {
 	exocmd.CliCommandSettings `cli-cmd:"-"`
@@ -43,7 +39,7 @@ func (c *deployTargetListCmd) CmdLong() string {
 	return fmt.Sprintf(`This command lists existing Deploy Targets.
 
 Supported output template annotations: %s`,
-		strings.Join(output.TemplateAnnotations(&deployTargetListOutput{}), ", "))
+		strings.Join(output.TemplateAnnotations(&deployTargetListItemOutput{}), ", "))
 }
 
 func (c *deployTargetListCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
@@ -51,6 +47,10 @@ func (c *deployTargetListCmd) CmdPreRun(cmd *cobra.Command, args []string) error
 }
 
 func (c *deployTargetListCmd) CmdRun(_ *cobra.Command, _ []string) error {
+	return runDeployTargetList(c, os.Stdout, os.Stderr)
+}
+
+func runDeployTargetList(c *deployTargetListCmd, stdout, stderr io.Writer) error {
 	client := globalstate.EgoscaleV3Client
 	ctx := exocmd.GContext
 
@@ -59,44 +59,36 @@ func (c *deployTargetListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	out := make(deployTargetListOutput, 0)
-	res := make(chan deployTargetListItemOutput)
-	done := make(chan struct{})
+	sink := utils.NewWarningSinkTo(stderr)
+	defer sink.Flush()
 
-	go func() {
-		for dt := range res {
-			out = append(out, dt)
-		}
-		done <- struct{}{}
-	}()
+	streamer := output.NewStreamer(deployTargetListItemOutput{}, stdout)
+	defer func() { _ = streamer.Close() }()
 
-	err = utils.ForEveryZone(zones, func(zone v3.Zone) error {
-		c := client.WithEndpoint(zone.APIEndpoint)
-		list, err := c.ListDeployTargets(ctx)
-		if err != nil {
-			return fmt.Errorf("unable to list Deploy Targets in zone %s: %w", zone, err)
-		}
-
-		for _, dt := range list.DeployTargets {
-			res <- deployTargetListItemOutput{
-				ID:   dt.ID,
-				Name: dt.Name,
-				Type: string(dt.Type),
-				Zone: zone.Name,
+	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
+		func(ctx context.Context, zone v3.Zone) error {
+			zc := client.WithEndpoint(zone.APIEndpoint)
+			list, err := zc.ListDeployTargets(ctx)
+			if err != nil {
+				return fmt.Errorf("unable to list Deploy Targets in zone %s: %w", zone, err)
 			}
-		}
+			for _, dt := range list.DeployTargets {
+				if err := streamer.Push(deployTargetListItemOutput{
+					ID:   dt.ID,
+					Name: dt.Name,
+					Type: string(dt.Type),
+					Zone: zone.Name,
+				}); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
 
-		return nil
-	})
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr,
-			"warning: errors during listing, results might be incomplete.\n%s\n", err) // nolint:golint
+	if failed > 0 {
+		return fmt.Errorf("%d zone(s) failed", failed)
 	}
-
-	close(res)
-	<-done
-
-	return c.OutputFunc(&out, nil)
+	return nil
 }
 
 func init() {

--- a/cmd/compute/deploy_target/deploy_target_list.go
+++ b/cmd/compute/deploy_target/deploy_target_list.go
@@ -63,7 +63,11 @@ func runDeployTargetList(c *deployTargetListCmd, stdout, stderr io.Writer) error
 	defer sink.Flush()
 
 	streamer := output.NewStreamer(deployTargetListItemOutput{}, stdout)
-	defer func() { _ = streamer.Close() }()
+	defer func() {
+		if err := streamer.Close(); err != nil {
+			_, _ = fmt.Fprintf(stderr, "error: %s\n", err)
+		}
+	}()
 
 	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
 		func(ctx context.Context, zone v3.Zone) error {

--- a/cmd/compute/elastic_ip/elastic_ip_list.go
+++ b/cmd/compute/elastic_ip/elastic_ip_list.go
@@ -1,7 +1,9 @@
 package elastic_ip
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -15,18 +17,12 @@ import (
 )
 
 type elasticIPListItemOutput struct {
-	ID          v3.UUID     `json:"id"`
-	IPAddress   string      `json:"ip_address"`
-	Description string      `json:"description"`
-	Type        string      `json:"type"`
-	Zone        v3.ZoneName `json:"zone"`
+	ID          v3.UUID     `json:"id" outputWidth:"36"`
+	IPAddress   string      `json:"ip_address" outputWidth:"18"`
+	Description string      `json:"description" outputWidth:"40"`
+	Type        string      `json:"type" outputWidth:"10"`
+	Zone        v3.ZoneName `json:"zone" outputWidth:"8"`
 }
-
-type elasticIPListOutput []elasticIPListItemOutput
-
-func (o *elasticIPListOutput) ToJSON()  { output.JSON(o) }
-func (o *elasticIPListOutput) ToText()  { output.Text(o) }
-func (o *elasticIPListOutput) ToTable() { output.Table(o) }
 
 type elasticIPListCmd struct {
 	exocmd.CliCommandSettings `cli-cmd:"-"`
@@ -52,6 +48,10 @@ func (c *elasticIPListCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
 }
 
 func (c *elasticIPListCmd) CmdRun(_ *cobra.Command, _ []string) error {
+	return runElasticIPList(c, os.Stdout, os.Stderr)
+}
+
+func runElasticIPList(c *elasticIPListCmd, stdout, stderr io.Writer) error {
 	client := globalstate.EgoscaleV3Client
 	ctx := exocmd.GContext
 
@@ -60,51 +60,43 @@ func (c *elasticIPListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	out := make(elasticIPListOutput, 0)
-	res := make(chan elasticIPListItemOutput)
-	done := make(chan struct{})
+	sink := utils.NewWarningSinkTo(stderr)
+	defer sink.Flush()
 
-	go func() {
-		for nlb := range res {
-			out = append(out, nlb)
-		}
-		done <- struct{}{}
-	}()
-	err = utils.ForEveryZone(zones, func(zone v3.Zone) error {
-		c := client.WithEndpoint(zone.APIEndpoint)
-		list, err := c.ListElasticIPS(ctx)
+	streamer := output.NewStreamer(elasticIPListItemOutput{}, stdout)
+	defer func() { _ = streamer.Close() }()
 
-		if err != nil {
-			return fmt.Errorf("unable to list Elastic IP addresses in zone %s: %w", zone, err)
-		}
-
-		if list != nil {
-			for _, e := range list.ElasticIPS {
-				eipType := "Manual"
-				if e.Healthcheck != nil {
-					eipType = "Managed"
-				}
-				res <- elasticIPListItemOutput{
-					ID:          e.ID,
-					IPAddress:   e.IP,
-					Description: e.Description,
-					Type:        eipType,
-					Zone:        zone.Name,
+	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
+		func(ctx context.Context, zone v3.Zone) error {
+			zc := client.WithEndpoint(zone.APIEndpoint)
+			list, err := zc.ListElasticIPS(ctx)
+			if err != nil {
+				return fmt.Errorf("unable to list Elastic IP addresses in zone %s: %w", zone, err)
+			}
+			if list != nil {
+				for _, e := range list.ElasticIPS {
+					eipType := "Manual"
+					if e.Healthcheck != nil {
+						eipType = "Managed"
+					}
+					if err := streamer.Push(elasticIPListItemOutput{
+						ID:          e.ID,
+						IPAddress:   e.IP,
+						Description: e.Description,
+						Type:        eipType,
+						Zone:        zone.Name,
+					}); err != nil {
+						return err
+					}
 				}
 			}
+			return nil
+		})
 
-		}
-		return nil
-	})
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr,
-			"warning: errors during listing, results might be incomplete.\n%s\n", err) // nolint:golint
+	if failed > 0 {
+		return fmt.Errorf("%d zone(s) failed", failed)
 	}
-
-	close(res)
-	<-done
-
-	return c.OutputFunc(&out, nil)
+	return nil
 }
 
 func init() {

--- a/cmd/compute/elastic_ip/elastic_ip_list.go
+++ b/cmd/compute/elastic_ip/elastic_ip_list.go
@@ -64,7 +64,11 @@ func runElasticIPList(c *elasticIPListCmd, stdout, stderr io.Writer) error {
 	defer sink.Flush()
 
 	streamer := output.NewStreamer(elasticIPListItemOutput{}, stdout)
-	defer func() { _ = streamer.Close() }()
+	defer func() {
+		if err := streamer.Close(); err != nil {
+			_, _ = fmt.Fprintf(stderr, "error: %s\n", err)
+		}
+	}()
 
 	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
 		func(ctx context.Context, zone v3.Zone) error {

--- a/cmd/compute/elastic_ip/elastic_ip_list.go
+++ b/cmd/compute/elastic_ip/elastic_ip_list.go
@@ -19,7 +19,7 @@ import (
 type elasticIPListItemOutput struct {
 	ID          v3.UUID     `json:"id" outputWidth:"36"`
 	IPAddress   string      `json:"ip_address" outputWidth:"18"`
-	Description string      `json:"description" outputWidth:"40"`
+	Description string      `json:"description" outputWidth:"70"`
 	Type        string      `json:"type" outputWidth:"10"`
 	Zone        v3.ZoneName `json:"zone" outputWidth:"8"`
 }

--- a/cmd/compute/instance_pool/instance_pool_list.go
+++ b/cmd/compute/instance_pool/instance_pool_list.go
@@ -1,7 +1,9 @@
 package instance_pool
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -15,18 +17,12 @@ import (
 )
 
 type instancePoolListItemOutput struct {
-	ID    v3.UUID     `json:"id"`
-	Name  string      `json:"name"`
-	Zone  v3.ZoneName `json:"zone"`
-	Size  int64       `json:"size"`
-	State string      `json:"state"`
+	ID    v3.UUID     `json:"id" outputWidth:"36"`
+	Name  string      `json:"name" outputWidth:"38"`
+	Zone  v3.ZoneName `json:"zone" outputWidth:"8"`
+	Size  int64       `json:"size" outputWidth:"4"`
+	State string      `json:"state" outputWidth:"12"`
 }
-
-type instancePoolListOutput []instancePoolListItemOutput
-
-func (o *instancePoolListOutput) ToJSON()  { output.JSON(o) }
-func (o *instancePoolListOutput) ToText()  { output.Text(o) }
-func (o *instancePoolListOutput) ToTable() { output.Table(o) }
 
 type instancePoolListCmd struct {
 	exocmd.CliCommandSettings `cli-cmd:"-"`
@@ -52,6 +48,10 @@ func (c *instancePoolListCmd) CmdPreRun(cmd *cobra.Command, args []string) error
 }
 
 func (c *instancePoolListCmd) CmdRun(_ *cobra.Command, _ []string) error {
+	return runInstancePoolList(c, os.Stdout, os.Stderr)
+}
+
+func runInstancePoolList(c *instancePoolListCmd, stdout, stderr io.Writer) error {
 	client := globalstate.EgoscaleV3Client
 	ctx := exocmd.GContext
 
@@ -60,45 +60,37 @@ func (c *instancePoolListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	out := make(instancePoolListOutput, 0)
-	res := make(chan instancePoolListItemOutput)
-	done := make(chan struct{})
+	sink := utils.NewWarningSinkTo(stderr)
+	defer sink.Flush()
 
-	go func() {
-		for instancePool := range res {
-			out = append(out, instancePool)
-		}
-		done <- struct{}{}
-	}()
-	err = utils.ForEveryZone(zones, func(zone v3.Zone) error {
-		c := client.WithEndpoint(zone.APIEndpoint)
-		list, err := c.ListInstancePools(ctx)
+	streamer := output.NewStreamer(instancePoolListItemOutput{}, stdout)
+	defer func() { _ = streamer.Close() }()
 
-		if err != nil {
-			return fmt.Errorf("unable to list Instance Pools in zone %s: %w", zone, err)
-		}
-
-		for _, i := range list.InstancePools {
-			res <- instancePoolListItemOutput{
-				ID:    i.ID,
-				Name:  i.Name,
-				Zone:  zone.Name,
-				Size:  i.Size,
-				State: string(i.State),
+	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
+		func(ctx context.Context, zone v3.Zone) error {
+			zc := client.WithEndpoint(zone.APIEndpoint)
+			list, err := zc.ListInstancePools(ctx)
+			if err != nil {
+				return fmt.Errorf("unable to list Instance Pools in zone %s: %w", zone, err)
 			}
-		}
+			for _, i := range list.InstancePools {
+				if err := streamer.Push(instancePoolListItemOutput{
+					ID:    i.ID,
+					Name:  i.Name,
+					Zone:  zone.Name,
+					Size:  i.Size,
+					State: string(i.State),
+				}); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
 
-		return nil
-	})
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr,
-			"warning: errors during listing, results might be incomplete.\n%s\n", err) // nolint:golint
+	if failed > 0 {
+		return fmt.Errorf("%d zone(s) failed", failed)
 	}
-
-	close(res)
-	<-done
-
-	return c.OutputFunc(&out, nil)
+	return nil
 }
 
 func init() {

--- a/cmd/compute/instance_pool/instance_pool_list.go
+++ b/cmd/compute/instance_pool/instance_pool_list.go
@@ -64,7 +64,11 @@ func runInstancePoolList(c *instancePoolListCmd, stdout, stderr io.Writer) error
 	defer sink.Flush()
 
 	streamer := output.NewStreamer(instancePoolListItemOutput{}, stdout)
-	defer func() { _ = streamer.Close() }()
+	defer func() {
+		if err := streamer.Close(); err != nil {
+			_, _ = fmt.Fprintf(stderr, "error: %s\n", err)
+		}
+	}()
 
 	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
 		func(ctx context.Context, zone v3.Zone) error {

--- a/cmd/compute/instance_pool/instance_pool_list.go
+++ b/cmd/compute/instance_pool/instance_pool_list.go
@@ -18,7 +18,7 @@ import (
 
 type instancePoolListItemOutput struct {
 	ID    v3.UUID     `json:"id" outputWidth:"36"`
-	Name  string      `json:"name" outputWidth:"38"`
+	Name  string      `json:"name" outputWidth:"70"`
 	Zone  v3.ZoneName `json:"zone" outputWidth:"8"`
 	Size  int64       `json:"size" outputWidth:"4"`
 	State string      `json:"state" outputWidth:"12"`

--- a/cmd/compute/load_balancer/nlb_list.go
+++ b/cmd/compute/load_balancer/nlb_list.go
@@ -18,7 +18,7 @@ import (
 
 type nlbListItemOutput struct {
 	ID        v3.UUID     `json:"id" outputWidth:"36"`
-	Name      string      `json:"name" outputWidth:"38"`
+	Name      string      `json:"name" outputWidth:"70"`
 	Zone      v3.ZoneName `json:"zone" outputWidth:"8"`
 	IPAddress string      `json:"ip_address" outputWidth:"18"`
 }

--- a/cmd/compute/load_balancer/nlb_list.go
+++ b/cmd/compute/load_balancer/nlb_list.go
@@ -63,7 +63,11 @@ func runNlbList(c *nlbListCmd, stdout, stderr io.Writer) error {
 	defer sink.Flush()
 
 	streamer := output.NewStreamer(nlbListItemOutput{}, stdout)
-	defer func() { _ = streamer.Close() }()
+	defer func() {
+		if err := streamer.Close(); err != nil {
+			_, _ = fmt.Fprintf(stderr, "error: %s\n", err)
+		}
+	}()
 
 	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
 		func(ctx context.Context, zone v3.Zone) error {

--- a/cmd/compute/load_balancer/nlb_list.go
+++ b/cmd/compute/load_balancer/nlb_list.go
@@ -1,7 +1,9 @@
 package load_balancer
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -15,17 +17,11 @@ import (
 )
 
 type nlbListItemOutput struct {
-	ID        v3.UUID     `json:"id"`
-	Name      string      `json:"name"`
-	Zone      v3.ZoneName `json:"zone"`
-	IPAddress string      `json:"ip_address"`
+	ID        v3.UUID     `json:"id" outputWidth:"36"`
+	Name      string      `json:"name" outputWidth:"38"`
+	Zone      v3.ZoneName `json:"zone" outputWidth:"8"`
+	IPAddress string      `json:"ip_address" outputWidth:"18"`
 }
-
-type nlbListOutput []nlbListItemOutput
-
-func (o *nlbListOutput) ToJSON()  { output.JSON(o) }
-func (o *nlbListOutput) ToText()  { output.Text(o) }
-func (o *nlbListOutput) ToTable() { output.Table(o) }
 
 type nlbListCmd struct {
 	exocmd.CliCommandSettings `cli-cmd:"-"`
@@ -51,6 +47,10 @@ func (c *nlbListCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
 }
 
 func (c *nlbListCmd) CmdRun(_ *cobra.Command, _ []string) error {
+	return runNlbList(c, os.Stdout, os.Stderr)
+}
+
+func runNlbList(c *nlbListCmd, stdout, stderr io.Writer) error {
 	client := globalstate.EgoscaleV3Client
 	ctx := exocmd.GContext
 
@@ -59,43 +59,36 @@ func (c *nlbListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	out := make(nlbListOutput, 0)
-	res := make(chan nlbListItemOutput)
-	done := make(chan struct{})
+	sink := utils.NewWarningSinkTo(stderr)
+	defer sink.Flush()
 
-	go func() {
-		for nlb := range res {
-			out = append(out, nlb)
-		}
-		done <- struct{}{}
-	}()
-	err = utils.ForEveryZone(zones, func(zone v3.Zone) error {
-		c := client.WithEndpoint(zone.APIEndpoint)
-		list, err := c.ListLoadBalancers(ctx)
-		if err != nil {
-			return fmt.Errorf("unable to list Network Load Balancers in zone %s: %w", zone, err)
-		}
+	streamer := output.NewStreamer(nlbListItemOutput{}, stdout)
+	defer func() { _ = streamer.Close() }()
 
-		for _, nlb := range list.LoadBalancers {
-			res <- nlbListItemOutput{
-				ID:        nlb.ID,
-				Name:      nlb.Name,
-				Zone:      zone.Name,
-				IPAddress: nlb.IP.String(),
+	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
+		func(ctx context.Context, zone v3.Zone) error {
+			zc := client.WithEndpoint(zone.APIEndpoint)
+			list, err := zc.ListLoadBalancers(ctx)
+			if err != nil {
+				return fmt.Errorf("unable to list Network Load Balancers in zone %s: %w", zone, err)
 			}
-		}
+			for _, nlb := range list.LoadBalancers {
+				if err := streamer.Push(nlbListItemOutput{
+					ID:        nlb.ID,
+					Name:      nlb.Name,
+					Zone:      zone.Name,
+					IPAddress: nlb.IP.String(),
+				}); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
 
-		return nil
-	})
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr,
-			"warning: errors during listing, results might be incomplete.\n%s\n", err) // nolint:golint
+	if failed > 0 {
+		return fmt.Errorf("%d zone(s) failed", failed)
 	}
-
-	close(res)
-	<-done
-
-	return c.OutputFunc(&out, nil)
+	return nil
 }
 
 func init() {

--- a/cmd/compute/private_network/private_network_list.go
+++ b/cmd/compute/private_network/private_network_list.go
@@ -1,7 +1,9 @@
 package private_network
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -15,16 +17,10 @@ import (
 )
 
 type privateNetworkListItemOutput struct {
-	ID   v3.UUID     `json:"id"`
-	Name string      `json:"name"`
-	Zone v3.ZoneName `json:"zone"`
+	ID   v3.UUID     `json:"id" outputWidth:"36"`
+	Name string      `json:"name" outputWidth:"38"`
+	Zone v3.ZoneName `json:"zone" outputWidth:"8"`
 }
-
-type privateNetworkListOutput []privateNetworkListItemOutput
-
-func (o *privateNetworkListOutput) ToJSON()  { output.JSON(o) }
-func (o *privateNetworkListOutput) ToText()  { output.Text(o) }
-func (o *privateNetworkListOutput) ToTable() { output.Table(o) }
 
 type privateNetworkListCmd struct {
 	exocmd.CliCommandSettings `cli-cmd:"-"`
@@ -50,6 +46,10 @@ func (c *privateNetworkListCmd) CmdPreRun(cmd *cobra.Command, args []string) err
 }
 
 func (c *privateNetworkListCmd) CmdRun(_ *cobra.Command, _ []string) error {
+	return runPrivateNetworkList(c, os.Stdout, os.Stderr)
+}
+
+func runPrivateNetworkList(c *privateNetworkListCmd, stdout, stderr io.Writer) error {
 	client := globalstate.EgoscaleV3Client
 	ctx := exocmd.GContext
 
@@ -58,43 +58,35 @@ func (c *privateNetworkListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	out := make(privateNetworkListOutput, 0)
-	res := make(chan privateNetworkListItemOutput)
-	done := make(chan struct{})
+	sink := utils.NewWarningSinkTo(stderr)
+	defer sink.Flush()
 
-	go func() {
-		for pn := range res {
-			out = append(out, pn)
-		}
-		done <- struct{}{}
-	}()
-	err = utils.ForEveryZone(zones, func(zone v3.Zone) error {
+	streamer := output.NewStreamer(privateNetworkListItemOutput{}, stdout)
+	defer func() { _ = streamer.Close() }()
 
-		c := client.WithEndpoint(zone.APIEndpoint)
-		resp, err := c.ListPrivateNetworks(ctx)
-		if err != nil {
-			return fmt.Errorf("unable to list Private Networks in zone %s: %w", zone, err)
-		}
-
-		for _, p := range resp.PrivateNetworks {
-			res <- privateNetworkListItemOutput{
-				ID:   p.ID,
-				Name: p.Name,
-				Zone: zone.Name,
+	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
+		func(ctx context.Context, zone v3.Zone) error {
+			zc := client.WithEndpoint(zone.APIEndpoint)
+			resp, err := zc.ListPrivateNetworks(ctx)
+			if err != nil {
+				return fmt.Errorf("unable to list Private Networks in zone %s: %w", zone, err)
 			}
-		}
+			for _, p := range resp.PrivateNetworks {
+				if err := streamer.Push(privateNetworkListItemOutput{
+					ID:   p.ID,
+					Name: p.Name,
+					Zone: zone.Name,
+				}); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
 
-		return nil
-	})
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr,
-			"warning: errors during listing, results might be incomplete.\n%s\n", err) // nolint:golint
+	if failed > 0 {
+		return fmt.Errorf("%d zone(s) failed", failed)
 	}
-
-	close(res)
-	<-done
-
-	return c.OutputFunc(&out, nil)
+	return nil
 }
 
 func init() {

--- a/cmd/compute/private_network/private_network_list.go
+++ b/cmd/compute/private_network/private_network_list.go
@@ -62,7 +62,11 @@ func runPrivateNetworkList(c *privateNetworkListCmd, stdout, stderr io.Writer) e
 	defer sink.Flush()
 
 	streamer := output.NewStreamer(privateNetworkListItemOutput{}, stdout)
-	defer func() { _ = streamer.Close() }()
+	defer func() {
+		if err := streamer.Close(); err != nil {
+			_, _ = fmt.Fprintf(stderr, "error: %s\n", err)
+		}
+	}()
 
 	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
 		func(ctx context.Context, zone v3.Zone) error {

--- a/cmd/compute/private_network/private_network_list.go
+++ b/cmd/compute/private_network/private_network_list.go
@@ -18,7 +18,7 @@ import (
 
 type privateNetworkListItemOutput struct {
 	ID   v3.UUID     `json:"id" outputWidth:"36"`
-	Name string      `json:"name" outputWidth:"38"`
+	Name string      `json:"name" outputWidth:"70"`
 	Zone v3.ZoneName `json:"zone" outputWidth:"8"`
 }
 

--- a/cmd/compute/sks/sks_list.go
+++ b/cmd/compute/sks/sks_list.go
@@ -1,7 +1,9 @@
 package sks
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -15,17 +17,11 @@ import (
 )
 
 type sksClusterListItemOutput struct {
-	ID           v3.UUID     `json:"id"`
-	Name         string      `json:"name"`
-	Zone         v3.ZoneName `json:"zone"`
-	AuditEnabled bool        `json:"audit_enabled"`
+	ID           v3.UUID     `json:"id" outputWidth:"36"`
+	Name         string      `json:"name" outputWidth:"38"`
+	Zone         v3.ZoneName `json:"zone" outputWidth:"8"`
+	AuditEnabled bool        `json:"audit_enabled" outputWidth:"11"`
 }
-
-type sksClusterListOutput []sksClusterListItemOutput
-
-func (o *sksClusterListOutput) ToJSON()  { output.JSON(o) }
-func (o *sksClusterListOutput) ToText()  { output.Text(o) }
-func (o *sksClusterListOutput) ToTable() { output.Table(o) }
 
 type sksListCmd struct {
 	exocmd.CliCommandSettings `cli-cmd:"-"`
@@ -51,6 +47,10 @@ func (c *sksListCmd) CmdPreRun(cmd *cobra.Command, args []string) error {
 }
 
 func (c *sksListCmd) CmdRun(_ *cobra.Command, _ []string) error {
+	return runSksList(c, os.Stdout, os.Stderr)
+}
+
+func runSksList(c *sksListCmd, stdout, stderr io.Writer) error {
 	client := globalstate.EgoscaleV3Client
 	ctx := exocmd.GContext
 
@@ -68,45 +68,38 @@ func (c *sksListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		zones = []v3.Zone{{APIEndpoint: endpoint}}
 	}
 
-	out := make(sksClusterListOutput, 0)
-	res := make(chan sksClusterListItemOutput)
-	done := make(chan struct{})
+	sink := utils.NewWarningSinkTo(stderr)
+	defer sink.Flush()
 
-	go func() {
-		for cluster := range res {
-			out = append(out, cluster)
-		}
-		done <- struct{}{}
-	}()
-	err = utils.ForEveryZone(zones, func(zone v3.Zone) error {
-		c := client.WithEndpoint((zone.APIEndpoint))
-		resp, err := c.ListSKSClusters(ctx)
-		if err != nil {
-			return fmt.Errorf("unable to list SKS clusters in zone %s: %w", zone, err)
-		}
+	streamer := output.NewStreamer(sksClusterListItemOutput{}, stdout)
+	defer func() { _ = streamer.Close() }()
 
-		for _, cluster := range resp.SKSClusters {
-			res <- sksClusterListItemOutput{
-				ID:   cluster.ID,
-				Name: cluster.Name,
-				Zone: zone.Name,
-				AuditEnabled: func() bool {
-					return cluster.Audit != nil && cluster.Audit.Enabled != nil && *cluster.Audit.Enabled
-				}(),
+	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
+		func(ctx context.Context, zone v3.Zone) error {
+			zc := client.WithEndpoint(zone.APIEndpoint)
+			resp, err := zc.ListSKSClusters(ctx)
+			if err != nil {
+				return fmt.Errorf("unable to list SKS clusters in zone %s: %w", zone, err)
 			}
-		}
+			for _, cluster := range resp.SKSClusters {
+				if err := streamer.Push(sksClusterListItemOutput{
+					ID:   cluster.ID,
+					Name: cluster.Name,
+					Zone: zone.Name,
+					AuditEnabled: func() bool {
+						return cluster.Audit != nil && cluster.Audit.Enabled != nil && *cluster.Audit.Enabled
+					}(),
+				}); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
 
-		return nil
-	})
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr,
-			"warning: errors during listing, results might be incomplete.\n%s\n", err) // nolint:golint
+	if failed > 0 {
+		return fmt.Errorf("%d zone(s) failed", failed)
 	}
-
-	close(res)
-	<-done
-
-	return c.OutputFunc(&out, nil)
+	return nil
 }
 
 func init() {

--- a/cmd/compute/sks/sks_list.go
+++ b/cmd/compute/sks/sks_list.go
@@ -18,7 +18,7 @@ import (
 
 type sksClusterListItemOutput struct {
 	ID           v3.UUID     `json:"id" outputWidth:"36"`
-	Name         string      `json:"name" outputWidth:"38"`
+	Name         string      `json:"name" outputWidth:"70"`
 	Zone         v3.ZoneName `json:"zone" outputWidth:"8"`
 	AuditEnabled bool        `json:"audit_enabled" outputWidth:"11"`
 }

--- a/cmd/compute/sks/sks_list.go
+++ b/cmd/compute/sks/sks_list.go
@@ -72,7 +72,11 @@ func runSksList(c *sksListCmd, stdout, stderr io.Writer) error {
 	defer sink.Flush()
 
 	streamer := output.NewStreamer(sksClusterListItemOutput{}, stdout)
-	defer func() { _ = streamer.Close() }()
+	defer func() {
+		if err := streamer.Close(); err != nil {
+			_, _ = fmt.Fprintf(stderr, "error: %s\n", err)
+		}
+	}()
 
 	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
 		func(ctx context.Context, zone v3.Zone) error {

--- a/cmd/compute/sks/sks_nodepool_list.go
+++ b/cmd/compute/sks/sks_nodepool_list.go
@@ -1,7 +1,9 @@
 package sks
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -15,19 +17,13 @@ import (
 )
 
 type sksNodepoolListItemOutput struct {
-	ID      v3.UUID     `json:"id"`
-	Name    string      `json:"name"`
-	Cluster string      `json:"cluster"`
-	Size    int64       `json:"size"`
-	State   string      `json:"state"`
-	Zone    v3.ZoneName `json:"zone"`
+	ID      v3.UUID     `json:"id" outputWidth:"36"`
+	Name    string      `json:"name" outputWidth:"38"`
+	Cluster string      `json:"cluster" outputWidth:"38"`
+	Size    int64       `json:"size" outputWidth:"4"`
+	State   string      `json:"state" outputWidth:"12"`
+	Zone    v3.ZoneName `json:"zone" outputWidth:"8"`
 }
-
-type sksNodepoolListOutput []sksNodepoolListItemOutput
-
-func (o *sksNodepoolListOutput) ToJSON()  { output.JSON(o) }
-func (o *sksNodepoolListOutput) ToText()  { output.Text(o) }
-func (o *sksNodepoolListOutput) ToTable() { output.Table(o) }
 
 type sksNodepoolListCmd struct {
 	exocmd.CliCommandSettings `cli-cmd:"-"`
@@ -53,6 +49,10 @@ func (c *sksNodepoolListCmd) CmdPreRun(cmd *cobra.Command, args []string) error 
 }
 
 func (c *sksNodepoolListCmd) CmdRun(_ *cobra.Command, _ []string) error {
+	return runSksNodepoolList(c, os.Stdout, os.Stderr)
+}
+
+func runSksNodepoolList(c *sksNodepoolListCmd, stdout, stderr io.Writer) error {
 	client := globalstate.EgoscaleV3Client
 	ctx := exocmd.GContext
 
@@ -70,49 +70,40 @@ func (c *sksNodepoolListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		zones = []v3.Zone{{APIEndpoint: endpoint}}
 	}
 
-	out := make(sksNodepoolListOutput, 0)
-	res := make(chan sksNodepoolListItemOutput)
-	done := make(chan struct{})
+	sink := utils.NewWarningSinkTo(stderr)
+	defer sink.Flush()
 
-	go func() {
-		for cluster := range res {
-			out = append(out, cluster)
-		}
-		done <- struct{}{}
-	}()
-	err = utils.ForEveryZone(zones, func(zone v3.Zone) error {
+	streamer := output.NewStreamer(sksNodepoolListItemOutput{}, stdout)
+	defer func() { _ = streamer.Close() }()
 
-		c := client.WithEndpoint((zone.APIEndpoint))
-		listResp, err := c.ListSKSClusters(ctx)
-		if err != nil {
-			return fmt.Errorf("unable to list SKS clusters in zone %s: %w", zone, err)
-		}
-
-		for _, cluster := range listResp.SKSClusters {
-			for _, np := range cluster.Nodepools {
-				res <- sksNodepoolListItemOutput{
-					ID:      np.ID,
-					Name:    np.Name,
-					Cluster: cluster.Name,
-					Size:    np.Size,
-					State:   string(np.State),
-					Zone:    zone.Name,
+	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
+		func(ctx context.Context, zone v3.Zone) error {
+			zc := client.WithEndpoint(zone.APIEndpoint)
+			listResp, err := zc.ListSKSClusters(ctx)
+			if err != nil {
+				return fmt.Errorf("unable to list SKS clusters in zone %s: %w", zone, err)
+			}
+			for _, cluster := range listResp.SKSClusters {
+				for _, np := range cluster.Nodepools {
+					if err := streamer.Push(sksNodepoolListItemOutput{
+						ID:      np.ID,
+						Name:    np.Name,
+						Cluster: cluster.Name,
+						Size:    np.Size,
+						State:   string(np.State),
+						Zone:    zone.Name,
+					}); err != nil {
+						return err
+					}
 				}
 			}
-		}
+			return nil
+		})
 
-		return nil
-	})
-
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr,
-			"warning: errors during listing, results might be incomplete.\n%s\n", err) // nolint:golint
+	if failed > 0 {
+		return fmt.Errorf("%d zone(s) failed", failed)
 	}
-
-	close(res)
-	<-done
-
-	return c.OutputFunc(&out, nil)
+	return nil
 }
 
 func init() {

--- a/cmd/compute/sks/sks_nodepool_list.go
+++ b/cmd/compute/sks/sks_nodepool_list.go
@@ -18,7 +18,7 @@ import (
 
 type sksNodepoolListItemOutput struct {
 	ID      v3.UUID     `json:"id" outputWidth:"36"`
-	Name    string      `json:"name" outputWidth:"38"`
+	Name    string      `json:"name" outputWidth:"70"`
 	Cluster string      `json:"cluster" outputWidth:"38"`
 	Size    int64       `json:"size" outputWidth:"4"`
 	State   string      `json:"state" outputWidth:"12"`

--- a/cmd/compute/sks/sks_nodepool_list.go
+++ b/cmd/compute/sks/sks_nodepool_list.go
@@ -74,7 +74,11 @@ func runSksNodepoolList(c *sksNodepoolListCmd, stdout, stderr io.Writer) error {
 	defer sink.Flush()
 
 	streamer := output.NewStreamer(sksNodepoolListItemOutput{}, stdout)
-	defer func() { _ = streamer.Close() }()
+	defer func() {
+		if err := streamer.Close(); err != nil {
+			_, _ = fmt.Fprintf(stderr, "error: %s\n", err)
+		}
+	}()
 
 	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
 		func(ctx context.Context, zone v3.Zone) error {

--- a/cmd/dbaas/dbaas_list.go
+++ b/cmd/dbaas/dbaas_list.go
@@ -63,7 +63,11 @@ func runDbaasList(c *dbaasServiceListCmd, stdout, stderr io.Writer) error {
 	defer sink.Flush()
 
 	streamer := output.NewStreamer(dbaasServiceListItemOutput{}, stdout)
-	defer func() { _ = streamer.Close() }()
+	defer func() {
+		if err := streamer.Close(); err != nil {
+			_, _ = fmt.Fprintf(stderr, "error: %s\n", err)
+		}
+	}()
 
 	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
 		func(ctx context.Context, zone v3.Zone) error {

--- a/cmd/dbaas/dbaas_list.go
+++ b/cmd/dbaas/dbaas_list.go
@@ -1,7 +1,9 @@
 package dbaas
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -15,17 +17,11 @@ import (
 )
 
 type dbaasServiceListItemOutput struct {
-	Name string      `json:"name"`
-	Type string      `json:"type"`
-	Plan string      `json:"plan"`
-	Zone v3.ZoneName `json:"zone"`
+	Name string      `json:"name" outputWidth:"38"`
+	Type string      `json:"type" outputWidth:"16"`
+	Plan string      `json:"plan" outputWidth:"16"`
+	Zone v3.ZoneName `json:"zone" outputWidth:"8"`
 }
-
-type dbaasServiceListOutput []dbaasServiceListItemOutput
-
-func (o *dbaasServiceListOutput) ToJSON()  { output.JSON(o) }
-func (o *dbaasServiceListOutput) ToText()  { output.Text(o) }
-func (o *dbaasServiceListOutput) ToTable() { output.Table(o) }
 
 type dbaasServiceListCmd struct {
 	exocmd.CliCommandSettings `cli-cmd:"-"`
@@ -51,6 +47,10 @@ func (c *dbaasServiceListCmd) CmdPreRun(cmd *cobra.Command, args []string) error
 }
 
 func (c *dbaasServiceListCmd) CmdRun(_ *cobra.Command, _ []string) error {
+	return runDbaasList(c, os.Stdout, os.Stderr)
+}
+
+func runDbaasList(c *dbaasServiceListCmd, stdout, stderr io.Writer) error {
 	client := globalstate.EgoscaleV3Client
 	ctx := exocmd.GContext
 
@@ -59,44 +59,36 @@ func (c *dbaasServiceListCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	out := make(dbaasServiceListOutput, 0)
-	res := make(chan dbaasServiceListItemOutput)
-	done := make(chan struct{})
+	sink := utils.NewWarningSinkTo(stderr)
+	defer sink.Flush()
 
-	go func() {
-		for dbService := range res {
-			out = append(out, dbService)
-		}
-		done <- struct{}{}
-	}()
-	err = utils.ForEveryZone(zones, func(zone v3.Zone) error {
-		c := client.WithEndpoint((zone.APIEndpoint))
-		list, err := c.ListDBAASServices(ctx)
+	streamer := output.NewStreamer(dbaasServiceListItemOutput{}, stdout)
+	defer func() { _ = streamer.Close() }()
 
-		if err != nil {
-			return fmt.Errorf("unable to list Database Services in zone %s: %w", zone, err)
-		}
-
-		for _, dbService := range list.DBAASServices {
-			res <- dbaasServiceListItemOutput{
-				Name: string(dbService.Name),
-				Type: string(dbService.Type),
-				Plan: dbService.Plan,
-				Zone: zone.Name,
+	failed := utils.ForEveryZoneAsync(ctx, zones, globalstate.RequestTimeout, sink, true,
+		func(ctx context.Context, zone v3.Zone) error {
+			zc := client.WithEndpoint(zone.APIEndpoint)
+			list, err := zc.ListDBAASServices(ctx)
+			if err != nil {
+				return fmt.Errorf("unable to list Database Services in zone %s: %w", zone, err)
 			}
-		}
+			for _, dbService := range list.DBAASServices {
+				if err := streamer.Push(dbaasServiceListItemOutput{
+					Name: string(dbService.Name),
+					Type: string(dbService.Type),
+					Plan: dbService.Plan,
+					Zone: zone.Name,
+				}); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
 
-		return nil
-	})
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr,
-			"warning: errors during listing, results might be incomplete.\n%s\n", err) // nolint:golint
+	if failed > 0 {
+		return fmt.Errorf("%d zone(s) failed", failed)
 	}
-
-	close(res)
-	<-done
-
-	return c.OutputFunc(&out, nil)
+	return nil
 }
 
 func init() {

--- a/cmd/dbaas/dbaas_list.go
+++ b/cmd/dbaas/dbaas_list.go
@@ -17,7 +17,7 @@ import (
 )
 
 type dbaasServiceListItemOutput struct {
-	Name string      `json:"name" outputWidth:"38"`
+	Name string      `json:"name" outputWidth:"70"`
 	Type string      `json:"type" outputWidth:"16"`
 	Plan string      `json:"plan" outputWidth:"16"`
 	Zone v3.ZoneName `json:"zone" outputWidth:"8"`


### PR DESCRIPTION
# Description

Follow-up to https://github.com/exoscale/cli/pull/826, finishes [sc-177228](https://app.shortcut.com/exoscale/story/177228/improve-zone-failure-handling)

Migrated:
- cmd/aiservices/model/model_list.go                                                     
- cmd/aiservices/deployment/instance_type_list.go                                                     
- cmd/compute/elastic_ip/elastic_ip_list.go
- cmd/compute/instance_pool/instance_pool_list.go
- cmd/compute/private_network/private_network_list.go
- cmd/compute/load_balancer/nlb_list.go
- cmd/compute/deploy_target/deploy_target_list.go
- cmd/compute/sks/sks_list.go
- cmd/compute/sks/sks_nodepool_list.go
- cmd/dbaas/dbaas_list.go

Skipped: 
- cmd/compute/instance_type/instance_type_list.go (would break sorting)
- cmd/compute/instance/instance_list.go (custom ToTable+sync.Map, don't want to get into it...)

Note that the Changelog is already updated from the previous PR! It doesn't need to be touched again

## Checklist

* [ ] ~~Changelog updated~~
* [x] Testing

## Testing

Manually ran every single command that has been updated against the exoscale-ops organization. Works smoothly. 
<img width="831" height="188" alt="Screenshot 2026-05-05 at 16 38 14" src="https://github.com/user-attachments/assets/288f788a-da18-4d14-8cd5-cfeea6e87cf3" />
