### PR TITLE
chore: re-enable arm64 builds for Windows

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,8 +33,6 @@ builds:
         goarch: arm64
       - goos: windows
         goarch: arm
-      - goos: windows
-        goarch: arm64
 
 # macOS Universal Binaries
 universal_binaries:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - storage: add `move` command for moving objects within and across buckets #838
+- Re-introduce ARM64 builds for Windows #844
 
 ### Improvements
 


### PR DESCRIPTION
# Description

This PR re-enables ARM64 builds for Windows.

## Why this matters

I maintain the [`setup-exoscale`](https://github.com/nhedger/setup-exoscale) GitHub action, and I'm about to introduce support for ARM64 runners. 

For completeness, I'd like to support Windows ARM64 runners as well, but you stopped building ARM64 binaries for Windows a few versions back (#582).

## Review notes

I've only re-introduced `arm64`, not `arm`.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block, and add the Pull Request #number for each bit you add to the `CHANGELOG.md`)
* [ ] Testing

## Testing

n/a