### PR TITLE
cli(storage): use account credentials for resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fixes
+
+- storage: can't list buckets if no default AWS credentials present #865
+
 ## 1.95.5
 
 ### Features

--- a/pkg/storage/sos/client.go
+++ b/pkg/storage/sos/client.go
@@ -167,6 +167,10 @@ func ClientOptZoneFromBucket(ctx context.Context, bucket string) ClientOpt {
 						)
 						return aws.Endpoint{URL: sosURL}, nil
 					})),
+				awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+					account.CurrentAccount.Key,
+					account.CurrentAccount.APISecret(),
+					"")),
 			)...)
 		if err != nil {
 			return err


### PR DESCRIPTION
When calling ClientOptZoneFromBucket, it's necessary to wire the account credentials, otherwise the aws s3 sdk will go through the chain of credential resolution, eventually failing in EC2 IMDS calls that happen when none of the usual AWS S3 credential files/env vars can be found (AWS_ env vars, /home/mping/.aws/credentials, etc)

# Description

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block, and add the Pull Request #number for each bit you add to the `CHANGELOG.md`)
* [x] Testing

## Testing

<!--
Describe the tests you did
-->
