### PR TITLE
fix(compute): adjust default disk size to template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+- compute: honor the selected template's minimum disk size when creating instances and instance pools (#882)
 - instance create: apply delete protection in the instance's zone, fixing a wrong-zone "Not Found" error when creating protected instances outside the default zone (#879)
 - sks cluster update: fix oidc config drop (#881)
 

--- a/cmd/compute/disk_size.go
+++ b/cmd/compute/disk_size.go
@@ -1,0 +1,23 @@
+package compute
+
+import "fmt"
+
+const gibibyte int64 = 1 << 30
+
+// ResolveTemplateDiskSize returns a disk size that can contain the selected template.
+func ResolveTemplateDiskSize(diskSize, templateSizeBytes int64, explicitlySet bool) (int64, error) {
+	minimumDiskSize := (templateSizeBytes + gibibyte - 1) / gibibyte
+	if diskSize >= minimumDiskSize {
+		return diskSize, nil
+	}
+	if explicitlySet {
+		return 0, fmt.Errorf(
+			"--disk-size %d GiB is smaller than the selected template's minimum of %d GiB; use --disk-size %d or larger",
+			diskSize,
+			minimumDiskSize,
+			minimumDiskSize,
+		)
+	}
+
+	return minimumDiskSize, nil
+}

--- a/cmd/compute/disk_size_test.go
+++ b/cmd/compute/disk_size_test.go
@@ -1,0 +1,58 @@
+package compute
+
+import "testing"
+
+func TestResolveTemplateDiskSize(t *testing.T) {
+	tests := []struct {
+		name          string
+		diskSize      int64
+		templateSize  int64
+		explicitlySet bool
+		want          int64
+		wantErr       string
+	}{
+		{
+			name:         "default is large enough",
+			diskSize:     50,
+			templateSize: 10 * gibibyte,
+			want:         50,
+		},
+		{
+			name:         "default is increased",
+			diskSize:     50,
+			templateSize: 80 * gibibyte,
+			want:         80,
+		},
+		{
+			name:         "template size is rounded up",
+			diskSize:     50,
+			templateSize: 80*gibibyte + 1,
+			want:         81,
+		},
+		{
+			name:          "explicit size is rejected",
+			diskSize:      50,
+			templateSize:  80 * gibibyte,
+			explicitlySet: true,
+			wantErr:       "--disk-size 50 GiB is smaller than the selected template's minimum of 80 GiB; use --disk-size 80 or larger",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveTemplateDiskSize(tt.diskSize, tt.templateSize, tt.explicitlySet)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("ResolveTemplateDiskSize() error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveTemplateDiskSize() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("ResolveTemplateDiskSize() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/compute/instance/instance_create.go
+++ b/cmd/compute/instance/instance_create.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	exocmd "github.com/exoscale/cli/cmd"
+	"github.com/exoscale/cli/cmd/compute"
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
@@ -88,6 +89,38 @@ func (c *instanceCreateCmd) CmdRun(cmd *cobra.Command, _ []string) error { //nol
 		return err
 	}
 
+	templates, err := client.ListTemplates(ctx, v3.ListTemplatesWithVisibility(v3.ListTemplatesVisibility(c.TemplateVisibility)))
+	if err != nil {
+		return fmt.Errorf("error listing template with visibility %q: %w", c.TemplateVisibility, err)
+	}
+	template, err := templates.FindTemplate(c.Template)
+	if err != nil {
+		return fmt.Errorf(
+			"no template %q found with visibility %s in zone %s",
+			c.Template,
+			c.TemplateVisibility,
+			c.Zone,
+		)
+	}
+	diskSize, err := compute.ResolveTemplateDiskSize(
+		c.DiskSize,
+		template.Size,
+		cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.DiskSize)),
+	)
+	if err != nil {
+		return err
+	}
+	if diskSize != c.DiskSize {
+		fmt.Fprintf(
+			os.Stderr,
+			"warning: template %q requires at least %d GiB; increasing the default disk size from %d GiB to %d GiB\n",
+			template.Name,
+			diskSize,
+			c.DiskSize,
+			diskSize,
+		)
+	}
+
 	var sshKeys []v3.SSHKey
 	for _, sshkeyName := range c.SSHKeys {
 		sshKeys = append(sshKeys, v3.SSHKey{Name: sshkeyName})
@@ -104,13 +137,14 @@ func (c *instanceCreateCmd) CmdRun(cmd *cobra.Command, _ []string) error { //nol
 	}
 
 	instanceReq := v3.CreateInstanceRequest{
-		DiskSize:           c.DiskSize,
+		DiskSize:           diskSize,
 		PublicIPAssignment: publicIPAssignment,
 		TpmEnabled:         &c.TPM,
 		SecurebootEnabled:  &c.SecureBoot,
 		Labels:             c.Labels,
 		Name:               c.Name,
 		SSHKeys:            sshKeys,
+		Template:           &v3.Template{ID: template.ID},
 	}
 
 	if l := len(c.AntiAffinityGroups); l > 0 {
@@ -225,21 +259,6 @@ func (c *instanceCreateCmd) CmdRun(cmd *cobra.Command, _ []string) error { //nol
 
 		instanceReq.SSHKeys = []v3.SSHKey{{Name: sshKeyName}}
 	}
-
-	templates, err := client.ListTemplates(ctx, v3.ListTemplatesWithVisibility(v3.ListTemplatesVisibility(c.TemplateVisibility)))
-	if err != nil {
-		return fmt.Errorf("error listing template with visibility %q: %w", c.TemplateVisibility, err)
-	}
-	template, err := templates.FindTemplate(c.Template)
-	if err != nil {
-		return fmt.Errorf(
-			"no template %q found with visibility %s in zone %s",
-			c.Template,
-			c.TemplateVisibility,
-			c.Zone,
-		)
-	}
-	instanceReq.Template = &v3.Template{ID: template.ID}
 
 	if c.CloudInitFile != "" {
 		userData, err := userdata.GetUserDataFromFile(c.CloudInitFile, c.CloudInitCompress)

--- a/cmd/compute/instance_pool/instance_pool_create.go
+++ b/cmd/compute/instance_pool/instance_pool_create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	exocmd "github.com/exoscale/cli/cmd"
+	"github.com/exoscale/cli/cmd/compute"
 	"github.com/exoscale/cli/pkg/account"
 	"github.com/exoscale/cli/pkg/globalstate"
 	"github.com/exoscale/cli/pkg/output"
@@ -62,7 +63,7 @@ func (c *instancePoolCreateCmd) CmdPreRun(cmd *cobra.Command, args []string) err
 	return exocmd.CliCommandDefaultPreRun(c, cmd, args)
 }
 
-func (c *instancePoolCreateCmd) CmdRun(_ *cobra.Command, _ []string) error {
+func (c *instancePoolCreateCmd) CmdRun(cmd *cobra.Command, _ []string) error {
 
 	ctx := exocmd.GContext
 	client, err := exocmd.SwitchClientZoneV3(ctx, globalstate.EgoscaleV3Client, c.Zone)
@@ -70,11 +71,43 @@ func (c *instancePoolCreateCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
+	templates, err := client.ListTemplates(ctx, v3.ListTemplatesWithVisibility(v3.ListTemplatesVisibility(c.TemplateVisibility)))
+	if err != nil {
+		return fmt.Errorf("error listing template with visibility %q: %w", c.TemplateVisibility, err)
+	}
+	template, err := templates.FindTemplate(c.Template)
+	if err != nil {
+		return fmt.Errorf(
+			"no template %q found with visibility %s in zone %s",
+			c.Template,
+			c.TemplateVisibility,
+			c.Zone,
+		)
+	}
+	diskSize, err := compute.ResolveTemplateDiskSize(
+		c.DiskSize,
+		template.Size,
+		cmd.Flags().Changed(exocmd.MustCLICommandFlagName(c, &c.DiskSize)),
+	)
+	if err != nil {
+		return err
+	}
+	if diskSize != c.DiskSize {
+		fmt.Fprintf(
+			os.Stderr,
+			"warning: template %q requires at least %d GiB; increasing the default disk size from %d GiB to %d GiB\n",
+			template.Name,
+			diskSize,
+			c.DiskSize,
+			diskSize,
+		)
+	}
+
 	sshKey := &v3.SSHKey{Name: c.SSHKey}
 
 	instancePoolReq := v3.CreateInstancePoolRequest{
 		Description:    c.Description,
-		DiskSize:       c.DiskSize,
+		DiskSize:       diskSize,
 		Ipv6Enabled:    &c.IPv6,
 		InstancePrefix: c.InstancePrefix,
 		Labels:         c.Labels,
@@ -82,6 +115,7 @@ func (c *instancePoolCreateCmd) CmdRun(_ *cobra.Command, _ []string) error {
 		Name:           c.Name,
 		SSHKey:         sshKey,
 		Size:           c.Size,
+		Template:       &v3.Template{ID: template.ID},
 	}
 
 	if l := len(c.AntiAffinityGroups); l > 0 {
@@ -183,21 +217,6 @@ func (c *instancePoolCreateCmd) CmdRun(_ *cobra.Command, _ []string) error {
 	if instancePoolReq.SSHKey == nil && account.CurrentAccount.DefaultSSHKey != "" {
 		instancePoolReq.SSHKey = &v3.SSHKey{Name: account.CurrentAccount.DefaultSSHKey}
 	}
-
-	templates, err := client.ListTemplates(ctx, v3.ListTemplatesWithVisibility(v3.ListTemplatesVisibility(c.TemplateVisibility)))
-	if err != nil {
-		return fmt.Errorf("error listing template with visibility %q: %w", c.TemplateVisibility, err)
-	}
-	template, err := templates.FindTemplate(c.Template)
-	if err != nil {
-		return fmt.Errorf(
-			"no template %q found with visibility %s in zone %s",
-			c.Template,
-			c.TemplateVisibility,
-			c.Zone,
-		)
-	}
-	instancePoolReq.Template = &v3.Template{ID: template.ID}
 
 	if c.CloudInitFile != "" {
 		userData, err := userdata.GetUserDataFromFile(c.CloudInitFile, c.CloudInitCompress)


### PR DESCRIPTION
# Description

`compute instance create` and `compute instance-pool create` default to a 50 GiB disk, but some templates require a larger disk. Using such a template without `--disk-size` currently sends an invalid request.

This change resolves the selected template before creation and:

* keeps the requested disk size when it is large enough;
* increases the implicit 50 GiB default to the template size, rounded up to GiB, and prints a warning;
* rejects an explicitly configured disk size that is too small, preserving the user's requested value and returning an actionable error.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block, and add the Pull Request #number for each bit you add to the `CHANGELOG.md`)
* [x] Testing

## Testing

Tested from PR head in `ch-dk-2` with a 10 GiB Ubuntu template and an 80 GiB Anapaya template. All instances, pools, and temporary SSH keys created for these checks were deleted afterward.

### Default already large enough

The 50 GiB default is preserved without a warning for a 10 GiB template.

```console
$ ./bin/exo compute instance create --zone ch-dk-2 \
    --instance-type standard.tiny \
    --template 5b473841-fd33-4b88-bcfe-a776abf15034 \
    pr882-instance-default-small-20260803

Creating instance "pr882-instance-default-small-20260803"... 36s

| Name      | pr882-instance-default-small-20260803 |
| Template  | Linux Ubuntu 22.04 LTS 64-bit         |
| Disk Size | 50 GiB                                |
| State     | running                               |
```

### Default increased to template size

The implicit 50 GiB default is increased to 80 GiB and the adjustment is reported on stderr.

```console
$ ./bin/exo compute instance create --zone ch-dk-2 \
    --template 774dd37a-287c-40f0-9e66-343e7b9c9bff \
    pr882-instance-default-large-20260803

warning: template "Anapaya Appliance v0.41.1-1" requires at least 80 GiB; increasing the default disk size from 50 GiB to 80 GiB
Creating instance "pr882-instance-default-large-20260803"... 1m31s

| Name      | pr882-instance-default-large-20260803 |
| Template  | Anapaya Appliance v0.41.1-1           |
| Disk Size | 80 GiB                                |
| State     | running                               |
```

### Explicit sufficient size preserved

An explicit size that can contain the template is used unchanged.

```console
$ ./bin/exo compute instance create --zone ch-dk-2 \
    --instance-type standard.tiny \
    --disk-size 20 \
    --template 5b473841-fd33-4b88-bcfe-a776abf15034 \
    pr882-instance-explicit-valid-20260803

Creating instance "pr882-instance-explicit-valid-20260803"... 21s

| Name      | pr882-instance-explicit-valid-20260803 |
| Template  | Linux Ubuntu 22.04 LTS 64-bit          |
| Disk Size | 20 GiB                                 |
| State     | running                                |
```

### Explicit undersized value rejected

An explicit value smaller than the selected template fails before creating a resource.

```console
$ ./bin/exo compute instance create --zone ch-dk-2 \
    --disk-size 50 \
    --template 774dd37a-287c-40f0-9e66-343e7b9c9bff \
    pr882-instance-explicit-small-20260803

error: --disk-size 50 GiB is smaller than the selected template's minimum of 80 GiB; use --disk-size 80 or larger
```

The instance-pool command returns the same error before creation:

```console
$ ./bin/exo compute instance-pool create --zone ch-dk-2 \
    --disk-size 50 \
    --template 774dd37a-287c-40f0-9e66-343e7b9c9bff \
    pr882-pool-explicit-small-20260803

error: --disk-size 50 GiB is smaller than the selected template's minimum of 80 GiB; use --disk-size 80 or larger
```

### Instance Pool default increased

The same default adjustment is applied when creating an Instance Pool.

```console
$ ./bin/exo compute instance-pool create --zone ch-dk-2 \
    --ssh-key pr882-pool-key-20260803 \
    --template 774dd37a-287c-40f0-9e66-343e7b9c9bff \
    pr882-pool-default-large-20260803

warning: template "Anapaya Appliance v0.41.1-1" requires at least 80 GiB; increasing the default disk size from 50 GiB to 80 GiB
Creating Instance Pool "pr882-pool-default-large-20260803"... 2m7s

| Name      | pr882-pool-default-large-20260803 |
| Template  | Anapaya Appliance v0.41.1-1       |
| Size      | 1                                 |
| Disk Size | 80 GiB                            |
| State     | running                           |
```

---

> [!NOTE]
> AI assistance: changelog entry, test scaffolding, PR description.