### PR TITLE
AUR package: reset pkgrel in PKGBUILD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,7 @@ jobs:
 
               cd /home/runner/$aurpkg
               sed -i "/^pkgver=/s/.*/pkgver=$version_tag/" PKGBUILD
+              sed -i "/^pkgrel=/s/.*/pkgrel=1/" PKGBUILD
               if [ $aurpkg == "exoscale-cli-bin" ]; then
                 sed -i "/^sha256sums=/s/.*/sha256sums=\('$checksum'/" PKGBUILD
               fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improvements⏎
+
+- AUR package: reset pkgrel in PKGBUILD (#878)
+
 ## 1.97.0
 
 ### Bug fixes


### PR DESCRIPTION
# Description
When we need to update PKGBUILD file manually, we will keep the same `pkgver` (corresponding to the CLI tag) and  bump the `pkgrel` number (packaging version) as per [official docs](https://wiki.archlinux.org/title/Arch_package_guidelines#Package_versioning). This PR makes sure that on new tagged CLI release CI resets the `pkgrel`.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block, and add the Pull Request #number for each bit you add to the `CHANGELOG.md`)
* [ ] Testing

## Testing

```
$ cat PKGBUILD | grep pkgrel
pkgrel=2
$ sed -i "/^pkgrel=/s/.*/pkgrel=1/" PKGBUILD
$ cat PKGBUILD | grep pkgrel
pkgrel=1
```
