### PR TITLE
Prepare release 1.95.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.95.6
+
 ### Bug fixes
 
 - storage: fix IMDS fallback when using bucket-path syntax (`sos://bucket/`) on non-EC2 hosts #864


### PR DESCRIPTION
# Description
Prepare release 1.95.6 by moving the storage IMDS fallback fix from `Unreleased` into the `1.95.6` changelog section.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block, and add the Pull Request #number for each bit you add to the `CHANGELOG.md`)
* [x] Testing

## Testing
* `make fmt`
* `make build && make test-verbose`
* `make lint`
* `golangci-lint run --timeout 4m`
* `go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...`
* `(cd tests/e2e && go test -v)`

---
> [!NOTE]
> AI assistance: PR description, changelog update.