### PR TITLE
build: update Go to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/exoscale/cli
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.1

--- a/tests/integ/go.mod
+++ b/tests/integ/go.mod
@@ -1,6 +1,6 @@
 module github.com/exoscale/cli/internal/integ
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.1


### PR DESCRIPTION
# Description

Update the root and integration module toolchain directives to Go 1.26.6. This ensures CI and release artifacts use the latest standard-library security fixes and unblocks release PR #897.

Go 1.26.6 fixes the reachable standard-library vulnerabilities reported by `govulncheck`:

* [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218)
* [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090)
* [GO-2026-6088](https://pkg.go.dev/vuln/GO-2026-6088)
* [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972)
* [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026)

## Checklist
(For exoscale contributors)

* [x] Changelog updated (not required for this build-only patch)
* [x] Testing

## Testing

<details>
<summary>Commands and results</summary>

All local commands used the official Go 1.26.6 toolchain through `GOTOOLCHAIN=go1.26.6`.

* Before: `govulncheck ./...` with CI Go 1.26.5 reported five reachable standard-library vulnerabilities in [run 31806335572](https://github.com/exoscale/cli/actions/runs/31806335572).
* After: `govulncheck ./...` in both modules reported `No vulnerabilities found`.
* `go fmt ./...`, `go mod tidy`, `go mod vendor`, and `go mod verify`: passed with no generated dependency diff.
* `go vet ./...`, `make lint`, and `golangci-lint run --timeout 4m`: passed with 0 lint issues.
* `make build` and `make test-verbose`: passed, including race-enabled unit tests.
* `(cd tests/e2e && go test -v)`: all no-API scenarios passed.
* In `tests/integ`, `go test ./...` and `go test -tags=integration_api -run "^$" ./...` passed.

</details>

---
> [!NOTE]
> AI assistance: dependency analysis, PR description.