### PR TITLE
test(e2e): embed short commit SHA in cli-e2e- prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - e2e: prefix API test run IDs with `cli-e2e-` so shared test org resources don't collide with other repos
+- e2e: embed the short commit SHA in the `cli-e2e-` prefix so leaked resources can be traced back to the commit that created them
 
 ## 1.95.1
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -21,9 +21,10 @@ go test -v -tags=api -run X      # api only, set EXOSCALE_API_KEY and EXOSCALE_A
 
 ## Resource naming
 
-API tests share an Exoscale org with other repos (terraform-provider, csi-driver, ...). The runner injects a unique `TEST_RUN_ID` prefixed with `cli-e2e-` into every scenario. Use it for every resource you create.
+API tests share an Exoscale org with other repos. The runner injects a unique `TEST_RUN_ID` into every scenario. Use it for every resource you create.
 
 - good: `${TEST_RUN_ID}-nlb-a`, `pg-$TEST_RUN_ID`, `reboot-$TEST_RUN_ID`
+- shape: `cli-e2e-<short-sha>-<unix>-<rand6>`, the SHA is for traceability
 - bad: hardcoded names, or `e2e-...` without the `cli-` part
 
 Placeholders that intentionally don't exist (for not-found error tests) are fine as-is, e.g. `nonexistent-e2e-instance`.

--- a/tests/e2e/testscript_api_test.go
+++ b/tests/e2e/testscript_api_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -53,10 +54,9 @@ func runAPITestSuite(t *testing.T, dir string) {
 		zone = "ch-gva-2"
 	}
 
-	// Prefix every test resource with `cli-e2e-` so runs against the shared
-	// Exoscale test organisation do not collide with resources created by
-	// other repositories (terraform-provider-exoscale, csi-driver, ...).
-	runID := fmt.Sprintf("cli-e2e-%d-%s", time.Now().Unix(), randString(6))
+	// Prefix shared-test-org resources with cli-e2e-<sha>- so a leaked
+	// resource maps back to the commit that created it.
+	runID := fmt.Sprintf("cli-e2e-%s-%d-%s", shortSHA(), time.Now().Unix(), randString(6))
 	t.Logf("API test run ID: %s (zone: %s)", runID, zone)
 
 	suite := &APITestSuite{
@@ -322,4 +322,28 @@ func randString(n int) string {
 		b[i] = letters[r.Intn(len(letters))]
 	}
 	return string(b)
+}
+
+// shortSHA returns the short commit SHA of the CLI repo, or "unknown" if
+// git is unavailable, so the prefix stays well-formed.
+func shortSHA() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "unknown"
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			cmd := exec.Command("git", "-C", dir, "rev-parse", "--short", "HEAD")
+			out, err := cmd.Output()
+			if err != nil {
+				return "unknown"
+			}
+			return strings.TrimSpace(string(out))
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "unknown"
+		}
+		dir = parent
+	}
 }


### PR DESCRIPTION
## Description

PR #841 made the `cli-e2e-` prefix the single source of truth for naming API e2e test resources. This PR embeds the short commit SHA of the CLI repo into the prefix so any leaked resource in the portal can be traced straight back to the commit that created it.

Concrete change: `TEST_RUN_ID` is now `cli-e2e-<short-sha>-<unix>-<rand6>` instead of `cli-e2e-<unix>-<rand6>`. So an NLB is now named `cli-e2e-abc1234-1717000000-xyz789-nlb-a`. On `git log` for `abc1234` you get the commit; on that commit's page, you get the PR.

The SHA is resolved at test startup with `git rev-parse --short HEAD`. If git is not on `PATH` or the working copy is not inside a git repository, the helper returns `unknown` and the prefix stays well-formed rather than failing the suite.

## Related issue

Follow-up to #841.

## Changes

- `tests/e2e/testscript_api_test.go`: `runID` now includes the short SHA. Added a `shortSHA` helper that walks up to find the repo root and shells out to git. Falls back to `unknown` on failure.
- `tests/e2e/README.md`: documents the new `cli-e2e-<short-sha>-<unix>-<rand6>` shape.
- `CHANGELOG.md`: entry under Unreleased.

## Checklist

- [x] Changelog updated (Unreleased block)
- [x] Testing

## Testing

- `go vet ./...` and `go vet -tags=api ./...` from `tests/e2e/` pass.
- `go build ./...` and `go build -tags=api ./...` from `tests/e2e/` pass.
- Smoke-tested the `shortSHA` helper standalone in a one-off Go program; returned the expected 8-char SHA (git returns longer than 7 chars when the 7-char prefix is ambiguous).

I have not run the actual `-tags=api` scenarios because they need `EXOSCALE_API_KEY` and `EXOSCALE_API_SECRET`. CI is the source of truth for the full run.

## Notes for reviewers

- Name length: with the SHA the prefix is up to ~31 chars including the descriptor suffix. Exoscale's NLB name limit is 255 chars, instance name limit is 255, PG service name limit is 63. All safe.
- `git rev-parse --short` is intentionally left unconstrained on length. Git will return 7 chars by default and grow the short form automatically if 7 chars are ambiguous, which is the right behaviour.
- The `unknown` fallback is for environments where git is not installed (e.g. some minimal CI images). The `cli-e2e-` prefix is preserved in that case, so collision protection from #841 still works.