### PR TITLE
fix compute instance show: display multiple ssh keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@
 
 ### Bug fixes
 
+
 - compute: allow instance and instance pool operations to use template IDs omitted from template lists (#888)
 - compute: honor the selected template's minimum disk size when creating instances and instance pools (#882)
 - instance create: apply delete protection in the instance's zone, fixing a wrong-zone "Not Found" error when creating protected instances outside the default zone (#879)
+- instance show: correctly show multiple ssh keys
 - sks cluster update: fix oidc config drop (#881)
 
 ### Improvements⏎

--- a/cmd/compute/instance/instance_show.go
+++ b/cmd/compute/instance/instance_show.go
@@ -33,7 +33,7 @@ type InstanceShowOutput struct {
 	PublicIPAssignment    v3.PublicIPAssignment `json:"public-ip" outputLabel:"Public IP"`
 	IPAddress             string                `json:"ip_address"`
 	IPv6Address           string                `json:"ipv6_address" outputLabel:"IPv6 Address"`
-	SSHKey                string                `json:"ssh_key"`
+	SSHKeys               []string              `json:"ssh_keys"`
 	DiskSize              string                `json:"disk_size"`
 	State                 v3.InstanceState      `json:"state"`
 	Labels                map[string]string     `json:"labels"`
@@ -115,9 +115,9 @@ func (c *instanceShowCmd) CmdRun(cmd *cobra.Command, _ []string) error {
 		ipV6 = &parsed // only assign pointer if it's a valid IP
 	}
 
-	var sshKeyName *string
+	sshKeys := instance.SSHKeys
 	if instance.SSHKey != nil {
-		sshKeyName = &instance.SSHKey.Name
+		sshKeys = append(sshKeys, *instance.SSHKey)
 	}
 
 	out := InstanceShowOutput{
@@ -137,7 +137,7 @@ func (c *instanceShowCmd) CmdRun(cmd *cobra.Command, _ []string) error {
 		}(),
 		Name:            instance.Name,
 		PrivateNetworks: make([]string, 0),
-		SSHKey:          utils.DefaultString(sshKeyName, "-"),
+		SSHKeys:         make([]string, 0),
 		SecurityGroups:  make([]string, 0),
 		SecureBoot:      *instance.SecurebootEnabled,
 		Tpm:             *instance.TpmEnabled,
@@ -213,6 +213,10 @@ func (c *instanceShowCmd) CmdRun(cmd *cobra.Command, _ []string) error {
 			}
 			out.PrivateNetworks = append(out.PrivateNetworks, foundPN.Name)
 		}
+	}
+
+	for _, k := range instance.SSHKeys {
+		out.SSHKeys = append(out.SSHKeys, k.Name)
 	}
 
 	if instance.SecurityGroups != nil {

--- a/cmd/compute/instance/instance_show.go
+++ b/cmd/compute/instance/instance_show.go
@@ -115,11 +115,6 @@ func (c *instanceShowCmd) CmdRun(cmd *cobra.Command, _ []string) error {
 		ipV6 = &parsed // only assign pointer if it's a valid IP
 	}
 
-	sshKeys := instance.SSHKeys
-	if instance.SSHKey != nil {
-		sshKeys = append(sshKeys, *instance.SSHKey)
-	}
-
 	out := InstanceShowOutput{
 		AntiAffinityGroups: make([]string, 0),
 		CreationDate:       instance.CreatedAT.String(),


### PR DESCRIPTION
# Description
The cli (during compute instance show) was still using the deprecated `sshKey` fieldas the source of truth while nowadays it's `sshKeys` (plural) that needs to be used as an instance can have multiple ssh keys 

Creation was already working fine 

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block, and add the Pull Request #number for each bit you add to the `CHANGELOG.md`)
* [ ] Testing

## Testing

Before
```console
❯ exo c i create test-with-ssh-keys --ssh-key k1 --ssh-key k2 --ssh-key k3
 ✔ Creating instance "test-with-ssh-keys"... 24s
┼─────────────────────────────────────────┼──────────────────────────────────────┼
│            COMPUTE INSTANCE             │                                      │
┼─────────────────────────────────────────┼──────────────────────────────────────┼
│ ID                                      │ ad37e967-765d-4071-b99b-3c256baf5bdd │
│ Name                                    │ test-with-ssh-keys                   │
│ Creation Date                           │ 2026-08-19 07:50:20 +0000 UTC        │
│ Instance Type                           │ standard.medium                      │
│ Template                                │ Linux Ubuntu 24.04 LTS 64-bit        │
│ Zone                                    │ ch-gva-2                             │
│ Anti-Affinity Groups                    │ n/a                                  │
│ Deploy Target                           │ -                                    │
│ Security Groups                         │ default                              │
│ Private Instance                        │ No                                   │
│ Private Networks                        │ n/a                                  │
│ Elastic IPs                             │ n/a                                  │
│ Public IP                               │ inet4                                │
│ IP Address                              │ 151.145.196.141                      │
│ IPv6 Address                            │ -                                    │
│ SSH Key                                 │ k1                                   │
│ Disk Size                               │ 50 GiB                               │
│ State                                   │ running                              │
│ Labels                                  │ n/a                                  │
│ Secure Boot                             │ false                                │
│ Tpm                                     │ false                                │
│ Reverse DNS                             │                                      │
│ Application-Consistent Snapshot enabled │ false                                │
┼─────────────────────────────────────────┼──────────────────────────────────────┼
```

after
```console
❯ go run . c i show test-with-ssh-keys
┼─────────────────────────────────────────┼──────────────────────────────────────┼
│            COMPUTE INSTANCE             │                                      │
┼─────────────────────────────────────────┼──────────────────────────────────────┼
│ ID                                      │ ad37e967-765d-4071-b99b-3c256baf5bdd │
│ Name                                    │ test-with-ssh-keys                   │
│ Creation Date                           │ 2026-08-19 07:50:20 +0000 UTC        │
│ Instance Type                           │ standard.medium                      │
│ Template                                │ Linux Ubuntu 24.04 LTS 64-bit        │
│ Zone                                    │ ch-gva-2                             │
│ Anti-Affinity Groups                    │ n/a                                  │
│ Deploy Target                           │ -                                    │
│ Security Groups                         │ default                              │
│ Private Instance                        │ No                                   │
│ Private Networks                        │ n/a                                  │
│ Elastic IPs                             │ n/a                                  │
│ Public IP                               │ inet4                                │
│ IP Address                              │ 151.145.196.141                      │
│ IPv6 Address                            │ -                                    │
│ SSH Keys                                │ k1                                   │
│                                         │ k2                                   │
│                                         │ k3                                   │
│ Disk Size                               │ 50 GiB                               │
│ State                                   │ running                              │
│ Labels                                  │ n/a                                  │
│ Secure Boot                             │ false                                │
│ Tpm                                     │ false                                │
│ Reverse DNS                             │                                      │
│ Application-Consistent Snapshot enabled │ false                                │
┼─────────────────────────────────────────┼──────────────────────────────────────┼
```
