### PR TITLE
fix: display memory in GiB instead of GB in instance-type list (#171530)

### DIFF
--- a/cmd/compute/instance_type/instance_type_list.go
+++ b/cmd/compute/instance_type/instance_type_list.go
@@ -49,7 +49,7 @@ func (o *instanceTypeListOutput) ToTable() {
 			cols = append(
 				cols,
 				fmt.Sprint(p.CPUs),
-				humanize.Bytes(uint64(p.Memory)),
+				humanize.IBytes(uint64(p.Memory)),
 				fmt.Sprint(p.Authorized),
 			)
 		}


### PR DESCRIPTION
Closes #171530

## Problem
The API returns memory values in bytes (e.g., 8589934592 bytes for 8 GiB).
Using `humanize.Bytes()` was converting to GB (dividing by 1000), which was incorrect.
For example, 8589934592 bytes was displayed as **8.6 GB** instead of **8 GiB**.

## Solution
Changed to use `humanize.IBytes()` which correctly converts to GiB (dividing by 1024).

## Changes
- `cmd/compute/instance_type/instance_type_list.go`: Changed `humanize.Bytes()` to `humanize.IBytes()`

Note: The `instance_type_show.go` already uses the correct `humanize.IBytes()` function, so no change was needed there.