### PR TITLE
fix(kms): add nil pointer check on automatic field

### DIFF
--- a/cmd/kms/key/formatting.go
+++ b/cmd/kms/key/formatting.go
@@ -43,8 +43,14 @@ func formatKeyMaterial(s *v3.KeyMaterial) string {
 	if s == nil {
 		return "-"
 	}
-	return fmt.Sprintf("auto: %s\ncreatedAt: %s\nversion: %d",
-		strconv.FormatBool(*s.Automatic),
+	// TODO: temp fix to prevent null pointer exception. Automatic field will be renamed to manual.
+	if s.Automatic != nil {
+		return fmt.Sprintf("auto: %s\ncreatedAt: %s\nversion: %d",
+			strconv.FormatBool(*s.Automatic),
+			s.CreatedAT,
+			s.Version)
+	}
+	return fmt.Sprintf("createdAt: %s\nversion: %d",
 		s.CreatedAT,
 		s.Version)
 }


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block, and add the Pull Request #number for each bit you add to the `CHANGELOG.md`)
* [ ] Testing

## Testing

```
go run main.go kms key show 019f7e76-a085-71c6-a010-18cd5e7a0a7c
┼─────────────────┼────────────────────────────────────────────────────┼
│     KMS KEY     │                                                    │
┼─────────────────┼────────────────────────────────────────────────────┼
│ ID              │ 019f7e76-a085-71c6-a010-18cd5e7a0a7c               │
│ Name            │ test-4                                             │
│ Created At      │ 2026-07-20 07:39:36.268625235 +0000 UTC            │
│ Multizone       │ true                                               │
│ Origin Zone     │ ch-gva-2                                           │
│ Status          │ enabled                                            │
│ Replicas Status │ de-fra-1                                           │
│ Material        │ createdAt: 2026-07-20 07:39:36.268625235 +0000 UTC │
│                 │ version: 2                                         │
│ Rotation        │ auto: true                                         │
│                 │ count: 1                                           │
│                 │ nextAt: 2027-07-20 07:38:51.399877708 +0000 UTC    │
│                 │ rotationPeriod: 365                                │
│ Usage           │ encrypt-decrypt                                    │
│ Source          │ exoscale-kms                                       │
│ Description     │                                                    │
┼─────────────────┼────────────────────────────────────────────────────┼
```
