### PR TITLE
fix(dbaas): send `pg-migration-ignore-dbs` value to API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Bug fixes
+
+- dbaas: send `--pg-migration-ignore-dbs` value to API #839
 
 ## 1.95.0
 

--- a/cmd/aiservices/deployment/deployment_actions_test.go
+++ b/cmd/aiservices/deployment/deployment_actions_test.go
@@ -1,7 +1,6 @@
 package deployment
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -12,10 +11,9 @@ import (
 	"time"
 
 	exocmd "github.com/exoscale/cli/cmd"
-	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
+	"github.com/exoscale/cli/pkg/testutils"
 	v3 "github.com/exoscale/egoscale/v3"
-	"github.com/exoscale/egoscale/v3/credentials"
 )
 
 type depActionsServer struct {
@@ -30,9 +28,9 @@ func newDepActionsServer(t *testing.T) *depActionsServer {
 	mux.HandleFunc("/ai/deployment", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			writeJSON(t, w, http.StatusOK, v3.ListDeploymentsResponse{Deployments: ts.deployments})
+			testutils.WriteJSON(t, w, http.StatusOK, v3.ListDeploymentsResponse{Deployments: ts.deployments})
 		case http.MethodPost:
-			writeJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-deploy-create"), State: v3.OperationStateSuccess})
+			testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-deploy-create"), State: v3.OperationStateSuccess})
 		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}
@@ -49,7 +47,7 @@ func newDepActionsServer(t *testing.T) *depActionsServer {
 			for _, d := range ts.deployments {
 				if string(d.ID) == id {
 					resp := v3.GetDeploymentResponse{ID: d.ID, Name: d.Name, State: v3.GetDeploymentResponseState(d.State), GpuType: d.GpuType, GpuCount: d.GpuCount, Replicas: d.Replicas, ServiceLevel: d.ServiceLevel, DeploymentURL: d.DeploymentURL, Model: d.Model, CreatedAT: d.CreatedAT, UpdatedAT: d.UpdatedAT}
-					writeJSON(t, w, http.StatusOK, resp)
+					testutils.WriteJSON(t, w, http.StatusOK, resp)
 					return
 				}
 			}
@@ -57,22 +55,22 @@ func newDepActionsServer(t *testing.T) *depActionsServer {
 			return
 		}
 		if len(parts) == 1 && r.Method == http.MethodDelete {
-			writeJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-deploy-delete"), State: v3.OperationStateSuccess})
+			testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-deploy-delete"), State: v3.OperationStateSuccess})
 			return
 		}
 		if len(parts) == 2 && parts[1] == "scale" && r.Method == http.MethodPost {
 			b, _ := io.ReadAll(r.Body)
 			r.Body.Close()
 			ts.lastScaleBody = string(b)
-			writeJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-deploy-scale"), State: v3.OperationStateSuccess})
+			testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-deploy-scale"), State: v3.OperationStateSuccess})
 			return
 		}
 		if len(parts) == 2 && parts[1] == "api-key" && r.Method == http.MethodGet {
-			writeJSON(t, w, http.StatusOK, v3.RevealDeploymentAPIKeyResponse{APIKey: "secret"})
+			testutils.WriteJSON(t, w, http.StatusOK, v3.RevealDeploymentAPIKeyResponse{APIKey: "secret"})
 			return
 		}
 		if len(parts) == 2 && parts[1] == "logs" && r.Method == http.MethodGet {
-			writeJSON(t, w, http.StatusOK, v3.GetDeploymentLogsResponse{
+			testutils.WriteJSON(t, w, http.StatusOK, v3.GetDeploymentLogsResponse{
 				Logs: []v3.GetDeploymentLogsEntry{
 					{Message: "l1"},
 					{Message: "l2"},
@@ -87,7 +85,7 @@ func newDepActionsServer(t *testing.T) *depActionsServer {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		writeJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID(path.Base(r.URL.Path)), State: v3.OperationStateSuccess})
+		testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID(path.Base(r.URL.Path)), State: v3.OperationStateSuccess})
 	})
 	ts.server = httptest.NewServer(mux)
 	return ts
@@ -96,14 +94,7 @@ func newDepActionsServer(t *testing.T) *depActionsServer {
 func TestDeploymentDeleteScaleRevealLogs(t *testing.T) {
 	ts := newDepActionsServer(t)
 	defer ts.server.Close()
-	exocmd.GContext = context.Background()
-	globalstate.Quiet = true
-	creds := credentials.NewStaticCredentials("key", "secret")
-	client, err := v3.NewClient(creds)
-	if err != nil {
-		t.Fatalf("new client: %v", err)
-	}
-	globalstate.EgoscaleV3Client = client.WithEndpoint(v3.Endpoint(ts.server.URL))
+	testutils.SetupV3Client(t, ts.server.URL)
 
 	now := time.Now()
 	ts.deployments = []v3.ListDeploymentsResponseEntry{{ID: v3.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), Name: "alpha", CreatedAT: now, UpdatedAT: now}}
@@ -150,14 +141,8 @@ func TestDeploymentDeleteScaleRevealLogs(t *testing.T) {
 func TestDeploymentScaleZeroIncludesReplicas(t *testing.T) {
 	ts := newDepActionsServer(t)
 	defer ts.server.Close()
-	exocmd.GContext = context.Background()
-	globalstate.Quiet = true
-	creds := credentials.NewStaticCredentials("key", "secret")
-	client, err := v3.NewClient(creds)
-	if err != nil {
-		t.Fatalf("new client: %v", err)
-	}
-	globalstate.EgoscaleV3Client = client.WithEndpoint(v3.Endpoint(ts.server.URL))
+	testutils.SetupV3Client(t, ts.server.URL)
+
 	now := time.Now()
 	ts.deployments = []v3.ListDeploymentsResponseEntry{{ID: v3.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), Name: "alpha", CreatedAT: now, UpdatedAT: now}}
 	sc := &DeploymentScaleCmd{CliCommandSettings: exocmd.DefaultCLICmdSettings(), Deployment: "alpha", Size: 0}

--- a/cmd/aiservices/deployment/deployment_create_test.go
+++ b/cmd/aiservices/deployment/deployment_create_test.go
@@ -1,7 +1,6 @@
 package deployment
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -9,9 +8,8 @@ import (
 	"testing"
 
 	exocmd "github.com/exoscale/cli/cmd"
-	"github.com/exoscale/cli/pkg/globalstate"
+	"github.com/exoscale/cli/pkg/testutils"
 	v3 "github.com/exoscale/egoscale/v3"
-	"github.com/exoscale/egoscale/v3/credentials"
 )
 
 func TestDeploymentCreateValidationAndSuccess(t *testing.T) {
@@ -21,26 +19,18 @@ func TestDeploymentCreateValidationAndSuccess(t *testing.T) {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		writeJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-deploy-create"), State: v3.OperationStateSuccess})
+		testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-deploy-create"), State: v3.OperationStateSuccess})
 	})
 	mux.HandleFunc("/operation/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		writeJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-deploy-create"), State: v3.OperationStateSuccess})
+		testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-deploy-create"), State: v3.OperationStateSuccess})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
-
-	exocmd.GContext = context.Background()
-	globalstate.Quiet = true
-	creds := credentials.NewStaticCredentials("key", "secret")
-	client, err := v3.NewClient(creds)
-	if err != nil {
-		t.Fatalf("new client: %v", err)
-	}
-	globalstate.EgoscaleV3Client = client.WithEndpoint(v3.Endpoint(srv.URL))
+	testutils.SetupV3Client(t, srv.URL)
 
 	// missing gpu flags
 	c := &DeploymentCreateCmd{CliCommandSettings: exocmd.DefaultCLICmdSettings()}
@@ -77,26 +67,18 @@ func TestDeploymentCreateWithInferenceEngineParameters(t *testing.T) {
 		if err := json.Unmarshal(body, &capturedRequest); err != nil {
 			t.Fatalf("failed to unmarshal request: %v", err)
 		}
-		writeJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-deploy-create"), State: v3.OperationStateSuccess})
+		testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-deploy-create"), State: v3.OperationStateSuccess})
 	})
 	mux.HandleFunc("/operation/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		writeJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-deploy-create"), State: v3.OperationStateSuccess})
+		testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-deploy-create"), State: v3.OperationStateSuccess})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
-
-	exocmd.GContext = context.Background()
-	globalstate.Quiet = true
-	creds := credentials.NewStaticCredentials("key", "secret")
-	client, err := v3.NewClient(creds)
-	if err != nil {
-		t.Fatalf("new client: %v", err)
-	}
-	globalstate.EgoscaleV3Client = client.WithEndpoint(v3.Endpoint(srv.URL))
+	testutils.SetupV3Client(t, srv.URL)
 
 	// Test with space-separated inference engine parameters
 	c := &DeploymentCreateCmd{
@@ -137,26 +119,18 @@ func TestDeploymentCreateWithInferenceEngineVersion(t *testing.T) {
 		if err := json.Unmarshal(body, &capturedRequest); err != nil {
 			t.Fatalf("failed to unmarshal request: %v", err)
 		}
-		writeJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-deploy-create"), State: v3.OperationStateSuccess})
+		testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-deploy-create"), State: v3.OperationStateSuccess})
 	})
 	mux.HandleFunc("/operation/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		writeJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-deploy-create"), State: v3.OperationStateSuccess})
+		testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-deploy-create"), State: v3.OperationStateSuccess})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
-
-	exocmd.GContext = context.Background()
-	globalstate.Quiet = true
-	creds := credentials.NewStaticCredentials("key", "secret")
-	client, err := v3.NewClient(creds)
-	if err != nil {
-		t.Fatalf("new client: %v", err)
-	}
-	globalstate.EgoscaleV3Client = client.WithEndpoint(v3.Endpoint(srv.URL))
+	testutils.SetupV3Client(t, srv.URL)
 
 	c := &DeploymentCreateCmd{
 		CliCommandSettings:     exocmd.DefaultCLICmdSettings(),
@@ -205,19 +179,11 @@ func TestDeploymentCreateInferenceEngineHelp(t *testing.T) {
 				},
 			},
 		}
-		writeJSON(t, w, http.StatusOK, resp)
+		testutils.WriteJSON(t, w, http.StatusOK, resp)
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
-
-	exocmd.GContext = context.Background()
-	globalstate.Quiet = true
-	creds := credentials.NewStaticCredentials("key", "secret")
-	client, err := v3.NewClient(creds)
-	if err != nil {
-		t.Fatalf("new client: %v", err)
-	}
-	globalstate.EgoscaleV3Client = client.WithEndpoint(v3.Endpoint(srv.URL))
+	testutils.SetupV3Client(t, srv.URL)
 
 	c := &DeploymentCreateCmd{
 		CliCommandSettings:  exocmd.DefaultCLICmdSettings(),

--- a/cmd/aiservices/deployment/deployment_helpers_test.go
+++ b/cmd/aiservices/deployment/deployment_helpers_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/exoscale/cli/pkg/testutils"
 	v3 "github.com/exoscale/egoscale/v3"
-	"github.com/exoscale/egoscale/v3/credentials"
 )
 
 type depHelperServer struct {
@@ -24,7 +24,7 @@ func newDepHelperServer(t *testing.T) *depHelperServer {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ai/deployment", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
-			writeJSON(t, w, http.StatusOK, v3.ListDeploymentsResponse{Deployments: ts.deployments})
+			testutils.WriteJSON(t, w, http.StatusOK, v3.ListDeploymentsResponse{Deployments: ts.deployments})
 			return
 		}
 		w.WriteHeader(http.StatusMethodNotAllowed)
@@ -35,13 +35,13 @@ func newDepHelperServer(t *testing.T) *depHelperServer {
 		case http.MethodGet:
 			for _, d := range ts.deployments {
 				if string(d.ID) == id {
-					writeJSON(t, w, http.StatusOK, v3.GetDeploymentResponse{ID: d.ID, Name: d.Name, State: v3.GetDeploymentResponseState(d.State), GpuType: d.GpuType, GpuCount: d.GpuCount, Replicas: d.Replicas, ServiceLevel: d.ServiceLevel, DeploymentURL: d.DeploymentURL, Model: d.Model, CreatedAT: d.CreatedAT, UpdatedAT: d.UpdatedAT})
+					testutils.WriteJSON(t, w, http.StatusOK, v3.GetDeploymentResponse{ID: d.ID, Name: d.Name, State: v3.GetDeploymentResponseState(d.State), GpuType: d.GpuType, GpuCount: d.GpuCount, Replicas: d.Replicas, ServiceLevel: d.ServiceLevel, DeploymentURL: d.DeploymentURL, Model: d.Model, CreatedAT: d.CreatedAT, UpdatedAT: d.UpdatedAT})
 					return
 				}
 			}
 			w.WriteHeader(http.StatusNotFound)
 		case http.MethodDelete:
-			writeJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op"), State: v3.OperationStateSuccess})
+			testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op"), State: v3.OperationStateSuccess})
 		case http.MethodPost:
 			if strings.HasSuffix(r.URL.Path, "/scale") {
 				_, err := io.Copy(io.Discard, r.Body)
@@ -52,7 +52,7 @@ func newDepHelperServer(t *testing.T) *depHelperServer {
 				if err != nil {
 					t.Fail()
 				}
-				writeJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op"), State: v3.OperationStateSuccess})
+				testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op"), State: v3.OperationStateSuccess})
 				return
 			}
 			w.WriteHeader(http.StatusNotFound)
@@ -69,12 +69,7 @@ func TestFindListDeploymentsResponseEntryByIDAndName(t *testing.T) {
 	defer ts.server.Close()
 	now := time.Now()
 	ts.deployments = []v3.ListDeploymentsResponseEntry{{ID: v3.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), Name: "alpha", CreatedAT: now, UpdatedAT: now}}
-	creds := credentials.NewStaticCredentials("key", "secret")
-	client, err := v3.NewClient(creds)
-	if err != nil {
-		t.Fatalf("new client: %v", err)
-	}
-	client = client.WithEndpoint(v3.Endpoint(ts.server.URL))
+	client := testutils.NewV3Client(t, ts.server.URL)
 	ctx := context.Background()
 
 	// by ID

--- a/cmd/aiservices/deployment/deployment_list_test.go
+++ b/cmd/aiservices/deployment/deployment_list_test.go
@@ -2,7 +2,6 @@ package deployment
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -14,8 +13,8 @@ import (
 
 	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
+	"github.com/exoscale/cli/pkg/testutils"
 	v3 "github.com/exoscale/egoscale/v3"
-	"github.com/exoscale/egoscale/v3/credentials"
 )
 
 // zoneBehavior describes how a fake per-zone backend should respond.
@@ -75,10 +74,10 @@ func newMultiZoneHarness(t *testing.T, fixtures []*zoneFixture, slowDelay time.D
 				http.Error(w, "boom", http.StatusInternalServerError)
 				return
 			case zoneEmpty:
-				writeJSON(t, w, http.StatusOK, v3.ListDeploymentsResponse{})
+				testutils.WriteJSON(t, w, http.StatusOK, v3.ListDeploymentsResponse{})
 				return
 			default:
-				writeJSON(t, w, http.StatusOK, v3.ListDeploymentsResponse{Deployments: zone.Deployments})
+				testutils.WriteJSON(t, w, http.StatusOK, v3.ListDeploymentsResponse{Deployments: zone.Deployments})
 			}
 		})
 		zone.server = httptest.NewServer(mux)
@@ -94,31 +93,10 @@ func newMultiZoneHarness(t *testing.T, fixtures []*zoneFixture, slowDelay time.D
 				APIEndpoint: v3.Endpoint(z.server.URL),
 			})
 		}
-		writeJSON(t, w, http.StatusOK, v3.ListZonesResponse{Zones: zones})
+		testutils.WriteJSON(t, w, http.StatusOK, v3.ListZonesResponse{Zones: zones})
 	})
 	h.control = httptest.NewServer(controlMux)
 	return h
-}
-
-func writeJSON(t *testing.T, w http.ResponseWriter, code int, v interface{}) {
-	t.Helper()
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(code)
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		t.Fatalf("encode json: %v", err)
-	}
-}
-
-func setupClient(t *testing.T, controlURL string) {
-	t.Helper()
-	exocmd.GContext = context.Background()
-	globalstate.Quiet = true
-	creds := credentials.NewStaticCredentials("key", "secret")
-	client, err := v3.NewClient(creds)
-	if err != nil {
-		t.Fatalf("new client: %v", err)
-	}
-	globalstate.EgoscaleV3Client = client.WithEndpoint(v3.Endpoint(controlURL))
 }
 
 func sampleDeployments(zoneSuffix string, n int) []v3.ListDeploymentsResponseEntry {
@@ -159,7 +137,7 @@ func TestDeploymentList_AllHealthy(t *testing.T) {
 	}
 	h := newMultiZoneHarness(t, zones, 0)
 	defer h.close()
-	setupClient(t, h.control.URL)
+	testutils.SetupV3Client(t, h.control.URL)
 	defer withFormat(t, "json")()
 
 	stdout, stderr, err := runList(t, "")
@@ -195,7 +173,7 @@ func TestDeploymentList_OneTimeout(t *testing.T) {
 	}
 	h := newMultiZoneHarness(t, zones, 2*time.Second)
 	defer h.close()
-	setupClient(t, h.control.URL)
+	testutils.SetupV3Client(t, h.control.URL)
 	defer withFormat(t, "json")()
 
 	start := time.Now()
@@ -231,7 +209,7 @@ func TestDeploymentList_OneServerError(t *testing.T) {
 	}
 	h := newMultiZoneHarness(t, zones, 0)
 	defer h.close()
-	setupClient(t, h.control.URL)
+	testutils.SetupV3Client(t, h.control.URL)
 	defer withFormat(t, "json")()
 
 	stdout, stderr, err := runList(t, "")
@@ -258,7 +236,7 @@ func TestDeploymentList_AllFailed(t *testing.T) {
 	}
 	h := newMultiZoneHarness(t, zones, 0)
 	defer h.close()
-	setupClient(t, h.control.URL)
+	testutils.SetupV3Client(t, h.control.URL)
 	defer withFormat(t, "json")()
 
 	stdout, stderr, err := runList(t, "")
@@ -282,7 +260,7 @@ func TestDeploymentList_ZoneFilter(t *testing.T) {
 	}
 	h := newMultiZoneHarness(t, zones, 0)
 	defer h.close()
-	setupClient(t, h.control.URL)
+	testutils.SetupV3Client(t, h.control.URL)
 	defer withFormat(t, "json")()
 
 	stdout, _, err := runList(t, "z1")

--- a/cmd/aiservices/deployment/deployment_show_test.go
+++ b/cmd/aiservices/deployment/deployment_show_test.go
@@ -1,7 +1,6 @@
 package deployment
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"path"
@@ -9,10 +8,9 @@ import (
 	"time"
 
 	exocmd "github.com/exoscale/cli/cmd"
-	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
+	"github.com/exoscale/cli/pkg/testutils"
 	v3 "github.com/exoscale/egoscale/v3"
-	"github.com/exoscale/egoscale/v3/credentials"
 )
 
 type depShowServer struct {
@@ -25,7 +23,7 @@ func newDepShowServer(t *testing.T) *depShowServer {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ai/deployment", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
-			writeJSON(t, w, http.StatusOK, v3.ListDeploymentsResponse{Deployments: ts.deployments})
+			testutils.WriteJSON(t, w, http.StatusOK, v3.ListDeploymentsResponse{Deployments: ts.deployments})
 			return
 		}
 		w.WriteHeader(http.StatusMethodNotAllowed)
@@ -54,7 +52,7 @@ func newDepShowServer(t *testing.T) *depShowServer {
 					CreatedAT:              d.CreatedAT,
 					UpdatedAT:              d.UpdatedAT,
 				}
-				writeJSON(t, w, http.StatusOK, resp)
+				testutils.WriteJSON(t, w, http.StatusOK, resp)
 				return
 			}
 		}
@@ -67,14 +65,7 @@ func newDepShowServer(t *testing.T) *depShowServer {
 func TestDeploymentShowByIDAndName(t *testing.T) {
 	ts := newDepShowServer(t)
 	defer ts.server.Close()
-	exocmd.GContext = context.Background()
-	globalstate.Quiet = true
-	creds := credentials.NewStaticCredentials("key", "secret")
-	client, err := v3.NewClient(creds)
-	if err != nil {
-		t.Fatalf("new client: %v", err)
-	}
-	globalstate.EgoscaleV3Client = client.WithEndpoint(v3.Endpoint(ts.server.URL))
+	testutils.SetupV3Client(t, ts.server.URL)
 
 	now := time.Now()
 	ts.deployments = []v3.ListDeploymentsResponseEntry{{ID: v3.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), Name: "alpha", State: v3.ListDeploymentsResponseEntryStateReady, GpuType: "gpua5000", GpuCount: 1, Replicas: 1, ServiceLevel: "pro", DeploymentURL: "https://u", Model: &v3.ModelRef{ID: v3.UUID("11111111-1111-1111-1111-111111111111"), Name: "m1"}, CreatedAT: now, UpdatedAT: now}}

--- a/cmd/aiservices/deployment/deployment_update_test.go
+++ b/cmd/aiservices/deployment/deployment_update_test.go
@@ -1,7 +1,6 @@
 package deployment
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -10,9 +9,8 @@ import (
 	"testing"
 
 	exocmd "github.com/exoscale/cli/cmd"
-	"github.com/exoscale/cli/pkg/globalstate"
+	"github.com/exoscale/cli/pkg/testutils"
 	v3 "github.com/exoscale/egoscale/v3"
-	"github.com/exoscale/egoscale/v3/credentials"
 )
 
 func TestDeploymentUpdate(t *testing.T) {
@@ -31,7 +29,7 @@ func TestDeploymentUpdate(t *testing.T) {
 					},
 				},
 			}
-			writeJSON(t, w, http.StatusOK, resp)
+			testutils.WriteJSON(t, w, http.StatusOK, resp)
 			return
 		}
 		w.WriteHeader(http.StatusMethodNotAllowed)
@@ -46,27 +44,19 @@ func TestDeploymentUpdate(t *testing.T) {
 			if err := json.Unmarshal(body, &capturedRequest); err != nil {
 				t.Fatalf("failed to unmarshal request: %v", err)
 			}
-			writeJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-update"), State: v3.OperationStateSuccess})
+			testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-update"), State: v3.OperationStateSuccess})
 			return
 		}
 		w.WriteHeader(http.StatusMethodNotAllowed)
 	})
 
 	mux.HandleFunc("/operation/", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-update"), State: v3.OperationStateSuccess})
+		testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-update"), State: v3.OperationStateSuccess})
 	})
 
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
-
-	exocmd.GContext = context.Background()
-	globalstate.Quiet = true
-	creds := credentials.NewStaticCredentials("key", "secret")
-	client, err := v3.NewClient(creds)
-	if err != nil {
-		t.Fatalf("new client: %v", err)
-	}
-	globalstate.EgoscaleV3Client = client.WithEndpoint(v3.Endpoint(srv.URL))
+	testutils.SetupV3Client(t, srv.URL)
 
 	c := &DeploymentUpdateCmd{
 		CliCommandSettings:        exocmd.DefaultCLICmdSettings(),

--- a/cmd/aiservices/deployment/instance_type_list_test.go
+++ b/cmd/aiservices/deployment/instance_type_list_test.go
@@ -2,7 +2,6 @@ package deployment
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -10,8 +9,8 @@ import (
 
 	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
+	"github.com/exoscale/cli/pkg/testutils"
 	v3 "github.com/exoscale/egoscale/v3"
-	"github.com/exoscale/egoscale/v3/credentials"
 )
 
 type instanceTypeListServer struct {
@@ -25,34 +24,23 @@ func newInstanceTypeListServer(t *testing.T) *instanceTypeListServer {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ai/instance-type", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
-			writeJSON(t, w, http.StatusOK, v3.ListAIInstanceTypesResponse{InstanceTypes: ts.instanceTypes})
+			testutils.WriteJSON(t, w, http.StatusOK, v3.ListAIInstanceTypesResponse{InstanceTypes: ts.instanceTypes})
 			return
 		}
 		w.WriteHeader(http.StatusMethodNotAllowed)
 	})
 	mux.HandleFunc("/zone", func(w http.ResponseWriter, r *http.Request) {
 		ts.zones++
-		writeJSON(t, w, http.StatusOK, v3.ListZonesResponse{Zones: []v3.Zone{{APIEndpoint: v3.Endpoint(ts.server.URL), Name: v3.ZoneName("test-zone")}}})
+		testutils.WriteJSON(t, w, http.StatusOK, v3.ListZonesResponse{Zones: []v3.Zone{{APIEndpoint: v3.Endpoint(ts.server.URL), Name: v3.ZoneName("test-zone")}}})
 	})
 	ts.server = httptest.NewServer(mux)
 	return ts
 }
 
-func instanceTypeSetup(t *testing.T, url string) {
-	exocmd.GContext = context.Background()
-	globalstate.Quiet = true
-	creds := credentials.NewStaticCredentials("key", "secret")
-	client, err := v3.NewClient(creds)
-	if err != nil {
-		t.Fatalf("new client: %v", err)
-	}
-	globalstate.EgoscaleV3Client = client.WithEndpoint(v3.Endpoint(url))
-}
-
 func TestInstanceTypeList(t *testing.T) {
 	ts := newInstanceTypeListServer(t)
 	defer ts.server.Close()
-	instanceTypeSetup(t, ts.server.URL)
+	testutils.SetupV3Client(t, ts.server.URL)
 
 	trueVal := true
 	falseVal := false
@@ -88,7 +76,7 @@ func TestInstanceTypeList(t *testing.T) {
 func TestInstanceTypeListUsesZone(t *testing.T) {
 	ts := newInstanceTypeListServer(t)
 	defer ts.server.Close()
-	instanceTypeSetup(t, ts.server.URL)
+	testutils.SetupV3Client(t, ts.server.URL)
 
 	cmd := &InstanceTypeListCmd{CliCommandSettings: exocmd.DefaultCLICmdSettings(), Zone: v3.ZoneName("test-zone")}
 	if err := cmd.CmdRun(nil, nil); err != nil {

--- a/cmd/aiservices/model/model_create_test.go
+++ b/cmd/aiservices/model/model_create_test.go
@@ -1,22 +1,20 @@
 package model
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	exocmd "github.com/exoscale/cli/cmd"
-	"github.com/exoscale/cli/pkg/globalstate"
+	"github.com/exoscale/cli/pkg/testutils"
 	v3 "github.com/exoscale/egoscale/v3"
-	"github.com/exoscale/egoscale/v3/credentials"
 )
 
 func newModelCreateServer(t *testing.T) *httptest.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ai/model", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
-			writeJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-model-create"), State: v3.OperationStateSuccess})
+			testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-model-create"), State: v3.OperationStateSuccess})
 			return
 		}
 		w.WriteHeader(http.StatusMethodNotAllowed)
@@ -26,7 +24,7 @@ func newModelCreateServer(t *testing.T) *httptest.Server {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		writeJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-model-create"), State: v3.OperationStateSuccess})
+		testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-model-create"), State: v3.OperationStateSuccess})
 	})
 	return httptest.NewServer(mux)
 }
@@ -34,14 +32,7 @@ func newModelCreateServer(t *testing.T) *httptest.Server {
 func TestModelCreateSuccessAndMissingName(t *testing.T) {
 	srv := newModelCreateServer(t)
 	defer srv.Close()
-	exocmd.GContext = context.Background()
-	globalstate.Quiet = true
-	creds := credentials.NewStaticCredentials("key", "secret")
-	client, err := v3.NewClient(creds)
-	if err != nil {
-		t.Fatalf("new client: %v", err)
-	}
-	globalstate.EgoscaleV3Client = client.WithEndpoint(v3.Endpoint(srv.URL))
+	testutils.SetupV3Client(t, srv.URL)
 
 	// missing name
 	cmd := &ModelCreateCmd{CliCommandSettings: exocmd.DefaultCLICmdSettings()}

--- a/cmd/aiservices/model/model_delete_test.go
+++ b/cmd/aiservices/model/model_delete_test.go
@@ -4,12 +4,14 @@ import (
 	"testing"
 
 	exocmd "github.com/exoscale/cli/cmd"
+	"github.com/exoscale/cli/pkg/testutils"
 	v3 "github.com/exoscale/egoscale/v3"
 )
 
 func TestModelDelete(t *testing.T) {
 	ts := newModelTestServer(t)
-	defer modelSetup(t, ts)()
+	testutils.SetupV3Client(t, ts.server.URL)
+	defer ts.server.Close()
 	ts.models = []v3.ListModelsResponseEntry{
 		{ID: v3.UUID("11111111-1111-1111-1111-111111111111"), Name: "m1"},
 		{ID: v3.UUID("22222222-2222-2222-2222-222222222222"), Name: "m2"},

--- a/cmd/aiservices/model/model_list_test.go
+++ b/cmd/aiservices/model/model_list_test.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -13,8 +12,8 @@ import (
 
 	exocmd "github.com/exoscale/cli/cmd"
 	"github.com/exoscale/cli/pkg/globalstate"
+	"github.com/exoscale/cli/pkg/testutils"
 	v3 "github.com/exoscale/egoscale/v3"
-	"github.com/exoscale/egoscale/v3/credentials"
 )
 
 type modelListTestServer struct {
@@ -29,9 +28,9 @@ func newModelListTestServer(t *testing.T) *modelListTestServer {
 	mux.HandleFunc("/ai/model", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			writeJSON(t, w, http.StatusOK, v3.ListModelsResponse{Models: ts.models})
+			testutils.WriteJSON(t, w, http.StatusOK, v3.ListModelsResponse{Models: ts.models})
 		case http.MethodPost:
-			writeJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-model-create"), State: v3.OperationStateSuccess})
+			testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-model-create"), State: v3.OperationStateSuccess})
 		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}
@@ -41,7 +40,7 @@ func newModelListTestServer(t *testing.T) *modelListTestServer {
 		if r.Method == http.MethodGet {
 			for _, m := range ts.models {
 				if string(m.ID) == id {
-					writeJSON(t, w, http.StatusOK, v3.GetModelResponse{ID: m.ID, Name: m.Name, State: v3.GetModelResponseState(m.State), ModelSize: m.ModelSize, CreatedAT: m.CreatedAT, UpdatedAT: m.UpdatedAT})
+					testutils.WriteJSON(t, w, http.StatusOK, v3.GetModelResponse{ID: m.ID, Name: m.Name, State: v3.GetModelResponseState(m.State), ModelSize: m.ModelSize, CreatedAT: m.CreatedAT, UpdatedAT: m.UpdatedAT})
 					return
 				}
 			}
@@ -49,29 +48,17 @@ func newModelListTestServer(t *testing.T) *modelListTestServer {
 			return
 		}
 		if r.Method == http.MethodDelete {
-			writeJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-model-delete"), State: v3.OperationStateSuccess})
+			testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-model-delete"), State: v3.OperationStateSuccess})
 			return
 		}
 		w.WriteHeader(http.StatusMethodNotAllowed)
 	})
 	mux.HandleFunc("/zone", func(w http.ResponseWriter, r *http.Request) {
 		ts.zoneListCount.Add(1)
-		writeJSON(t, w, http.StatusOK, v3.ListZonesResponse{Zones: []v3.Zone{{APIEndpoint: v3.Endpoint(ts.server.URL), Name: v3.ZoneName("test-zone")}}})
+		testutils.WriteJSON(t, w, http.StatusOK, v3.ListZonesResponse{Zones: []v3.Zone{{APIEndpoint: v3.Endpoint(ts.server.URL), Name: v3.ZoneName("test-zone")}}})
 	})
 	ts.server = httptest.NewServer(mux)
 	return ts
-}
-
-func setupModelList(t *testing.T, ts *modelListTestServer) func() {
-	exocmd.GContext = context.Background()
-	globalstate.Quiet = true
-	creds := credentials.NewStaticCredentials("key", "secret")
-	client, err := v3.NewClient(creds)
-	if err != nil {
-		t.Fatalf("new client: %v", err)
-	}
-	globalstate.EgoscaleV3Client = client.WithEndpoint(v3.Endpoint(ts.server.URL))
-	return func() { ts.server.Close() }
 }
 
 func runModelListTest(t *testing.T, zoneFilter v3.ZoneName) (stdout, stderr string, err error) {
@@ -87,7 +74,9 @@ func runModelListTest(t *testing.T, zoneFilter v3.ZoneName) (stdout, stderr stri
 
 func TestModelList(t *testing.T) {
 	ts := newModelListTestServer(t)
-	defer setupModelList(t, ts)()
+	defer ts.server.Close()
+	testutils.SetupV3Client(t, ts.server.URL)
+
 	now := time.Now()
 	ts.models = []v3.ListModelsResponseEntry{
 		{ID: v3.UUID("11111111-1111-1111-1111-111111111111"), Name: "m1", State: v3.ListModelsResponseEntryStateReady, ModelSize: 0, CreatedAT: now, UpdatedAT: now},
@@ -122,7 +111,9 @@ func TestModelList(t *testing.T) {
 
 func TestModelListUsesZone(t *testing.T) {
 	ts := newModelListTestServer(t)
-	defer setupModelList(t, ts)()
+	defer ts.server.Close()
+	testutils.SetupV3Client(t, ts.server.URL)
+
 	cmd := &ModelListCmd{CliCommandSettings: exocmd.DefaultCLICmdSettings(), Zone: v3.ZoneName("test-zone")}
 	if err := cmd.CmdRun(nil, nil); err != nil {
 		t.Fatalf("model list: %v", err)
@@ -142,7 +133,8 @@ func TestModelListCmd_CmdShort(t *testing.T) {
 
 func TestModelList_ZoneEmpty(t *testing.T) {
 	ts := newModelListTestServer(t)
-	defer setupModelList(t, ts)()
+	defer ts.server.Close()
+	testutils.SetupV3Client(t, ts.server.URL)
 	defer withFormat(t, "json")()
 	ts.models = nil
 

--- a/cmd/aiservices/model/model_show_test.go
+++ b/cmd/aiservices/model/model_show_test.go
@@ -1,8 +1,6 @@
 package model
 
 import (
-	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"path"
@@ -10,10 +8,9 @@ import (
 	"time"
 
 	exocmd "github.com/exoscale/cli/cmd"
-	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
+	"github.com/exoscale/cli/pkg/testutils"
 	v3 "github.com/exoscale/egoscale/v3"
-	"github.com/exoscale/egoscale/v3/credentials"
 )
 
 // Minimal test server + helpers used across model tests in this package.
@@ -29,10 +26,10 @@ func newModelTestServer(t *testing.T) *modelTestServer {
 		switch r.Method {
 		case http.MethodGet:
 			resp := v3.ListModelsResponse{Models: ts.models}
-			writeJSON(t, w, http.StatusOK, resp)
+			testutils.WriteJSON(t, w, http.StatusOK, resp)
 		case http.MethodPost:
 			op := v3.Operation{ID: v3.UUID("op-model-create"), State: v3.OperationStateSuccess}
-			writeJSON(t, w, http.StatusOK, op)
+			testutils.WriteJSON(t, w, http.StatusOK, op)
 		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}
@@ -51,14 +48,14 @@ func newModelTestServer(t *testing.T) *modelTestServer {
 						CreatedAT: m.CreatedAT,
 						UpdatedAT: m.UpdatedAT,
 					}
-					writeJSON(t, w, http.StatusOK, resp)
+					testutils.WriteJSON(t, w, http.StatusOK, resp)
 					return
 				}
 			}
 			w.WriteHeader(http.StatusNotFound)
 		case http.MethodDelete:
 			op := v3.Operation{ID: v3.UUID("op-model-delete"), State: v3.OperationStateSuccess}
-			writeJSON(t, w, http.StatusOK, op)
+			testutils.WriteJSON(t, w, http.StatusOK, op)
 		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}
@@ -69,7 +66,7 @@ func newModelTestServer(t *testing.T) *modelTestServer {
 			return
 		}
 		op := v3.Operation{ID: v3.UUID(path.Base(r.URL.Path)), State: v3.OperationStateSuccess}
-		writeJSON(t, w, http.StatusOK, op)
+		testutils.WriteJSON(t, w, http.StatusOK, op)
 	})
 	mux.HandleFunc("/zone", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -77,39 +74,16 @@ func newModelTestServer(t *testing.T) *modelTestServer {
 			return
 		}
 		resp := v3.ListZonesResponse{Zones: []v3.Zone{{APIEndpoint: v3.Endpoint(ts.server.URL), Name: v3.ZoneName("test-zone")}}}
-		writeJSON(t, w, http.StatusOK, resp)
+		testutils.WriteJSON(t, w, http.StatusOK, resp)
 	})
 	ts.server = httptest.NewServer(mux)
 	return ts
 }
 
-func writeJSON(t *testing.T, w http.ResponseWriter, code int, v interface{}) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(code)
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		t.Fatalf("encode json: %v", err)
-	}
-}
-
-func newV3Client(t *testing.T, endpoint string) *v3.Client {
-	creds := credentials.NewStaticCredentials("key", "secret")
-	client, err := v3.NewClient(creds)
-	if err != nil {
-		t.Fatalf("new client: %v", err)
-	}
-	return client.WithEndpoint(v3.Endpoint(endpoint))
-}
-
-func modelSetup(t *testing.T, ts *modelTestServer) func() {
-	exocmd.GContext = context.Background()
-	globalstate.Quiet = true
-	globalstate.EgoscaleV3Client = newV3Client(t, ts.server.URL)
-	return func() { ts.server.Close() }
-}
-
 func TestModelShow(t *testing.T) {
 	ts := newModelTestServer(t)
-	defer modelSetup(t, ts)()
+	defer ts.server.Close()
+	testutils.SetupV3Client(t, ts.server.URL)
 	now := time.Now()
 	ts.models = []v3.ListModelsResponseEntry{{
 		ID:        v3.UUID("11111111-1111-1111-1111-111111111111"),

--- a/cmd/dbaas/dbaas_update_pg.go
+++ b/cmd/dbaas/dbaas_update_pg.go
@@ -174,7 +174,7 @@ func (c *dbaasServiceUpdateCmd) updatePG(cmd *cobra.Command, _ []string) error {
 			method := v3.EnumMigrationMethod(c.PGMigrationMethod)
 			databaseService.Migration.Method = method
 		}
-		if len(c.MysqlMigrationIgnoreDbs) > 0 {
+		if len(c.PGMigrationIgnoreDbs) > 0 {
 			dbsJoin := strings.Join(c.PGMigrationIgnoreDbs, ",")
 			databaseService.Migration.IgnoreDbs = dbsJoin
 		}

--- a/cmd/dbaas/dbaas_update_pg_test.go
+++ b/cmd/dbaas/dbaas_update_pg_test.go
@@ -1,0 +1,124 @@
+package dbaas
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	exocmd "github.com/exoscale/cli/cmd"
+	"github.com/exoscale/cli/pkg/testutils"
+	v3 "github.com/exoscale/egoscale/v3"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDBAASPGUpdate(t *testing.T) {
+	var gotReq v3.UpdateDBAASServicePGRequest
+	ts := setupPGUpdateTestServer(t, &gotReq)
+	defer ts.Close()
+
+	testutils.SetupV3Client(t, ts.URL)
+
+	c := &dbaasServiceUpdateCmd{
+		CliCommandSettings: exocmd.DefaultCLICmdSettings(),
+	}
+	rootCmd := &cobra.Command{}
+	err := exocmd.RegisterCLICommand(rootCmd, c)
+	require.NoError(t, err)
+	rootCmd.SetArgs([]string{
+		"update", "testdb",
+		"--zone", "test-zone",
+		"--pg-migration-host", "123.123.123.123",
+		"--pg-migration-port", "5432",
+		"--pg-migration-username", "testsuperuser",
+		"--pg-migration-password", "testpassword",
+		"--pg-migration-method", "replication",
+		"--pg-migration-ssl",
+		"--pg-migration-dbname", "testdb",
+		"--pg-migration-ignore-dbs", "telegraf,nagiosdb",
+		"--force",
+	})
+	err = rootCmd.Execute()
+	require.NoError(t, err)
+
+	sslBool := true
+	expReq := v3.UpdateDBAASServicePGRequest{
+		Migration: &v3.UpdateDBAASServicePGRequestMigration{
+			Dbname:    "testdb",
+			Host:      "123.123.123.123",
+			Port:      5432,
+			Password:  "testpassword",
+			Username:  "testsuperuser",
+			Method:    "replication",
+			SSL:       &sslBool,
+			IgnoreDbs: "telegraf,nagiosdb",
+		},
+	}
+
+	assert.Equal(t, expReq, gotReq)
+}
+
+func setupPGUpdateTestServer(t *testing.T, gotReq *v3.UpdateDBAASServicePGRequest) *httptest.Server {
+	t.Helper()
+
+	var ts *httptest.Server
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/zone", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		resp := v3.ListZonesResponse{Zones: []v3.Zone{{APIEndpoint: v3.Endpoint(ts.URL), Name: v3.ZoneName("test-zone")}}}
+		testutils.WriteJSON(t, w, http.StatusOK, resp)
+	})
+
+	mux.HandleFunc("/dbaas-service", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			resp := v3.ListDBAASServicesResponse{
+				DBAASServices: []v3.DBAASServiceCommon{
+					{
+						Name: "testdb",
+						Type: "pg",
+					},
+				},
+			}
+			testutils.WriteJSON(t, w, http.StatusOK, resp)
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	})
+
+	mux.HandleFunc("/dbaas-settings-pg", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			resp := v3.GetDBAASSettingsPGResponse{}
+			testutils.WriteJSON(t, w, http.StatusOK, resp)
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	})
+
+	mux.HandleFunc("/dbaas-postgres/testdb", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			body, _ := io.ReadAll(r.Body)
+			err := r.Body.Close()
+			require.NoError(t, err)
+			err = json.Unmarshal(body, gotReq)
+			require.NoError(t, err)
+			testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-update"), State: v3.OperationStateSuccess})
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	})
+
+	mux.HandleFunc("/operation/", func(w http.ResponseWriter, r *http.Request) {
+		testutils.WriteJSON(t, w, http.StatusOK, v3.Operation{ID: v3.UUID("op-update"), State: v3.OperationStateSuccess})
+	})
+
+	ts = httptest.NewUnstartedServer(mux)
+	ts.Start()
+	return ts
+}

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -1,0 +1,43 @@
+package testutils
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	exocmd "github.com/exoscale/cli/cmd"
+	"github.com/exoscale/cli/pkg/globalstate"
+	v3 "github.com/exoscale/egoscale/v3"
+	"github.com/exoscale/egoscale/v3/credentials"
+)
+
+// WriteJSON encodes v to w as JSON, and sets the response Content-Type to
+// application/json with the given status code.
+func WriteJSON(t *testing.T, w http.ResponseWriter, code int, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("encode json: %v", err)
+	}
+}
+
+// NewV3Client returns a v3.Client with test credentials and the given endpoint.
+func NewV3Client(t *testing.T, endpoint string) *v3.Client {
+	t.Helper()
+	creds := credentials.NewStaticCredentials("key", "secret")
+	client, err := v3.NewClient(creds)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	return client.WithEndpoint(v3.Endpoint(endpoint))
+}
+
+// SetupV3Client creates a v3.Client and sets it in the global state.
+func SetupV3Client(t *testing.T, endpoint string) {
+	t.Helper()
+	exocmd.GContext = context.Background()
+	globalstate.Quiet = true
+	globalstate.EgoscaleV3Client = NewV3Client(t, endpoint)
+}


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Previously the value of `--pg-migration-ignore-dbs` was being ignored, since the command checked for the value of `MysqlMigrationIgnoreDbs` instead of `PGMigrationIgnoreDbs`.

I also took the opportunity to DRY some of our test helpers and move them into a common `testutils` package.

Part of internal support ticket 1167395.

## Checklist
(For exoscale contributors)

* [x] Changelog updated
* [x] Testing

## Testing

Added a new unit test that confirms the value is correctly sent to the server.