### PR TITLE
sks cluster update: fix oidc config drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 - instance create: apply delete protection in the instance's zone, fixing a wrong-zone "Not Found" error when creating protected instances outside the default zone (#879)
+- sks cluster update: fix oidc config drop (#881)
 
 ### Improvements⏎
 

--- a/cmd/compute/sks/sks_update.go
+++ b/cmd/compute/sks/sks_update.go
@@ -79,7 +79,9 @@ func (c *sksUpdateCmd) CmdRun(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	updateReq := v3.UpdateSKSClusterRequest{}
+	updateReq := v3.UpdateSKSClusterRequest{
+		Oidc: cluster.Oidc,
+	}
 
 	if cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.AutoUpgrade)) {
 		updateReq.AutoUpgrade = &c.AutoUpgrade


### PR DESCRIPTION
# Description

Fix the OIDC config getting nulled when any other attribute is updated.
API handles explicit `null` as empty, but it does not set `nullable` in OpenAPI spec which makes CLI/egoscale send explicit `null`.
This is why we have to set existing value in every update call. 

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block, and add the Pull Request #number for each bit you add to the `CHANGELOG.md`)
* [x] Testing

## Testing

```
$ EXOSCALE_TRACE=1 exo c sks get mycluster
..."oidc":{"client-id":"12345","username-claim":"something",...
$ go run . c sks update mycluster --description test
 ✔ Updating SKS cluster "mycluster"... 33s
...
$ EXOSCALE_TRACE=1 exo c sks get mycluster
..."oidc":{"client-id":"12345","username-claim":"something",...
```