### PR TITLE
fix(instance create): apply delete protection in the instance's zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fixes
+
+- instance create: apply delete protection in the instance's zone, fixing a wrong-zone "Not Found" error when creating protected instances outside the default zone (#879)
+
 ### Improvements⏎
 
 - AUR package: reset pkgrel in PKGBUILD (#878)

--- a/cmd/compute/instance/instance_create.go
+++ b/cmd/compute/instance/instance_create.go
@@ -302,11 +302,11 @@ func (c *instanceCreateCmd) CmdRun(cmd *cobra.Command, _ []string) error { //nol
 			if err != nil {
 				return
 			}
-			op, err = globalstate.EgoscaleV3Client.AddInstanceProtection(ctx, value)
+			op, err = client.AddInstanceProtection(ctx, value)
 			if err != nil {
 				return
 			}
-			_, err = globalstate.EgoscaleV3Client.Wait(ctx, op, v3.OperationStateSuccess)
+			_, err = client.Wait(ctx, op, v3.OperationStateSuccess)
 
 		}
 	})


### PR DESCRIPTION
# Description

`instance create --protection` called `AddInstanceProtection` on the default-zone
client (`globalstate.EgoscaleV3Client`) instead of the zone-switched `client` used
to create the instance. When the instance is created in a non-default zone, the
protection call goes to the wrong zone and fails with `Not Found: Instance not found`.

The instance is still created but left unprotected, and the command exits non-zero.
This is a silent partial failure: the operator believes the VM is protected when it
isn't, and automation sees a failed create for an instance that actually exists.

Fix: use the zone-scoped `client` for `AddInstanceProtection` and its `Wait`, the
same client every other step in the create flow uses.

## Checklist
* [x] Changelog updated
* [x] Testing

## Testing

Built from this branch and ran against `de-fra-1` (a non-default zone):

- Before: `exo compute instance create ... --protection` returned `error: Not Found: Instance not found`, exit 1; the instance was created but not protected (delete succeeded).
- After: the same command returned exit 0; the instance was created and protected (delete refused with `Forbidden ... manual instance protection` until `--protection=false`).
