### PR TITLE
build(deps): bump egoscale v3.1.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - e2e: prefix API test run IDs with `cli-e2e-` so shared test org resources don't collide with other repos
 
+### Bug fixes
+
+- dbaas: fix zone switching for DBaaS-only IAM keys (egoscale#767)
+
 ## 1.95.1
 
 ### Bug fixes

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/smithy-go v1.1.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/exoscale/egoscale/v3 v3.1.36-0.20260424083744-33446130ebd9
+	github.com/exoscale/egoscale/v3 v3.1.40
 	github.com/exoscale/openapi-cli-generator v1.2.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/go-control-plane v0.10.1/go.mod h1:AY7fTTXNdv/aJ2O5jwpxAPOWUZ7hQAEvzN5Pf27BkQQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
-github.com/exoscale/egoscale/v3 v3.1.36-0.20260424083744-33446130ebd9 h1:3fQP3zqWwhhiWflStd1Ns1DPXx2yxpN0fhlqEZ/vYgI=
-github.com/exoscale/egoscale/v3 v3.1.36-0.20260424083744-33446130ebd9/go.mod h1:/1RTNibUdltIdzBbFxMMewNAkB6KKdxzRE/Icu8K5RU=
+github.com/exoscale/egoscale/v3 v3.1.40 h1:OyDrJF8VpMrgcVJuiCrMoTxONnoVwYLF1pfJ5biqKKo=
+github.com/exoscale/egoscale/v3 v3.1.40/go.mod h1:DUTgeubl5msPAo3SKFed04AxNhyTNOrCTJHZDRYLR10=
 github.com/exoscale/openapi-cli-generator v1.2.0 h1:xgTff1bInBP+JZCauD7Jq9GNBFoKK31Cnv5FIAcxtrk=
 github.com/exoscale/openapi-cli-generator v1.2.0/go.mod h1:TZBnbT7f3hJ5ImyUphJwRM+X5xF/zCQZ6o8a42gQeTs=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=

--- a/vendor/github.com/exoscale/egoscale/v3/operations.go
+++ b/vendor/github.com/exoscale/egoscale/v3/operations.go
@@ -12,9 +12,9 @@ import (
 	"time"
 )
 
-// FindAIAPIKey attempts to find an AIAPIKey by nameOrID.
-func (l ListAIAPIKeysResponse) FindAIAPIKey(nameOrID string) (AIAPIKey, error) {
-	var result []AIAPIKey
+// FindListAIAPIKeysResponseEntry attempts to find an ListAIAPIKeysResponseEntry by nameOrID.
+func (l ListAIAPIKeysResponse) FindListAIAPIKeysResponseEntry(nameOrID string) (ListAIAPIKeysResponseEntry, error) {
+	var result []ListAIAPIKeysResponseEntry
 	for i, elem := range l.AIAPIKeys {
 		if string(elem.Name) == nameOrID || string(elem.ID) == nameOrID {
 			result = append(result, l.AIAPIKeys[i])
@@ -25,15 +25,15 @@ func (l ListAIAPIKeysResponse) FindAIAPIKey(nameOrID string) (AIAPIKey, error) {
 	}
 
 	if len(result) > 1 {
-		return AIAPIKey{}, fmt.Errorf("%q too many found in ListAIAPIKeysResponse: %w", nameOrID, ErrConflict)
+		return ListAIAPIKeysResponseEntry{}, fmt.Errorf("%q too many found in ListAIAPIKeysResponse: %w", nameOrID, ErrConflict)
 	}
 
-	return AIAPIKey{}, fmt.Errorf("%q not found in ListAIAPIKeysResponse: %w", nameOrID, ErrNotFound)
+	return ListAIAPIKeysResponseEntry{}, fmt.Errorf("%q not found in ListAIAPIKeysResponse: %w", nameOrID, ErrNotFound)
 }
 
 // List AI API keys for an organization
 func (c Client) ListAIAPIKeys(ctx context.Context) (*ListAIAPIKeysResponse, error) {
-	path := "/ai/ai-api-key"
+	path := "/ai/api-key"
 
 	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
 	if err != nil {
@@ -76,8 +76,8 @@ func (c Client) ListAIAPIKeys(ctx context.Context) (*ListAIAPIKeysResponse, erro
 }
 
 // Create a new AI API key
-func (c Client) CreateAIAPIKey(ctx context.Context, req CreateAIAPIKeyRequest) (*AIAPIKeyWithValue, error) {
-	path := "/ai/ai-api-key"
+func (c Client) CreateAIAPIKey(ctx context.Context, req CreateAIAPIKeyRequest) (*CreateAIAPIKeyResponse, error) {
+	path := "/ai/api-key"
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
@@ -118,7 +118,7 @@ func (c Client) CreateAIAPIKey(ctx context.Context, req CreateAIAPIKeyRequest) (
 		return nil, fmt.Errorf("CreateAIAPIKey: http response: %w", err)
 	}
 
-	bodyresp := new(AIAPIKeyWithValue)
+	bodyresp := new(CreateAIAPIKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateAIAPIKey: prepare Json response: %w", err)
 	}
@@ -126,57 +126,9 @@ func (c Client) CreateAIAPIKey(ctx context.Context, req CreateAIAPIKeyRequest) (
 	return bodyresp, nil
 }
 
-type DeleteAIAPIKeyResponse struct {
-	Deleted *bool `json:"deleted" validate:"required"`
-}
-
-// Delete AI API key
-func (c Client) DeleteAIAPIKey(ctx context.Context, id UUID) (*DeleteAIAPIKeyResponse, error) {
-	path := fmt.Sprintf("/ai/ai-api-key/%v", id)
-
-	request, err := http.NewRequestWithContext(ctx, "DELETE", c.serverEndpoint+path, nil)
-	if err != nil {
-		return nil, fmt.Errorf("DeleteAIAPIKey: new request: %w", err)
-	}
-
-	request.Header.Add("User-Agent", c.getUserAgent())
-
-	if err := c.executeRequestInterceptors(ctx, request); err != nil {
-		return nil, fmt.Errorf("DeleteAIAPIKey: execute request editors: %w", err)
-	}
-
-	if err := c.signRequest(request); err != nil {
-		return nil, fmt.Errorf("DeleteAIAPIKey: sign request: %w", err)
-	}
-
-	if c.trace {
-		dumpRequest(request, "delete-ai-api-key")
-	}
-
-	response, err := c.httpClient.Do(request)
-	if err != nil {
-		return nil, fmt.Errorf("DeleteAIAPIKey: http client do: %w", err)
-	}
-
-	if c.trace {
-		dumpResponse(response)
-	}
-
-	if err := handleHTTPErrorResp(response); err != nil {
-		return nil, fmt.Errorf("DeleteAIAPIKey: http response: %w", err)
-	}
-
-	bodyresp := new(DeleteAIAPIKeyResponse)
-	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteAIAPIKey: prepare Json response: %w", err)
-	}
-
-	return bodyresp, nil
-}
-
 // Get AI API key metadata
-func (c Client) GetAIAPIKey(ctx context.Context, id UUID) (*AIAPIKey, error) {
-	path := fmt.Sprintf("/ai/ai-api-key/%v", id)
+func (c Client) GetAIAPIKey(ctx context.Context, id UUID) (*GetAIAPIKeyResponse, error) {
+	path := fmt.Sprintf("/ai/api-key/%v", id)
 
 	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
 	if err != nil {
@@ -210,7 +162,7 @@ func (c Client) GetAIAPIKey(ctx context.Context, id UUID) (*AIAPIKey, error) {
 		return nil, fmt.Errorf("GetAIAPIKey: http response: %w", err)
 	}
 
-	bodyresp := new(AIAPIKey)
+	bodyresp := new(GetAIAPIKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetAIAPIKey: prepare Json response: %w", err)
 	}
@@ -219,8 +171,8 @@ func (c Client) GetAIAPIKey(ctx context.Context, id UUID) (*AIAPIKey, error) {
 }
 
 // Update AI API key name and/or scope
-func (c Client) UpdateAIAPIKey(ctx context.Context, id UUID, req UpdateAIAPIKeyRequest) (*AIAPIKey, error) {
-	path := fmt.Sprintf("/ai/ai-api-key/%v", id)
+func (c Client) UpdateAIAPIKey(ctx context.Context, id UUID, req UpdateAIAPIKeyRequest) (*UpdateAIAPIKeyResponse, error) {
+	path := fmt.Sprintf("/ai/api-key/%v", id)
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
@@ -261,7 +213,7 @@ func (c Client) UpdateAIAPIKey(ctx context.Context, id UUID, req UpdateAIAPIKeyR
 		return nil, fmt.Errorf("UpdateAIAPIKey: http response: %w", err)
 	}
 
-	bodyresp := new(AIAPIKey)
+	bodyresp := new(UpdateAIAPIKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateAIAPIKey: prepare Json response: %w", err)
 	}
@@ -269,9 +221,53 @@ func (c Client) UpdateAIAPIKey(ctx context.Context, id UUID, req UpdateAIAPIKeyR
 	return bodyresp, nil
 }
 
+// Reveal AI API key plaintext value
+func (c Client) RevealAIAPIKey(ctx context.Context, id UUID) (*RevealAIAPIKeyResponse, error) {
+	path := fmt.Sprintf("/ai/api-key/%v/reveal", id)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("RevealAIAPIKey: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("RevealAIAPIKey: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("RevealAIAPIKey: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reveal-ai-api-key")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("RevealAIAPIKey: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("RevealAIAPIKey: http response: %w", err)
+	}
+
+	bodyresp := new(RevealAIAPIKeyResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("RevealAIAPIKey: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
 // Rotate AI API key value
-func (c Client) RotateAIAPIKey(ctx context.Context, id UUID) (*AIAPIKeyWithValue, error) {
-	path := fmt.Sprintf("/ai/ai-api-key/%v/rotate", id)
+func (c Client) RotateAIAPIKey(ctx context.Context, id UUID) (*RotateAIAPIKeyResponse, error) {
+	path := fmt.Sprintf("/ai/api-key/%v/rotate", id)
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, nil)
 	if err != nil {
@@ -305,7 +301,7 @@ func (c Client) RotateAIAPIKey(ctx context.Context, id UUID) (*AIAPIKeyWithValue
 		return nil, fmt.Errorf("RotateAIAPIKey: http response: %w", err)
 	}
 
-	bodyresp := new(AIAPIKeyWithValue)
+	bodyresp := new(RotateAIAPIKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RotateAIAPIKey: prepare Json response: %w", err)
 	}
@@ -1062,6 +1058,50 @@ func (c Client) GetModel(ctx context.Context, id UUID) (*GetModelResponse, error
 	bodyresp := new(GetModelResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("GetModel: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// Get per-org Unit Of Measurement (UOM) consumption quota (UOM/min). Null means unlimited. UOM represents weighted units across different AI workloads (e.g., tokens for LLMs, minutes for TTS, pages for OCR).
+func (c Client) GetUserOrgConsumptionQuota(ctx context.Context) (*OrgConsumptionQuotaResponse, error) {
+	path := "/ai/quota"
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetUserOrgConsumptionQuota: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GetUserOrgConsumptionQuota: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GetUserOrgConsumptionQuota: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-user-org-consumption-quota")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GetUserOrgConsumptionQuota: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GetUserOrgConsumptionQuota: http response: %w", err)
+	}
+
+	bodyresp := new(OrgConsumptionQuotaResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GetUserOrgConsumptionQuota: prepare Json response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6864,6 +6904,8 @@ type CreateDBAASServicePGRequest struct {
 	Migration *CreateDBAASServicePGRequestMigration `json:"migration,omitempty"`
 	// postgresql.conf configuration values
 	PGSettings *JSONSchemaPG `json:"pg-settings,omitempty"`
+	// System-wide settings for the pgaudit extension.
+	PgauditSettings *JSONSchemaPgaudit `json:"pgaudit-settings,omitempty"`
 	// System-wide settings for pgbouncer.
 	PgbouncerSettings *JSONSchemaPgbouncer `json:"pgbouncer-settings,omitempty"`
 	// System-wide settings for pglookout.
@@ -6992,6 +7034,8 @@ type UpdateDBAASServicePGRequest struct {
 	Migration *UpdateDBAASServicePGRequestMigration `json:"migration,omitempty"`
 	// postgresql.conf configuration values
 	PGSettings *JSONSchemaPG `json:"pg-settings,omitempty"`
+	// System-wide settings for the pgaudit extension.
+	PgauditSettings *JSONSchemaPgaudit `json:"pgaudit-settings,omitempty"`
 	// System-wide settings for pgbouncer.
 	PgbouncerSettings *JSONSchemaPgbouncer `json:"pgbouncer-settings,omitempty"`
 	// System-wide settings for pglookout.
@@ -11115,8 +11159,8 @@ func (c Client) ListIAMRoles(ctx context.Context) (*ListIAMRolesResponse, error)
 }
 
 type CreateIAMRoleRequest struct {
-	// Policy
-	AssumeRolePolicy *IAMPolicy `json:"assume-role-policy,omitempty"`
+	// Assume Role Policy
+	AssumeRolePolicy *IAMAssumeRolePolicy `json:"assume-role-policy,omitempty"`
 	// IAM Role description
 	Description string `json:"description,omitempty" validate:"omitempty,gte=1,lte=255"`
 	// Sets if the IAM Role Policy is editable or not (default: true). This setting cannot be changed after creation
@@ -11272,6 +11316,8 @@ func (c Client) GetIAMRole(ctx context.Context, id UUID) (*IAMRole, error) {
 }
 
 type UpdateIAMRoleRequest struct {
+	// Assume Role Policy
+	AssumeRolePolicy *IAMAssumeRolePolicy `json:"assume-role-policy,omitempty"`
 	// IAM Role description
 	Description string `json:"description,omitempty" validate:"omitempty,gte=1,lte=255"`
 	Labels      Labels `json:"labels,omitempty"`
@@ -11332,18 +11378,32 @@ func (c Client) UpdateIAMRole(ctx context.Context, id UUID, req UpdateIAMRoleReq
 	return bodyresp, nil
 }
 
-// Update IAM Assume role Policy
-func (c Client) UpdateIAMRoleAssumePolicy(ctx context.Context, id UUID, req IAMPolicy) (*Operation, error) {
-	path := fmt.Sprintf("/iam-role/%v:assume-role-policy", id)
+type AssumeIAMRoleResponse struct {
+	ExpiresAT string `json:"expires-at,omitempty"`
+	Key       string `json:"key,omitempty"`
+	Name      string `json:"name,omitempty"`
+	OrgID     string `json:"org-id,omitempty"`
+	RoleID    string `json:"role-id,omitempty"`
+	Secret    string `json:"secret,omitempty"`
+}
+
+type AssumeIAMRoleRequest struct {
+	// TTL in seconds for the generated access key (cannot exceed the max TTL defined in the targeted assume role)
+	Ttl int64 `json:"ttl" validate:"required,gt=0"`
+}
+
+// [BETA] Request generation of key/secret that allow caller to assume target role
+func (c Client) AssumeIAMRole(ctx context.Context, id UUID, req AssumeIAMRoleRequest) (*AssumeIAMRoleResponse, error) {
+	path := fmt.Sprintf("/iam-role/%v/assume", id)
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateIAMRoleAssumePolicy: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AssumeIAMRole: prepare Json body: %w", err)
 	}
 
-	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
+	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateIAMRoleAssumePolicy: new request: %w", err)
+		return nil, fmt.Errorf("AssumeIAMRole: new request: %w", err)
 	}
 
 	request.Header.Add("User-Agent", c.getUserAgent())
@@ -11351,20 +11411,20 @@ func (c Client) UpdateIAMRoleAssumePolicy(ctx context.Context, id UUID, req IAMP
 	request.Header.Add("Content-Type", "application/json")
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
-		return nil, fmt.Errorf("UpdateIAMRoleAssumePolicy: execute request editors: %w", err)
+		return nil, fmt.Errorf("AssumeIAMRole: execute request editors: %w", err)
 	}
 
 	if err := c.signRequest(request); err != nil {
-		return nil, fmt.Errorf("UpdateIAMRoleAssumePolicy: sign request: %w", err)
+		return nil, fmt.Errorf("AssumeIAMRole: sign request: %w", err)
 	}
 
 	if c.trace {
-		dumpRequest(request, "update-iam-role-assume-policy")
+		dumpRequest(request, "assume-iam-role")
 	}
 
 	response, err := c.httpClient.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateIAMRoleAssumePolicy: http client do: %w", err)
+		return nil, fmt.Errorf("AssumeIAMRole: http client do: %w", err)
 	}
 
 	if c.trace {
@@ -11372,12 +11432,12 @@ func (c Client) UpdateIAMRoleAssumePolicy(ctx context.Context, id UUID, req IAMP
 	}
 
 	if err := handleHTTPErrorResp(response); err != nil {
-		return nil, fmt.Errorf("UpdateIAMRoleAssumePolicy: http response: %w", err)
+		return nil, fmt.Errorf("AssumeIAMRole: http response: %w", err)
 	}
 
-	bodyresp := new(Operation)
+	bodyresp := new(AssumeIAMRoleResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateIAMRoleAssumePolicy: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AssumeIAMRole: prepare Json response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11429,70 +11489,6 @@ func (c Client) UpdateIAMRolePolicy(ctx context.Context, id UUID, req IAMPolicy)
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("UpdateIAMRolePolicy: prepare Json response: %w", err)
-	}
-
-	return bodyresp, nil
-}
-
-type AssumeIAMRoleResponse struct {
-	Key    string `json:"key,omitempty"`
-	Name   string `json:"name,omitempty"`
-	OrgID  string `json:"org-id,omitempty"`
-	RoleID string `json:"role-id,omitempty"`
-	Secret string `json:"secret,omitempty"`
-}
-
-type AssumeIAMRoleRequest struct {
-	// TTL in seconds for the generated access key (cannot exceed the max TTL defined in the targeted assume role)
-	Ttl int64 `json:"ttl,omitempty" validate:"omitempty,gt=0"`
-}
-
-// [BETA] Request generation of key/secret that allow caller to assume target role
-func (c Client) AssumeIAMRole(ctx context.Context, targetRoleID UUID, req AssumeIAMRoleRequest) (*AssumeIAMRoleResponse, error) {
-	path := fmt.Sprintf("/iam-role/%v/assume", targetRoleID)
-
-	body, err := prepareJSONBody(req)
-	if err != nil {
-		return nil, fmt.Errorf("AssumeIAMRole: prepare Json body: %w", err)
-	}
-
-	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
-	if err != nil {
-		return nil, fmt.Errorf("AssumeIAMRole: new request: %w", err)
-	}
-
-	request.Header.Add("User-Agent", c.getUserAgent())
-
-	request.Header.Add("Content-Type", "application/json")
-
-	if err := c.executeRequestInterceptors(ctx, request); err != nil {
-		return nil, fmt.Errorf("AssumeIAMRole: execute request editors: %w", err)
-	}
-
-	if err := c.signRequest(request); err != nil {
-		return nil, fmt.Errorf("AssumeIAMRole: sign request: %w", err)
-	}
-
-	if c.trace {
-		dumpRequest(request, "assume-iam-role")
-	}
-
-	response, err := c.httpClient.Do(request)
-	if err != nil {
-		return nil, fmt.Errorf("AssumeIAMRole: http client do: %w", err)
-	}
-
-	if c.trace {
-		dumpResponse(response)
-	}
-
-	if err := handleHTTPErrorResp(response); err != nil {
-		return nil, fmt.Errorf("AssumeIAMRole: http response: %w", err)
-	}
-
-	bodyresp := new(AssumeIAMRoleResponse)
-	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AssumeIAMRole: prepare Json response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13987,6 +13983,50 @@ func (c Client) ScheduleKmsKeyDeletion(ctx context.Context, id UUID, req Schedul
 	bodyresp := new(SuccessResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("ScheduleKmsKeyDeletion: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// [BETA] Returns the live-balance of the current organization.
+func (c Client) GetLiveBalance(ctx context.Context) (*LiveBalance, error) {
+	path := "/live-balance"
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetLiveBalance: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GetLiveBalance: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GetLiveBalance: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-live-balance")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GetLiveBalance: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GetLiveBalance: http response: %w", err)
+	}
+
+	bodyresp := new(LiveBalance)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GetLiveBalance: prepare Json response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16752,6 +16792,102 @@ func (c Client) GetSKSClusterAuthorityCert(ctx context.Context, id UUID, authori
 	return bodyresp, nil
 }
 
+type GenerateSKSKarpenterExoscaleNodeclassResponse struct {
+	ExoscaleNodeclass string `json:"exoscale-nodeclass,omitempty"`
+}
+
+// Generate a Karpenter ExoscaleNodeClass manifest for an SKS cluster, including its default security group and feature flags if present
+func (c Client) GenerateSKSKarpenterExoscaleNodeclass(ctx context.Context, id UUID) (*GenerateSKSKarpenterExoscaleNodeclassResponse, error) {
+	path := fmt.Sprintf("/sks-cluster/%v/generate-karpenter-exoscale-nodeclass", id)
+
+	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterExoscaleNodeclass: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterExoscaleNodeclass: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterExoscaleNodeclass: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "generate-sks-karpenter-exoscale-nodeclass")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterExoscaleNodeclass: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterExoscaleNodeclass: http response: %w", err)
+	}
+
+	bodyresp := new(GenerateSKSKarpenterExoscaleNodeclassResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterExoscaleNodeclass: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type GenerateSKSKarpenterNodepoolResponse struct {
+	Nodepool string `json:"nodepool,omitempty"`
+}
+
+// Generate a Karpenter NodePool manifest with minimal configuration for an SKS cluster
+func (c Client) GenerateSKSKarpenterNodepool(ctx context.Context, id UUID) (*GenerateSKSKarpenterNodepoolResponse, error) {
+	path := fmt.Sprintf("/sks-cluster/%v/generate-karpenter-nodepool", id)
+
+	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterNodepool: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterNodepool: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterNodepool: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "generate-sks-karpenter-nodepool")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterNodepool: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterNodepool: http response: %w", err)
+	}
+
+	bodyresp := new(GenerateSKSKarpenterNodepoolResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GenerateSKSKarpenterNodepool: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
 type GetSKSClusterInspectionResponse map[string]any
 
 // Helps troubleshoot common problems when deploying a kubernetes cluster. Inspections run every couple of minutes.
@@ -18801,6 +18937,279 @@ func (c Client) UpdateUserRole(ctx context.Context, id UUID, req UpdateUserRoleR
 	return bodyresp, nil
 }
 
+type ListVpcsResponse struct {
+	Vpcs []ListVpcResponseEntry `json:"vpcs,omitempty"`
+}
+
+// FindListVpcResponseEntry attempts to find an ListVpcResponseEntry by nameOrID.
+func (l ListVpcsResponse) FindListVpcResponseEntry(nameOrID string) (ListVpcResponseEntry, error) {
+	var result []ListVpcResponseEntry
+	for i, elem := range l.Vpcs {
+		if string(elem.Name) == nameOrID || string(elem.ID) == nameOrID {
+			result = append(result, l.Vpcs[i])
+		}
+	}
+	if len(result) == 1 {
+		return result[0], nil
+	}
+
+	if len(result) > 1 {
+		return ListVpcResponseEntry{}, fmt.Errorf("%q too many found in ListVpcsResponse: %w", nameOrID, ErrConflict)
+	}
+
+	return ListVpcResponseEntry{}, fmt.Errorf("%q not found in ListVpcsResponse: %w", nameOrID, ErrNotFound)
+}
+
+// [BETA] List VPCs
+func (c Client) ListVpcs(ctx context.Context) (*ListVpcsResponse, error) {
+	path := "/vpc"
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("ListVpcs: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("ListVpcs: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("ListVpcs: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "list-vpcs")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("ListVpcs: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("ListVpcs: http response: %w", err)
+	}
+
+	bodyresp := new(ListVpcsResponse)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("ListVpcs: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type CreateVpcRequest struct {
+	// VPC description
+	Description string `json:"description,omitempty" validate:"omitempty,lte=4096"`
+	Labels      Labels `json:"labels,omitempty"`
+	// VPC name
+	Name string `json:"name" validate:"required,gte=1,lte=255"`
+}
+
+// [BETA] Create a VPC
+func (c Client) CreateVpc(ctx context.Context, req CreateVpcRequest) (*Operation, error) {
+	path := "/vpc"
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("CreateVpc: prepare Json body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("CreateVpc: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("CreateVpc: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("CreateVpc: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "create-vpc")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("CreateVpc: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("CreateVpc: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("CreateVpc: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// [BETA] Delete a VPC
+func (c Client) DeleteVpc(ctx context.Context, id UUID) (*Operation, error) {
+	path := fmt.Sprintf("/vpc/%v", id)
+
+	request, err := http.NewRequestWithContext(ctx, "DELETE", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteVpc: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("DeleteVpc: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("DeleteVpc: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "delete-vpc")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("DeleteVpc: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("DeleteVpc: http response: %w", err)
+	}
+
+	bodyresp := new(Operation)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("DeleteVpc: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// [BETA] Retrieve VPC details
+func (c Client) GetVpc(ctx context.Context, id UUID) (*Vpc, error) {
+	path := fmt.Sprintf("/vpc/%v", id)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetVpc: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("GetVpc: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("GetVpc: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "get-vpc")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("GetVpc: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("GetVpc: http response: %w", err)
+	}
+
+	bodyresp := new(Vpc)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("GetVpc: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+type UpdateVpcRequest struct {
+	// VPC description
+	Description *string `json:"description,omitempty" validate:"omitempty,lte=4096"`
+	Labels      Labels  `json:"labels"`
+	// VPC name
+	Name *string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
+}
+
+// [BETA] Update a VPC
+func (c Client) UpdateVpc(ctx context.Context, id UUID, req UpdateVpcRequest) (*Vpc, error) {
+	path := fmt.Sprintf("/vpc/%v", id)
+
+	body, err := prepareJSONBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("UpdateVpc: prepare Json body: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("UpdateVpc: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	request.Header.Add("Content-Type", "application/json")
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("UpdateVpc: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("UpdateVpc: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "update-vpc")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("UpdateVpc: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("UpdateVpc: http response: %w", err)
+	}
+
+	bodyresp := new(Vpc)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("UpdateVpc: prepare Json response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
 type ListZonesResponse struct {
 	Zones []Zone `json:"zones,omitempty"`
 }
@@ -18837,10 +19246,6 @@ func (c Client) ListZones(ctx context.Context) (*ListZonesResponse, error) {
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
 		return nil, fmt.Errorf("ListZones: execute request editors: %w", err)
-	}
-
-	if err := c.signRequest(request); err != nil {
-		return nil, fmt.Errorf("ListZones: sign request: %w", err)
 	}
 
 	if c.trace {

--- a/vendor/github.com/exoscale/egoscale/v3/schemas.go
+++ b/vendor/github.com/exoscale/egoscale/v3/schemas.go
@@ -74,24 +74,26 @@ type AccessKeyResource struct {
 	ResourceType AccessKeyResourceResourceType `json:"resource-type,omitempty"`
 }
 
-// AI API key metadata (without value)
+// AI API key metadata
 type AIAPIKey struct {
 	// Creation timestamp
-	CreatedAT time.Time `json:"created-at,omitempty"`
+	CreatedAT time.Time `json:"created-at" validate:"required"`
 	// AI API key ID
-	ID UUID `json:"id,omitempty"`
+	ID UUID `json:"id" validate:"required"`
 	// Human-readable name for the AI API key
-	Name string `json:"name,omitempty"`
+	Name string `json:"name" validate:"required"`
 	// Organization UUID that owns this key
-	OrgUuid UUID `json:"org-uuid,omitempty"`
+	OrgUuid UUID `json:"org-uuid" validate:"required"`
 	// Key scope: 'public' for all deployments, or a specific deployment UUID
-	Scope string `json:"scope,omitempty"`
+	Scope string `json:"scope" validate:"required"`
 	// Last update timestamp
-	UpdatedAT time.Time `json:"updated-at,omitempty"`
+	UpdatedAT time.Time `json:"updated-at" validate:"required"`
 }
 
-// AI API key with plaintext value
-type AIAPIKeyWithValue struct {
+// AI API key plaintext value
+type AIAPIKeyValue struct {
+	// Plaintext AI API key value
+	Value string `json:"value" validate:"required"`
 }
 
 // Anti-affinity Group
@@ -110,6 +112,14 @@ type AntiAffinityGroup struct {
 type AntiAffinityGroupRef struct {
 	// Anti-affinity group ID
 	ID UUID `json:"id,omitempty"`
+}
+
+// Usage breakdown for one API key, grouped by model
+type APIKeyUsageEntry struct {
+	// Map of model-uuid to accumulated counters. Keys are model UUIDs.
+	Models map[string]ModelUsageCounters `json:"models" validate:"required"`
+	// Organization that owns this API key
+	OrganizationID UUID `json:"organization-id" validate:"required"`
 }
 
 type BlockStorageSnapshotState string
@@ -172,6 +182,8 @@ type BlockStorageVolume struct {
 	Blocksize int64 `json:"blocksize,omitempty" validate:"omitempty,gte=0"`
 	// Volume creation date
 	CreatedAT time.Time `json:"created-at,omitempty"`
+	// Indicates if the block-storage volume is encrypted
+	Encrypted *bool `json:"encrypted,omitempty"`
 	// Volume ID
 	ID UUID `json:"id,omitempty"`
 	// Target Instance
@@ -199,7 +211,23 @@ type CreateAIAPIKeyRequest struct {
 	Scope string `json:"scope" validate:"required"`
 }
 
-// Deployment an AI model onto a set of GPUs
+// Create AI API key response
+type CreateAIAPIKeyResponse struct {
+	// Creation timestamp
+	CreatedAT time.Time `json:"created-at" validate:"required"`
+	// AI API key ID
+	ID UUID `json:"id" validate:"required"`
+	// Human-readable name for the AI API key
+	Name string `json:"name" validate:"required"`
+	// Organization UUID that owns this key
+	OrgUuid UUID `json:"org-uuid" validate:"required"`
+	// Key scope: 'public' for all deployments, or a specific deployment UUID
+	Scope string `json:"scope" validate:"required"`
+	// Last update timestamp
+	UpdatedAT time.Time `json:"updated-at" validate:"required"`
+}
+
+// Deploy an AI model onto a set of GPUs
 type CreateDeploymentRequest struct {
 	// Number of GPUs (1-8)
 	GpuCount int64 `json:"gpu-count" validate:"required,gte=1"`
@@ -209,7 +237,8 @@ type CreateDeploymentRequest struct {
 	InferenceEngineParameters []string `json:"inference-engine-parameters,omitempty"`
 	// Inference engine version
 	InferenceEngineVersion InferenceEngineVersion `json:"inference-engine-version,omitempty"`
-	Model                  *ModelRef              `json:"model" validate:"required"`
+	// Model reference. Provide either id or name.
+	Model *ModelRef `json:"model" validate:"required"`
 	// Deployment name
 	Name string `json:"name" validate:"required,gte=1"`
 	// Number of replicas (>=1)
@@ -223,10 +252,10 @@ const (
 )
 
 type CreateKmsKeyRequest struct {
-	Description string                   `json:"description" validate:"required"`
-	MultiZone   *bool                    `json:"multi-zone" validate:"required"`
+	Description string                   `json:"description,omitempty"`
+	MultiZone   *bool                    `json:"multi-zone,omitempty"`
 	Name        string                   `json:"name" validate:"required"`
-	Usage       CreateKmsKeyRequestUsage `json:"usage" validate:"required"`
+	Usage       CreateKmsKeyRequestUsage `json:"usage,omitempty"`
 }
 
 type CreateKmsKeyResponseSource string
@@ -253,6 +282,7 @@ type CreateKmsKeyResponse struct {
 	Revision    *RevisionStamp             `json:"revision" validate:"required"`
 	Source      CreateKmsKeyResponseSource `json:"source" validate:"required"`
 	Status      CreateKmsKeyResponseStatus `json:"status" validate:"required"`
+	StatusSince time.Time                  `json:"status-since" validate:"required"`
 	Usage       string                     `json:"usage" validate:"required"`
 }
 
@@ -1297,6 +1327,8 @@ type DBAASServiceMysql struct {
 	BackupSchedule *DBAASServiceMysqlBackupSchedule `json:"backup-schedule,omitempty"`
 	// List of backups for the service
 	Backups []DBAASServiceBackup `json:"backups,omitempty"`
+	// The minimum amount of time in seconds to keep binlog entries before deletion. This may be extended for services that require binlog entries for longer than the default for example if using the MySQL Debezium Kafka connector.
+	BinlogRetentionPeriod int64 `json:"binlog-retention-period,omitempty" validate:"omitempty,gt=0"`
 	// Service component information objects
 	Components []DBAASServiceMysqlComponents `json:"components,omitempty"`
 	// MySQL connection information properties
@@ -1599,6 +1631,8 @@ type DBAASServicePG struct {
 	Notifications []DBAASServiceNotification `json:"notifications,omitempty"`
 	// postgresql.conf configuration values
 	PGSettings *JSONSchemaPG `json:"pg-settings,omitempty"`
+	// System-wide settings for the pgaudit extension.
+	PgauditSettings *JSONSchemaPgaudit `json:"pgaudit-settings,omitempty"`
 	// System-wide settings for pgbouncer.
 	PgbouncerSettings *JSONSchemaPgbouncer `json:"pgbouncer-settings,omitempty"`
 	// System-wide settings for pglookout.
@@ -2387,25 +2421,41 @@ type GenerateDataKeyResponse struct {
 	Plaintext  []byte `json:"plaintext" validate:"required"`
 }
 
+// Get AI API key response
+type GetAIAPIKeyResponse struct {
+	// Creation timestamp
+	CreatedAT time.Time `json:"created-at" validate:"required"`
+	// AI API key ID
+	ID UUID `json:"id" validate:"required"`
+	// Human-readable name for the AI API key
+	Name string `json:"name" validate:"required"`
+	// Organization UUID that owns this key
+	OrgUuid UUID `json:"org-uuid" validate:"required"`
+	// Key scope: 'public' for all deployments, or a specific deployment UUID
+	Scope string `json:"scope" validate:"required"`
+	// Last update timestamp
+	UpdatedAT time.Time `json:"updated-at" validate:"required"`
+}
+
 // GPU usage for all organizations
 type GetConfederatioUsageResponse struct {
-	OrganizationsUsages map[string]OrganizationUsage `json:"organizations_usages" validate:"required"`
+	OrganizationsUsages map[string]OrganizationUsage `json:"organizations-usages" validate:"required"`
 }
 
 // A single log entry
 type GetDeploymentLogsEntry struct {
 	// Log message content
-	Message string `json:"message,omitempty"`
+	Message string `json:"message" validate:"required"`
 	// Node identifier
-	Node string `json:"node,omitempty"`
+	Node string `json:"node" validate:"required"`
 	// Timestamp of the log entry
-	Time string `json:"time,omitempty"`
+	Time time.Time `json:"time" validate:"required"`
 }
 
 // Deployment logs
 type GetDeploymentLogsResponse struct {
 	// List of log entries
-	Logs []GetDeploymentLogsEntry `json:"logs,omitempty"`
+	Logs []GetDeploymentLogsEntry `json:"logs" validate:"required"`
 }
 
 type GetDeploymentResponseState string
@@ -2413,44 +2463,48 @@ type GetDeploymentResponseState string
 const (
 	GetDeploymentResponseStateReady     GetDeploymentResponseState = "ready"
 	GetDeploymentResponseStateCreating  GetDeploymentResponseState = "creating"
+	GetDeploymentResponseStatePreparing GetDeploymentResponseState = "preparing"
 	GetDeploymentResponseStateError     GetDeploymentResponseState = "error"
 	GetDeploymentResponseStateDeploying GetDeploymentResponseState = "deploying"
+	GetDeploymentResponseStateScaling   GetDeploymentResponseState = "scaling"
+	GetDeploymentResponseStateUpdating  GetDeploymentResponseState = "updating"
 )
 
 // AI deployment
 type GetDeploymentResponse struct {
 	// Creation time
-	CreatedAT time.Time `json:"created-at,omitempty"`
-	// Deployment URL (nullable)
-	DeploymentURL string `json:"deployment-url,omitempty"`
+	CreatedAT time.Time `json:"created-at" validate:"required"`
+	// Deployment inference endpoint URL
+	DeploymentURL string `json:"deployment-url" validate:"required"`
 	// Number of GPUs
-	GpuCount int64 `json:"gpu-count,omitempty" validate:"omitempty,gte=1"`
+	GpuCount int64 `json:"gpu-count" validate:"required,gte=1"`
 	// GPU type family
-	GpuType string `json:"gpu-type,omitempty" validate:"omitempty,gte=1"`
+	GpuType string `json:"gpu-type" validate:"required,gte=1"`
 	// Deployment ID
-	ID UUID `json:"id,omitempty"`
+	ID UUID `json:"id" validate:"required"`
 	// Optional extra inference engine server CLI args
-	InferenceEngineParameters []string `json:"inference-engine-parameters,omitempty"`
+	InferenceEngineParameters []string `json:"inference-engine-parameters" validate:"required"`
 	// Inference engine version
-	InferenceEngineVersion InferenceEngineVersion `json:"inference-engine-version,omitempty"`
-	Model                  *ModelRef              `json:"model,omitempty"`
+	InferenceEngineVersion InferenceEngineVersion `json:"inference-engine-version" validate:"required"`
+	// Model reference. Provide either id or name.
+	Model *ModelRef `json:"model" validate:"required"`
 	// Deployment name
-	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
+	Name string `json:"name" validate:"required,gte=1"`
 	// Number of replicas (>=0)
-	Replicas int64 `json:"replicas,omitempty" validate:"omitempty,gte=0"`
+	Replicas int64 `json:"replicas" validate:"required,gte=0"`
 	// Service level
-	ServiceLevel string `json:"service-level,omitempty" validate:"omitempty,gte=1"`
+	ServiceLevel string `json:"service-level" validate:"required,gte=1"`
 	// Deployment state
-	State GetDeploymentResponseState `json:"state,omitempty"`
+	State GetDeploymentResponseState `json:"state" validate:"required"`
 	// Deployment state details
-	StateDetails string `json:"state-details,omitempty"`
+	StateDetails string `json:"state-details" validate:"required"`
 	// Update time
-	UpdatedAT time.Time `json:"updated-at,omitempty"`
+	UpdatedAT time.Time `json:"updated-at" validate:"required"`
 }
 
 // List of allowed inference-engine parameters
 type GetInferenceEngineHelpResponse struct {
-	Parameters []InferenceEngineParameterEntry `json:"parameters,omitempty"`
+	Parameters []InferenceEngineParameterEntry `json:"parameters" validate:"required"`
 }
 
 type GetKmsKeyResponseSource string
@@ -2498,23 +2552,23 @@ const (
 // AI model
 type GetModelResponse struct {
 	// Creation time
-	CreatedAT time.Time `json:"created-at,omitempty"`
+	CreatedAT time.Time `json:"created-at" validate:"required"`
 	// Model ID
-	ID UUID `json:"id,omitempty"`
-	// Model size (nullable)
-	ModelSize int64 `json:"model-size,omitempty" validate:"omitempty,gte=0"`
+	ID UUID `json:"id" validate:"required"`
+	// Model size in bytes
+	ModelSize int64 `json:"model-size" validate:"required,gte=0"`
 	// Model name
-	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
+	Name string `json:"name" validate:"required,gte=1"`
 	// Model state
-	State GetModelResponseState `json:"state,omitempty"`
+	State GetModelResponseState `json:"state" validate:"required"`
 	// Update time
-	UpdatedAT time.Time `json:"updated-at,omitempty"`
+	UpdatedAT time.Time `json:"updated-at" validate:"required"`
 }
 
 // GPU usage for an organization
 type GetOrganizationUsageResponse struct {
 	// Total GPU count
-	Gpu int64 `json:"gpu,omitempty" validate:"omitempty,gte=0"`
+	Gpu int64 `json:"gpu" validate:"required,gte=0"`
 }
 
 // IAM API Key
@@ -2539,6 +2593,12 @@ type IAMAPIKeyCreated struct {
 	Secret string `json:"secret,omitempty"`
 }
 
+// Assume Role Policy
+type IAMAssumeRolePolicy struct {
+	// IAM Assume Role Policy rules
+	Rules []IAMServicePolicyRule `json:"rules,omitempty"`
+}
+
 type IAMPolicyDefaultServiceStrategy string
 
 const (
@@ -2556,8 +2616,8 @@ type IAMPolicy struct {
 
 // IAM Role
 type IAMRole struct {
-	// Policy
-	AssumeRolePolicy *IAMPolicy `json:"assume-role-policy,omitempty"`
+	// Assume Role Policy
+	AssumeRolePolicy *IAMAssumeRolePolicy `json:"assume-role-policy,omitempty"`
 	// IAM Role description
 	Description string `json:"description,omitempty" validate:"omitempty,gte=1,lte=255"`
 	// IAM Role mutability
@@ -2630,7 +2690,34 @@ const (
 	InferenceEngineVersion0180 InferenceEngineVersion = "0.18.0"
 	InferenceEngineVersion0181 InferenceEngineVersion = "0.18.1"
 	InferenceEngineVersion0190 InferenceEngineVersion = "0.19.0"
+	InferenceEngineVersion0191 InferenceEngineVersion = "0.19.1"
+	InferenceEngineVersion0200 InferenceEngineVersion = "0.20.0"
+	InferenceEngineVersion0201 InferenceEngineVersion = "0.20.1"
+	InferenceEngineVersion0202 InferenceEngineVersion = "0.20.2"
+	InferenceEngineVersion0210 InferenceEngineVersion = "0.21.0"
+	InferenceEngineVersion0220 InferenceEngineVersion = "0.22.0"
+	InferenceEngineVersion0221 InferenceEngineVersion = "0.22.1"
 )
+
+// Router flush payload: the router's full in-memory usage map with flush identity fields
+type IngestMeteringRequest struct {
+	// ISO-8601 UTC timestamp when the flush snapshot was created (truncated to minute boundary for bucketing)
+	CreatedAT time.Time `json:"created-at" validate:"required"`
+	// UUID identifying this flush; used for idempotent deduplication
+	FlushID UUID `json:"flush-id" validate:"required"`
+	// Router instance identifier that produced this flush
+	RouterID string `json:"router-id" validate:"required,gte=1"`
+	// Map of api-key-uuid to usage entry. Keys are API key UUIDs. Mirrors the router's in-memory accumulator structure directly.
+	Usage map[string]APIKeyUsageEntry `json:"usage" validate:"required"`
+}
+
+// Result of a metering ingest operation
+type IngestMeteringResponse struct {
+	// True if flush-id was already processed (idempotent retry)
+	Duplicate *bool `json:"duplicate,omitempty"`
+	// Number of rows affected (inserted or updated) in usage_minutely; 0 if duplicate flush-id
+	Upserted int `json:"upserted" validate:"required"`
+}
 
 // Private Network
 type InstancePrivateNetworks struct {
@@ -2650,6 +2737,8 @@ type Instance struct {
 	CreatedAT time.Time `json:"created-at,omitempty"`
 	// Deploy target reference
 	DeployTarget *DeployTarget `json:"deploy-target,omitempty"`
+	// Indicates if the root volume of the instance is encrypted
+	DiskEncrypted *bool `json:"disk-encrypted,omitempty"`
 	// Instance disk size in GiB
 	DiskSize int64 `json:"disk-size,omitempty" validate:"omitempty,gte=10,lte=51200"`
 	// Instance Elastic IPs
@@ -2795,6 +2884,7 @@ const (
 	InstanceTypeFamilyGpu           InstanceTypeFamily = "gpu"
 	InstanceTypeFamilyMemory        InstanceTypeFamily = "memory"
 	InstanceTypeFamilyGpua5000      InstanceTypeFamily = "gpua5000"
+	InstanceTypeFamilyGpub300       InstanceTypeFamily = "gpub300"
 	InstanceTypeFamilyGpurtx6000pro InstanceTypeFamily = "gpurtx6000pro"
 	InstanceTypeFamilyStorage       InstanceTypeFamily = "storage"
 	InstanceTypeFamilyStandard      InstanceTypeFamily = "standard"
@@ -2842,9 +2932,9 @@ type InstanceType struct {
 // Instance type with authorization status
 type InstanceTypeEntry struct {
 	// Whether this instance type is authorized based on server availability
-	Authorized *bool `json:"authorized,omitempty"`
+	Authorized *bool `json:"authorized" validate:"required"`
 	// GPU family name
-	Family string `json:"family,omitempty"`
+	Family string `json:"family" validate:"required"`
 }
 
 // Instance type reference
@@ -3875,6 +3965,58 @@ type JSONSchemaPG struct {
 	Wal *JSONSchemaPGWal `json:"wal,omitempty"`
 }
 
+type JSONSchemaPgauditLogLevel string
+
+const (
+	JSONSchemaPgauditLogLevelDebug1  JSONSchemaPgauditLogLevel = "debug1"
+	JSONSchemaPgauditLogLevelDebug2  JSONSchemaPgauditLogLevel = "debug2"
+	JSONSchemaPgauditLogLevelDebug3  JSONSchemaPgauditLogLevel = "debug3"
+	JSONSchemaPgauditLogLevelDebug4  JSONSchemaPgauditLogLevel = "debug4"
+	JSONSchemaPgauditLogLevelDebug5  JSONSchemaPgauditLogLevel = "debug5"
+	JSONSchemaPgauditLogLevelInfo    JSONSchemaPgauditLogLevel = "info"
+	JSONSchemaPgauditLogLevelNotice  JSONSchemaPgauditLogLevel = "notice"
+	JSONSchemaPgauditLogLevelWarning JSONSchemaPgauditLogLevel = "warning"
+	JSONSchemaPgauditLogLevelLog     JSONSchemaPgauditLogLevel = "log"
+)
+
+// System-wide settings for the pgaudit extension.
+type JSONSchemaPgaudit struct {
+	// Enable pgaudit extension. When enabled, pgaudit extension will be automatically installed.Otherwise, extension will be uninstalled but auditing configurations will be preserved.
+	FeatureEnabled *bool `json:"feature_enabled,omitempty"`
+	// Specifies which classes of statements will be logged by session audit logging.
+	Log []string `json:"log,omitempty"`
+	// Specifies that session logging should be enabled in the case where all relations
+	// in a statement are in pg_catalog.
+	LogCatalog *bool `json:"log_catalog,omitempty"`
+	// Specifies whether log messages will be visible to a client process such as psql.
+	LogClient *bool `json:"log_client,omitempty"`
+	// Specifies the log level that will be used for log entries.
+	LogLevel JSONSchemaPgauditLogLevel `json:"log_level,omitempty"`
+	// Crop parameters representation and whole statements if they exceed this threshold.
+	// A (default) value of -1 disable the truncation.
+	LogMaxStringLength int `json:"log_max_string_length,omitempty" validate:"omitempty,gte=-1,lte=102400"`
+	// This GUC allows to turn off logging nested statements, that is, statements that are
+	// executed as part of another ExecutorRun.
+	LogNestedStatements *bool `json:"log_nested_statements,omitempty"`
+	// Specifies that audit logging should include the parameters that were passed with the statement.
+	LogParameter *bool `json:"log_parameter,omitempty"`
+	// Specifies that parameter values longer than this setting (in bytes) should not be logged,
+	// but replaced with <long param suppressed>.
+	LogParameterMaxSize int `json:"log_parameter_max_size,omitempty"`
+	// Specifies whether session audit logging should create a separate log entry
+	// for each relation (TABLE, VIEW, etc.) referenced in a SELECT or DML statement.
+	LogRelation *bool `json:"log_relation,omitempty"`
+	// Log Rows
+	LogRows *bool `json:"log_rows,omitempty"`
+	// Specifies whether logging will include the statement text and parameters (if enabled).
+	LogStatement *bool `json:"log_statement,omitempty"`
+	// Specifies whether logging will include the statement text and parameters with
+	// the first log entry for a statement/substatement combination or with every entry.
+	LogStatementOnce *bool `json:"log_statement_once,omitempty"`
+	// Specifies the master role to use for object audit logging.
+	Role string `json:"role,omitempty" validate:"omitempty,lte=64"`
+}
+
 type JSONSchemaPgbouncerAutodbPoolMode string
 
 const (
@@ -4042,17 +4184,33 @@ type Labels map[string]string
 
 // List of AI API keys
 type ListAIAPIKeysResponse struct {
-	AIAPIKeys []AIAPIKey `json:"ai-api-keys" validate:"required"`
+	AIAPIKeys []ListAIAPIKeysResponseEntry `json:"ai-api-keys" validate:"required"`
+}
+
+// AI API key list entry
+type ListAIAPIKeysResponseEntry struct {
+	// Creation timestamp
+	CreatedAT time.Time `json:"created-at" validate:"required"`
+	// AI API key ID
+	ID UUID `json:"id" validate:"required"`
+	// Human-readable name for the AI API key
+	Name string `json:"name" validate:"required"`
+	// Organization UUID that owns this key
+	OrgUuid UUID `json:"org-uuid" validate:"required"`
+	// Key scope: 'public' for all deployments, or a specific deployment UUID
+	Scope string `json:"scope" validate:"required"`
+	// Last update timestamp
+	UpdatedAT time.Time `json:"updated-at" validate:"required"`
 }
 
 // List of available instance types with authorization status
 type ListAIInstanceTypesResponse struct {
-	InstanceTypes []InstanceTypeEntry `json:"instance-types,omitempty"`
+	InstanceTypes []InstanceTypeEntry `json:"instance-types" validate:"required"`
 }
 
-// AI model list
+// AI deployment list
 type ListDeploymentsResponse struct {
-	Deployments []ListDeploymentsResponseEntry `json:"deployments,omitempty"`
+	Deployments []ListDeploymentsResponseEntry `json:"deployments" validate:"required"`
 }
 
 type ListDeploymentsResponseEntryState string
@@ -4060,33 +4218,37 @@ type ListDeploymentsResponseEntryState string
 const (
 	ListDeploymentsResponseEntryStateReady     ListDeploymentsResponseEntryState = "ready"
 	ListDeploymentsResponseEntryStateCreating  ListDeploymentsResponseEntryState = "creating"
+	ListDeploymentsResponseEntryStatePreparing ListDeploymentsResponseEntryState = "preparing"
 	ListDeploymentsResponseEntryStateError     ListDeploymentsResponseEntryState = "error"
 	ListDeploymentsResponseEntryStateDeploying ListDeploymentsResponseEntryState = "deploying"
+	ListDeploymentsResponseEntryStateScaling   ListDeploymentsResponseEntryState = "scaling"
+	ListDeploymentsResponseEntryStateUpdating  ListDeploymentsResponseEntryState = "updating"
 )
 
 // AI deployment
 type ListDeploymentsResponseEntry struct {
 	// Creation time
-	CreatedAT time.Time `json:"created-at,omitempty"`
-	// Deployment URL (nullable)
-	DeploymentURL string `json:"deployment-url,omitempty"`
+	CreatedAT time.Time `json:"created-at" validate:"required"`
+	// Deployment inference endpoint URL
+	DeploymentURL string `json:"deployment-url" validate:"required"`
 	// Number of GPUs
-	GpuCount int64 `json:"gpu-count,omitempty" validate:"omitempty,gte=1"`
+	GpuCount int64 `json:"gpu-count" validate:"required,gte=1"`
 	// GPU type family
-	GpuType string `json:"gpu-type,omitempty" validate:"omitempty,gte=1"`
+	GpuType string `json:"gpu-type" validate:"required,gte=1"`
 	// Deployment ID
-	ID    UUID      `json:"id,omitempty"`
-	Model *ModelRef `json:"model,omitempty"`
+	ID UUID `json:"id" validate:"required"`
+	// Model reference. Provide either id or name.
+	Model *ModelRef `json:"model" validate:"required"`
 	// Deployment name
-	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
+	Name string `json:"name" validate:"required,gte=1"`
 	// Number of replicas (>=0)
-	Replicas int64 `json:"replicas,omitempty" validate:"omitempty,gte=0"`
+	Replicas int64 `json:"replicas" validate:"required,gte=0"`
 	// Service level
-	ServiceLevel string `json:"service-level,omitempty" validate:"omitempty,gte=1"`
+	ServiceLevel string `json:"service-level" validate:"required,gte=1"`
 	// Deployment state
-	State ListDeploymentsResponseEntryState `json:"state,omitempty"`
+	State ListDeploymentsResponseEntryState `json:"state" validate:"required"`
 	// Update time
-	UpdatedAT time.Time `json:"updated-at,omitempty"`
+	UpdatedAT time.Time `json:"updated-at" validate:"required"`
 }
 
 type ListKmsKeyRotationsResponse struct {
@@ -4136,7 +4298,7 @@ type ListKmsKeysResponseEntry struct {
 
 // AI model list
 type ListModelsResponse struct {
-	Models []ListModelsResponseEntry `json:"models,omitempty"`
+	Models []ListModelsResponseEntry `json:"models" validate:"required"`
 }
 
 type ListModelsResponseEntryState string
@@ -4152,17 +4314,38 @@ const (
 // AI model
 type ListModelsResponseEntry struct {
 	// Creation time
-	CreatedAT time.Time `json:"created-at,omitempty"`
+	CreatedAT time.Time `json:"created-at" validate:"required"`
 	// Model ID
-	ID UUID `json:"id,omitempty"`
-	// Model size (nullable)
-	ModelSize int64 `json:"model-size,omitempty" validate:"omitempty,gte=0"`
+	ID UUID `json:"id" validate:"required"`
+	// Model size in bytes
+	ModelSize int64 `json:"model-size" validate:"required,gte=0"`
 	// Model name
-	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
+	Name string `json:"name" validate:"required,gte=1"`
 	// Model state
-	State ListModelsResponseEntryState `json:"state,omitempty"`
+	State ListModelsResponseEntryState `json:"state" validate:"required"`
 	// Update time
-	UpdatedAT time.Time `json:"updated-at,omitempty"`
+	UpdatedAT time.Time `json:"updated-at" validate:"required"`
+}
+
+// VPC
+type ListVpcResponseEntry struct {
+	// VPC creation date
+	CreatedAT time.Time `json:"created-at,omitempty"`
+	// VPC description
+	Description string `json:"description,omitempty" validate:"omitempty,lte=4096"`
+	// VPC ID
+	ID     UUID   `json:"id,omitempty"`
+	Labels Labels `json:"labels,omitempty"`
+	// VPC name
+	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
+}
+
+// Live balance
+type LiveBalance struct {
+	// Organization live balance
+	Balance float64 `json:"balance,omitempty"`
+	// Organization currency
+	Currency string `json:"currency,omitempty"`
 }
 
 type LoadBalancerState string
@@ -4302,11 +4485,22 @@ type Manager struct {
 	Type ManagerType `json:"type,omitempty"`
 }
 
+// Model reference. Provide either id or name.
 type ModelRef struct {
 	// Associated model ID
 	ID UUID `json:"id,omitempty"`
 	// Associated model name
 	Name string `json:"name,omitempty" validate:"omitempty,gte=1"`
+}
+
+// Accumulated Unit Of Measurement (UOM) counters for one model over a flush window
+type ModelUsageCounters struct {
+	// Number of inference calls in this flush window
+	CallCount int `json:"call-count" validate:"required,gte=1"`
+	// Total prompt/input Unit Of Measurement (UOM) across all calls in this flush window (e.g., tokens for LLMs, minutes for TTS, pages for OCR)
+	InputUom int `json:"input-uom" validate:"required,gte=0"`
+	// Total completion/output Unit Of Measurement (UOM) across all calls in this flush window (e.g., tokens for LLMs, minutes for TTS, pages for OCR)
+	OutputUom int `json:"output-uom" validate:"required,gte=0"`
 }
 
 // Cluster networking configuration.
@@ -4378,11 +4572,17 @@ type OperationResourceRef struct {
 	Link    string `json:"link,omitempty"`
 }
 
+// Per-org Unit Of Measurement (UOM) consumption quota response
+type OrgConsumptionQuotaResponse struct {
+	// Per-org Unit Of Measurement (UOM) consumption quota (UOM/min). Null means unlimited. UOM represents weighted units across different AI workloads (e.g., tokens for LLMs, minutes for TTS, pages for OCR).
+	QuotaUomPerMinute int `json:"quota-uom-per-minute,omitempty" validate:"omitempty,gte=0"`
+}
+
 // Organization
 type Organization struct {
 	// Organization address
 	Address string `json:"address,omitempty"`
-	// Organization balance
+	// Organization balance. DEPRECATED: use the dedicated `live-balance` endpoint
 	Balance float64 `json:"balance,omitempty"`
 	// Organization city
 	City string `json:"city,omitempty"`
@@ -4400,8 +4600,18 @@ type Organization struct {
 
 // Organization GPU usage
 type OrganizationUsage struct {
-	// Total GPU count
+	// Total GPU count (sum of all GPU types)
 	Gpu int64 `json:"gpu" validate:"required,gte=0"`
+	// GPU3 count
+	Gpu3 int64 `json:"gpu3,omitempty" validate:"omitempty,gte=0"`
+	// GPU3080TI count
+	Gpu3080ti int64 `json:"gpu3080ti,omitempty" validate:"omitempty,gte=0"`
+	// GPUA30 count
+	Gpua30 int64 `json:"gpua30,omitempty" validate:"omitempty,gte=0"`
+	// GPUA5000 count
+	Gpua5000 int64 `json:"gpua5000,omitempty" validate:"omitempty,gte=0"`
+	// GPURTX6000PRO count
+	Gpurtx6000pro int64 `json:"gpurtx6000pro,omitempty" validate:"omitempty,gte=0"`
 }
 
 // Private Network
@@ -4471,6 +4681,14 @@ type Quota struct {
 	Usage int64 `json:"usage,omitempty"`
 }
 
+// Rate Limit
+type RateLimited struct {
+	// The error message
+	Error string `json:"error,omitempty"`
+	// The time in seconds to wait before the next request
+	RetryAfter float64 `json:"retry_after,omitempty"`
+}
+
 type ReEncryptRequestDestination struct {
 	// Optional encryption context appended to the AAD.
 	EncryptionContext *[]byte `json:"encryption-context,omitempty"`
@@ -4525,9 +4743,16 @@ type Resource struct {
 	Name string `json:"name,omitempty"`
 }
 
+// Reveal AI API key response
+type RevealAIAPIKeyResponse struct {
+	// Plaintext AI API key value
+	Value string `json:"value" validate:"required"`
+}
+
 // AI deployment inference endpoint authentication key
 type RevealDeploymentAPIKeyResponse struct {
-	APIKey string `json:"api-key,omitempty"`
+	// Inference endpoint authentication key
+	APIKey string `json:"api-key" validate:"required"`
 }
 
 type ReverseDNSRecord struct {
@@ -4537,6 +4762,12 @@ type ReverseDNSRecord struct {
 type RevisionStamp struct {
 	AT  time.Time `json:"at" validate:"required"`
 	Seq int       `json:"seq" validate:"required,gte=0"`
+}
+
+// Rotate AI API key response
+type RotateAIAPIKeyResponse struct {
+	// Plaintext AI API key value
+	Value string `json:"value" validate:"required"`
 }
 
 type RotateKmsKeyResponse struct {
@@ -4638,6 +4869,12 @@ type SecurityGroupRule struct {
 	SecurityGroup *SecurityGroupResource `json:"security-group,omitempty"`
 	// Start port of the range
 	StartPort int64 `json:"start-port,omitempty" validate:"omitempty,gte=1,lte=65535"`
+}
+
+// Request to set per-org Unit Of Measurement (UOM) consumption quota
+type SetOrgConsumptionQuotaRequest struct {
+	// Per-org Unit Of Measurement (UOM) consumption quota (UOM/min). Pass null to remove the limit. UOM represents weighted units across different AI workloads (e.g., tokens for LLMs, minutes for TTS, pages for OCR).
+	QuotaUomPerMinute int `json:"quota-uom-per-minute,omitempty" validate:"omitempty,gte=0"`
 }
 
 // Kubernetes Audit parameters
@@ -4944,6 +5181,7 @@ type SuccessResponseStatus string
 const (
 	SuccessResponseStatusSuccess          SuccessResponseStatus = "success"
 	SuccessResponseStatusTargetRegistered SuccessResponseStatus = "target-registered"
+	SuccessResponseStatusAlreadyApplied   SuccessResponseStatus = "already-applied"
 )
 
 type SuccessResponse struct {
@@ -5018,6 +5256,22 @@ type UpdateAIAPIKeyRequest struct {
 	Scope string `json:"scope,omitempty"`
 }
 
+// Update AI API key response
+type UpdateAIAPIKeyResponse struct {
+	// Creation timestamp
+	CreatedAT time.Time `json:"created-at" validate:"required"`
+	// AI API key ID
+	ID UUID `json:"id" validate:"required"`
+	// Human-readable name for the AI API key
+	Name string `json:"name" validate:"required"`
+	// Organization UUID that owns this key
+	OrgUuid UUID `json:"org-uuid" validate:"required"`
+	// Key scope: 'public' for all deployments, or a specific deployment UUID
+	Scope string `json:"scope" validate:"required"`
+	// Last update timestamp
+	UpdatedAT time.Time `json:"updated-at" validate:"required"`
+}
+
 // Update AI deployment
 type UpdateDeploymentRequest struct {
 	// Optional extra inference engine server CLI args
@@ -5042,6 +5296,19 @@ type User struct {
 	Sso *bool `json:"sso,omitempty"`
 	// Two Factor Authentication enabled
 	TwoFactorAuthentication *bool `json:"two-factor-authentication,omitempty"`
+}
+
+// VPC
+type Vpc struct {
+	// VPC creation date
+	CreatedAT time.Time `json:"created-at,omitempty"`
+	// VPC description
+	Description string `json:"description,omitempty" validate:"omitempty,lte=4096"`
+	// VPC ID
+	ID     UUID   `json:"id,omitempty"`
+	Labels Labels `json:"labels,omitempty"`
+	// VPC name
+	Name string `json:"name,omitempty" validate:"omitempty,gte=1,lte=255"`
 }
 
 // Zone

--- a/vendor/github.com/exoscale/egoscale/v3/version.go
+++ b/vendor/github.com/exoscale/egoscale/v3/version.go
@@ -1,4 +1,4 @@
 package v3
 
 // Version represents the current egoscale v3 version.
-const Version = "v3.1.36"
+const Version = "v3.1.40"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -154,8 +154,8 @@ github.com/dlclark/regexp2/syntax
 # github.com/dustin/go-humanize v1.0.1
 ## explicit; go 1.16
 github.com/dustin/go-humanize
-# github.com/exoscale/egoscale/v3 v3.1.36-0.20260424083744-33446130ebd9
-## explicit; go 1.26
+# github.com/exoscale/egoscale/v3 v3.1.40
+## explicit; go 1.25
 github.com/exoscale/egoscale/v3
 github.com/exoscale/egoscale/v3/credentials
 # github.com/exoscale/openapi-cli-generator v1.2.0


### PR DESCRIPTION
# Description

Bumps `github.com/exoscale/egoscale/v3` to v3.1.40.

Picks up [exoscale/egoscale#767](https://github.com/exoscale/egoscale/pull/767): `ListZones` no longer sends an `Authorization` header, so DBaaS-only IAM keys (and other restricted keys) can switch zones without hitting 403 on the public `/zone` endpoint.

This also drags in the regenerated AI API key surface (path/types) and the enum separator fix from [exoscale/egoscale#783](https://github.com/exoscale/egoscale/pull/783). No CLI source changes are required: `go build`, `go vet` and `go test -run=^$ ./...` all pass cleanly against the new vendor tree.

The vendored `Client.ListZones` now skips `signRequest`, which is the change that ships in v3.1.40 (the `v3.1.39` tag pre-dates #767: v3.1.40 was cut specifically to include it).

## Related issue

- [exoscale/egoscale#767](https://github.com/exoscale/egoscale/pull/767)

## Changes

- `go.mod`, `go.sum`: pin `github.com/exoscale/egoscale/v3` from `v3.1.36-0.20260424083744-33446130ebd9` to `v3.1.40`
- `vendor/...`: regenerated via `go mod vendor` (the `v3/operations.go` `ListZones` body now skips `signRequest`)
- `CHANGELOG.md`: add Bug fixes entry under Unreleased

## Checklist

(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

- `go build ./...`
- `go vet ./...`
- `go test -run=^$ ./...` (compiles all test packages)

## Notes for reviewers

> [!NOTE]
> AI-assisted.