### PR TITLE
test(e2e): local creds helper for API tests

### DIFF
--- a/tests/e2e/local_test.go
+++ b/tests/e2e/local_test.go
@@ -1,0 +1,67 @@
+//go:build local_integration
+
+package e2e_test
+
+// Local dev only — use -tags=local_integration -account=<name>
+
+import (
+	"flag"
+	"os"
+	"strings"
+	"testing"
+)
+
+var flagAccount = flag.String("account", "owner-production", "account name substring in exoscale.toml")
+
+func TestAPIComputeLocal(t *testing.T) {
+	loadLocalCreds(t)
+	runAPITestSuite(t, "scenarios/with-api/compute")
+}
+
+func TestAPIDBaaSLocal(t *testing.T) {
+	loadLocalCreds(t)
+	runAPITestSuite(t, "scenarios/with-api/dbaas")
+}
+
+func loadLocalCreds(t *testing.T) {
+	t.Helper()
+
+	accountName := *flagAccount
+
+	toml, err := os.ReadFile(os.ExpandEnv("$HOME/.config/exoscale/exoscale.toml"))
+	if err != nil {
+		t.Fatalf("loadLocalCreds: %v", err)
+	}
+
+	blocks := strings.Split(string(toml), "[[accounts]]")
+	for _, block := range blocks[1:] {
+		if !strings.Contains(block, accountName) {
+			continue
+		}
+		key := tomlString(block, "key")
+		secret := tomlString(block, "secret")
+		zone := tomlString(block, "defaultZone")
+		if key == "" || secret == "" {
+			continue
+		}
+		t.Setenv("EXOSCALE_API_KEY", key)
+		t.Setenv("EXOSCALE_API_SECRET", secret)
+		if zone != "" {
+			t.Setenv("EXOSCALE_ZONE", zone)
+		}
+		return
+	}
+
+	t.Fatalf("loadLocalCreds: no account matching %q in exoscale.toml", accountName)
+}
+
+func tomlString(block, key string) string {
+	prefix := key + " = '"
+	for _, line := range strings.Split(block, "\n") {
+		line = strings.TrimSpace(line)
+		if after, ok := strings.CutPrefix(line, prefix); ok {
+			return strings.TrimSuffix(after, "'")
+		}
+	}
+	return ""
+}

--- a/tests/e2e/scenarios/README.md
+++ b/tests/e2e/scenarios/README.md
@@ -23,7 +23,7 @@ cd tests/e2e
 go test -v
 ```
 
-### With API (CI — env vars)
+### With API (CI, env vars)
 
 ```bash
 cd tests/e2e
@@ -37,7 +37,7 @@ EXOSCALE_API_KEY=... EXOSCALE_API_SECRET=... \
   go test -v -tags=api -timeout 30m -run TestScriptsAPIDBaaS
 ```
 
-### With API (local — reads from exoscale.toml)
+### With API (local, reads from exoscale.toml)
 
 ```bash
 cd tests/e2e

--- a/tests/e2e/scenarios/README.md
+++ b/tests/e2e/scenarios/README.md
@@ -1,62 +1,55 @@
 # E2E Testscript Scenarios
 
-This directory contains testscript scenarios for end-to-end testing the Exoscale CLI.
+Testscript scenarios for end-to-end testing the Exoscale CLI.
 
 ## Directory Structure
 
-- **without-api/**: Test scenarios that don't require API access (run by default)
-- **with-api/**: Test scenarios that require API access (run with `-tags=api`)
-
-## Current Scenarios
-
-### Tests Without API (scenarios/without-api/)
-
-- **basic_no_api.txtar**: Tests basic CLI functionality without API access (version, help commands)
-- **config_isolated.txtar**: Tests config file isolation using `XDG_CONFIG_HOME`
-
-### Tests With API (scenarios/with-api/)
-
-No API test scenarios yet. These will be added in a future PR.
+- **without-api/**: No API access required, runs by default
+- **with-api/compute/**: Compute API scenarios (`-tags=api`, `-run TestScriptsAPICompute`)
+- **with-api/dbaas/**: DBaaS API scenarios (`-tags=api`, `-run TestScriptsAPIDBaaS`)
 
 ## Running Tests
 
-Tests use the pre-built binary from the existing build pipeline. Build it first:
+Build the binary first:
 
 ```bash
-# Build the CLI binary (from repository root)
 make build
-
-# Run local tests only (default - no build tag needed)
-cd tests/e2e
-go test -v
-
-# Run API tests only (requires API credentials)
-cd tests/e2e
-go test -v -tags=api
-
-# Run all tests (local + API)
-cd tests/e2e
-go test -v -tags=api
 ```
 
-## Using Build Tags
+### Without API (default)
 
-The test suite uses Go build tags to separate local tests from API tests:
+```bash
+cd tests/e2e
+go test -v
+```
 
-- **Local tests** (`testscript_local_test.go`): No build tag, runs by default
-- **API tests** (`testscript_api_test.go`): Requires `-tags=api` build tag
+### With API (CI — env vars)
 
-This approach is more maintainable than regex filtering and follows Go best practices.
+```bash
+cd tests/e2e
+EXOSCALE_API_KEY=... EXOSCALE_API_SECRET=... \
+  go test -v -tags=api -timeout 30m -run TestScriptsAPICompute
+```
 
-## Future Work
+```bash
+cd tests/e2e
+EXOSCALE_API_KEY=... EXOSCALE_API_SECRET=... \
+  go test -v -tags=api -timeout 30m -run TestScriptsAPIDBaaS
+```
 
-**TODO**: API-based tests will be added in a separate PR to `scenarios/with-api/`. These will require:
-- Organization test account setup
-- Proper API credentials configuration (`EXOSCALE_API_KEY`, `EXOSCALE_API_SECRET`)
-- Test scenarios covering:
-  - Block storage operations (create, resize, snapshot, delete)
-  - Compute instance operations
-  - Network resources
-  - Other API-dependent features
+### With API (local — reads from exoscale.toml)
 
-The CI workflow is already configured to run API tests on the master branch when credentials are available.
+```bash
+cd tests/e2e
+go test -v -tags=local_integration -timeout 30m \
+  -run TestAPIComputeLocal -account=<account-name>
+```
+
+```bash
+cd tests/e2e
+go test -v -tags=local_integration -timeout 30m \
+  -run TestAPIDBaaSLocal -account=<account-name>
+```
+
+`-account` matches a substring of the account name in
+`~/.config/exoscale/exoscale.toml`. Defaults to `owner-production`.

--- a/tests/e2e/testscript_api_test.go
+++ b/tests/e2e/testscript_api_test.go
@@ -1,4 +1,4 @@
-//go:build api
+//go:build api || local_integration
 
 package e2e_test
 


### PR DESCRIPTION
Adds `tests/e2e/local_test.go` (build tag: `local`, never compiled on CI).

Reads credentials from `~/.config/exoscale/exoscale.toml` via `-account` flag and injects them with `t.Setenv`, never printed.

E.g., 
```sh
go test -tags='api local' -timeout 30m -run TestAPIComputeLocal . -account=my-user-owner
```