### PR TITLE
chore(kms): add delete-at field

### DIFF
--- a/cmd/kms/key/key_show.go
+++ b/cmd/kms/key/key_show.go
@@ -78,7 +78,7 @@ func (c *KeyShowCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		ReplicasStatus: formatReplicaStatus(resp.ReplicasStatus),
 		Material:       formatKeyMaterial(resp.Material),
 		Rotation:       formatKeyRotationConfig(resp.Rotation),
-		Usage:          string(resp.Usage),
+		Usage:          resp.Usage,
 		Source:         resp.Source,
 		Description:    resp.Description,
 		DeleteAt:       resp.DeleteAT,

--- a/cmd/kms/key/key_show.go
+++ b/cmd/kms/key/key_show.go
@@ -22,7 +22,8 @@ type KeyShowOutput struct {
 	Rotation       string                     `json:"rotation" validate:"required"`
 	Usage          string                     `json:"usage" validate:"required"`
 	Source         v3.GetKmsKeyResponseSource `json:"source" validate:"required"`
-	Description    string                     `json:"description" validate:"required"`
+	Description    string                     `json:"description,omitempty"`
+	DeleteAt       time.Time                  `json:"delete-at,omitempty"`
 }
 
 func (o *KeyShowOutput) Type() string { return "KMS key" }
@@ -80,7 +81,9 @@ func (c *KeyShowCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		Usage:          string(resp.Usage),
 		Source:         resp.Source,
 		Description:    resp.Description,
+		DeleteAt:       resp.DeleteAT,
 	}
+
 	return c.OutputFunc(&out, nil)
 }
 

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,8 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/go-control-plane v0.10.1/go.mod h1:AY7fTTXNdv/aJ2O5jwpxAPOWUZ7hQAEvzN5Pf27BkQQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
+github.com/exoscale/egoscale/v3 v3.1.40 h1:OyDrJF8VpMrgcVJuiCrMoTxONnoVwYLF1pfJ5biqKKo=
+github.com/exoscale/egoscale/v3 v3.1.40/go.mod h1:DUTgeubl5msPAo3SKFed04AxNhyTNOrCTJHZDRYLR10=
 github.com/exoscale/egoscale/v3 v3.1.42 h1:KlFDdm2ga1RdCdKuKlzJxLmgJjWVcDbJxF0t6FDswzw=
 github.com/exoscale/egoscale/v3 v3.1.42/go.mod h1:DUTgeubl5msPAo3SKFed04AxNhyTNOrCTJHZDRYLR10=
 github.com/exoscale/openapi-cli-generator v1.2.0 h1:xgTff1bInBP+JZCauD7Jq9GNBFoKK31Cnv5FIAcxtrk=

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,6 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/go-control-plane v0.10.1/go.mod h1:AY7fTTXNdv/aJ2O5jwpxAPOWUZ7hQAEvzN5Pf27BkQQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
-github.com/exoscale/egoscale/v3 v3.1.40 h1:OyDrJF8VpMrgcVJuiCrMoTxONnoVwYLF1pfJ5biqKKo=
-github.com/exoscale/egoscale/v3 v3.1.40/go.mod h1:DUTgeubl5msPAo3SKFed04AxNhyTNOrCTJHZDRYLR10=
 github.com/exoscale/egoscale/v3 v3.1.42 h1:KlFDdm2ga1RdCdKuKlzJxLmgJjWVcDbJxF0t6FDswzw=
 github.com/exoscale/egoscale/v3 v3.1.42/go.mod h1:DUTgeubl5msPAo3SKFed04AxNhyTNOrCTJHZDRYLR10=
 github.com/exoscale/openapi-cli-generator v1.2.0 h1:xgTff1bInBP+JZCauD7Jq9GNBFoKK31Cnv5FIAcxtrk=

--- a/pkg/output/outputter.go
+++ b/pkg/output/outputter.go
@@ -210,8 +210,9 @@ func Table(o interface{}) {
 			label = l
 		}
 
-		// If the field is a zero-value time.Time, skip displaying it entirely.
+		// If the field is a zero-value time.Time, print "n/a".
 		if ts, ok := v.Field(i).Interface().(time.Time); ok && ts.IsZero() {
+			tab.Append([]string{label, "n/a"})
 			continue
 		}
 

--- a/pkg/output/outputter.go
+++ b/pkg/output/outputter.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/exoscale/cli/table"
 	v3 "github.com/exoscale/egoscale/v3"
@@ -207,6 +208,11 @@ func Table(o interface{}) {
 		label := strings.Join(camelcase.Split(t.Field(i).Name), " ")
 		if l, ok := t.Field(i).Tag.Lookup("outputLabel"); ok {
 			label = l
+		}
+
+		// If the field is a zero-value time.Time, skip displaying it entirely.
+		if ts, ok := v.Field(i).Interface().(time.Time); ok && ts.IsZero() {
+			continue
 		}
 
 		switch v.Field(i).Kind() {


### PR DESCRIPTION
# Description

This PR adds the delete-at field for KMS keys. The convention is printing out every field, even when unset.
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->


`go run main.go kms key show 019e9327-0059-702f-b211-e2e0217f982c --zone de-fra-1`

```
┼─────────────────┼────────────────────────────────────────────────────┼
│     KMS KEY     │                                                    │
┼─────────────────┼────────────────────────────────────────────────────┼
│ ID              │ 019e9327-0059-702f-b211-e2e0217f982c               │
│ Name            │ serf                                               │
│ Created At      │ 2026-06-04 15:01:07.289146061 +0000 UTC            │
│ Multizone       │ false                                              │
│ Origin Zone     │ de-fra-1                                           │
│ Status          │ enabled                                            │
│ Replicas Status │ -                                                  │
│ Material        │ auto: false                                        │
│                 │ createdAt: 2026-06-04 15:01:07.289146061 +0000 UTC │
│                 │ version: 1                                         │
│ Rotation        │ auto: true                                         │
│                 │ count: 0                                           │
│                 │ nextAt: 2027-06-04 15:01:07.292841723 +0000 UTC    │
│                 │ rotationPeriod: 365                                │
│ Usage           │ encrypt-decrypt                                    │
│ Source          │ exoscale-kms                                       │
│ Description     │ sdfsef                                             │
│ Delete At       │ n/a                                                │
┼─────────────────┼────────────────────────────────────────────────────┼
```

`go run main.go kms key show 019ef4a7-c5d9-7880-8a78-4ebfaacb4423`
```                
┼─────────────────┼────────────────────────────────────────────────────┼
│     KMS KEY     │                                                    │
┼─────────────────┼────────────────────────────────────────────────────┼
│ ID              │ 019ef4a7-c5d9-7880-8a78-4ebfaacb4423               │
│ Name            │ aab                                                │
│ Created At      │ 2026-06-23 13:26:15.647876511 +0000 UTC            │
│ Multizone       │ false                                              │
│ Origin Zone     │ ch-gva-2                                           │
│ Status          │ pending-deletion                                   │
│ Replicas Status │ -                                                  │
│ Material        │ auto: false                                        │
│                 │ createdAt: 2026-06-23 13:26:15.647876511 +0000 UTC │
│                 │ version: 2                                         │
│ Rotation        │ auto: true                                         │
│                 │ count: 1                                           │
│                 │ nextAt: 2027-06-23 13:24:56.41204593 +0000 UTC     │
│                 │ rotationPeriod: 365                                │
│ Usage           │ encrypt-decrypt                                    │
│ Source          │ exoscale-kms                                       │
│ Description     │                                                    │
│ Delete At       │ 2026-07-22 09:51:26.813122066 +0000 UTC            │
┼─────────────────┼────────────────────────────────────────────────────┼
```

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block, and add the Pull Request #number for each bit you add to the `CHANGELOG.md`)
* [ ] Testing

## Testing

<!--
Describe the tests you did
-->
