### PR TITLE
feat: use public ip assignment for instancepool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Breaking changes
+- instancepool create: use public ip assignment - #901
+
+### Features
+### Bug fixes
+### Improvements
+
+
 ## 1.98.0
 
 ### Features

--- a/cmd/compute/instance_pool/instance_pool_create.go
+++ b/cmd/compute/instance_pool/instance_pool_create.go
@@ -3,6 +3,7 @@ package instance_pool
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -31,7 +32,7 @@ type instancePoolCreateCmd struct {
 	Description        string            `cli-usage:"Instance Pool description"`
 	DiskSize           int64             `cli-usage:"managed Compute instances disk size"`
 	ElasticIPs         []string          `cli-flag:"elastic-ip" cli-short:"e" cli-usage:"managed Compute instances Elastic IP ADDRESS|ID (can be specified multiple times)"`
-	IPv6               bool              `cli-flag:"ipv6" cli-short:"6" cli-usage:"enable IPv6 on managed Compute instances"`
+	PublicIPAssignment string            `cli-flag:"public-ip" cli-usage:"Configures public IP assignment of the instance pool (none|inet4|dual). (default: inet4)"`
 	InstancePrefix     string            `cli-usage:"string to prefix managed Compute instances names with"`
 	InstanceType       string            `cli-usage:"managed Compute instances type (format: [FAMILY.]SIZE)"`
 	Labels             map[string]string `cli-flag:"label" cli-usage:"Instance Pool label (format: key=value)"`
@@ -71,6 +72,18 @@ func (c *instancePoolCreateCmd) CmdRun(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	publicIPAssignment := v3.CreateInstancePoolRequestPublicIPAssignmentInet4
+	if c.PublicIPAssignment != "" {
+		if !slices.Contains([]v3.CreateInstancePoolRequestPublicIPAssignment{
+			v3.CreateInstancePoolRequestPublicIPAssignmentDual,
+			v3.CreateInstancePoolRequestPublicIPAssignmentInet4,
+			v3.CreateInstancePoolRequestPublicIPAssignmentNone,
+		}, v3.CreateInstancePoolRequestPublicIPAssignment(c.PublicIPAssignment)) {
+			return fmt.Errorf("error invalid public-ip: %s", c.PublicIPAssignment)
+		}
+		publicIPAssignment = v3.CreateInstancePoolRequestPublicIPAssignment(c.PublicIPAssignment)
+	}
+
 	template, err := compute.ResolveTemplate(ctx, client, c.Template, c.TemplateVisibility, c.Zone)
 	if err != nil {
 		return err
@@ -97,16 +110,16 @@ func (c *instancePoolCreateCmd) CmdRun(cmd *cobra.Command, _ []string) error {
 	sshKey := &v3.SSHKey{Name: c.SSHKey}
 
 	instancePoolReq := v3.CreateInstancePoolRequest{
-		Description:    c.Description,
-		DiskSize:       diskSize,
-		Ipv6Enabled:    &c.IPv6,
-		InstancePrefix: c.InstancePrefix,
-		Labels:         c.Labels,
-		MinAvailable:   c.MinAvailable,
-		Name:           c.Name,
-		SSHKey:         sshKey,
-		Size:           c.Size,
-		Template:       &v3.Template{ID: template.ID},
+		Description:        c.Description,
+		DiskSize:           diskSize,
+		PublicIPAssignment: publicIPAssignment,
+		InstancePrefix:     c.InstancePrefix,
+		Labels:             c.Labels,
+		MinAvailable:       c.MinAvailable,
+		Name:               c.Name,
+		SSHKey:             sshKey,
+		Size:               c.Size,
+		Template:           &v3.Template{ID: template.ID},
 	}
 
 	if l := len(c.AntiAffinityGroups); l > 0 {

--- a/cmd/compute/instance_pool/instance_pool_show.go
+++ b/cmd/compute/instance_pool/instance_pool_show.go
@@ -16,24 +16,25 @@ import (
 )
 
 type instancePoolShowOutput struct {
-	ID                 string            `json:"id"`
-	Name               string            `json:"name"`
-	Description        string            `json:"description"`
-	InstanceType       string            `json:"instance_type"`
-	Template           string            `json:"template"`
-	Zone               string            `json:"zone"`
-	AntiAffinityGroups []string          `json:"anti_affinity_groups" outputLabel:"Anti-Affinity Groups"`
-	SecurityGroups     []string          `json:"security_groups"`
-	PrivateNetworks    []string          `json:"private_networks"`
-	ElasticIPs         []string          `json:"elastic_ips" outputLabel:"Elastic IPs"`
-	IPv6               bool              `json:"ipv6" outputLabel:"IPv6"`
-	SSHKey             string            `json:"ssh_key"`
-	Size               int64             `json:"size"`
-	DiskSize           string            `json:"disk_size"`
-	InstancePrefix     string            `json:"instance_prefix"`
-	State              string            `json:"state"`
-	Labels             map[string]string `json:"labels"`
-	Instances          []string          `json:"instances"`
+	ID                 string                `json:"id"`
+	Name               string                `json:"name"`
+	Description        string                `json:"description"`
+	InstanceType       string                `json:"instance_type"`
+	Template           string                `json:"template"`
+	Zone               string                `json:"zone"`
+	AntiAffinityGroups []string              `json:"anti_affinity_groups" outputLabel:"Anti-Affinity Groups"`
+	SecurityGroups     []string              `json:"security_groups"`
+	PrivateNetworks    []string              `json:"private_networks"`
+	ElasticIPs         []string              `json:"elastic_ips" outputLabel:"Elastic IPs"`
+	IPv6               bool                  `json:"ipv6" outputLabel:"IPv6"`
+	PublicIPAssignment v3.PublicIPAssignment `json:"public-ip" outputLabel:"Public IP"`
+	SSHKey             string                `json:"ssh_key"`
+	Size               int64                 `json:"size"`
+	DiskSize           string                `json:"disk_size"`
+	InstancePrefix     string                `json:"instance_prefix"`
+	State              string                `json:"state"`
+	Labels             map[string]string     `json:"labels"`
+	Instances          []string              `json:"instances"`
 }
 
 func (o *instancePoolShowOutput) Type() string { return "Instance Pool" }
@@ -104,6 +105,7 @@ func (c *instancePoolShowCmd) CmdRun(cmd *cobra.Command, _ []string) error {
 		ElasticIPs:         make([]string, 0),
 		ID:                 instancePool.ID.String(),
 		IPv6:               utils.DefaultBool(instancePool.Ipv6Enabled, false),
+		PublicIPAssignment: instancePool.PublicIPAssignment,
 		InstancePrefix:     instancePool.InstancePrefix,
 		Instances:          make([]string, 0),
 		Labels: func() (v map[string]string) {


### PR DESCRIPTION
# Description
use public ip assigmnet (dual, inet4, none) for instancepool (cf. `instance` and `nodepool`)

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block, and add the Pull Request #number for each bit you add to the `CHANGELOG.md`)
* [x] Testing

## Testing
```diff
$ go run main.go compute instance-pool create test-dual --disk-size 60 --public-ip dual --size 2
 ✔ Creating Instance Pool "test-dual"... 36s
┼──────────────────────┼──────────────────────────────────────┼
│    INSTANCE POOL     │                                      │
┼──────────────────────┼──────────────────────────────────────┼
│ ID                   │ d522190d-7cc1-47a8-9638-ae7e1ec35dc9 │
│ Name                 │ test-dual                            │
│ Description          │                                      │
│ Instance Type        │ standard.medium                      │
│ Template             │ Linux Ubuntu 22.04 LTS 64-bit        │
│ Zone                 │ ch-gva-2                             │
│ Anti-Affinity Groups │ n/a                                  │
│ Security Groups      │ n/a                                  │
│ Private Networks     │ n/a                                  │
│ Elastic IPs          │ n/a                                  │
│ IPv6                 │ true                                 │
+ │ Public IP            │ dual                                 │
│ SSH Key              │ -                                    │
│ Size                 │ 2                                    │
│ Disk Size            │ 60 GiB                               │
│ Instance Prefix      │ pool                                 │
│ State                │ scaling-up                           │
│ Labels               │ n/a                                  │
│ Instances            │ pool-d5221-hcugg                     │
│                      │ pool-d5221-xzxoj                     │
┼──────────────────────┼──────────────────────────────────────┼
$ go run main.go compute instance-pool create test-inet4 --disk-size 60 --public-ip inet4 --size 2
 ✔ Creating Instance Pool "test-inet4"... 33s
┼──────────────────────┼──────────────────────────────────────┼
│    INSTANCE POOL     │                                      │
┼──────────────────────┼──────────────────────────────────────┼
│ ID                   │ 52563046-ea19-4f53-92af-944658ef661f │
│ Name                 │ test-inet4                           │
│ Description          │                                      │
│ Instance Type        │ standard.medium                      │
│ Template             │ Linux Ubuntu 22.04 LTS 64-bit        │
│ Zone                 │ ch-gva-2                             │
│ Anti-Affinity Groups │ n/a                                  │
│ Security Groups      │ n/a                                  │
│ Private Networks     │ n/a                                  │
│ Elastic IPs          │ n/a                                  │
│ IPv6                 │ false                                │
+ │ Public IP            │ inet4                                │
│ SSH Key              │ -                                    │
│ Size                 │ 2                                    │
│ Disk Size            │ 60 GiB                               │
│ Instance Prefix      │ pool                                 │
│ State                │ scaling-up                           │
│ Labels               │ n/a                                  │
│ Instances            │ pool-52563-jjnbm                     │
│                      │ pool-52563-souge                     │
┼──────────────────────┼──────────────────────────────────────┼
$ go run main.go compute instance-pool create test-none --disk-size 60 --public-ip none --size 2
 ✔ Creating Instance Pool "test-none"... 30s
┼──────────────────────┼──────────────────────────────────────┼
│    INSTANCE POOL     │                                      │
┼──────────────────────┼──────────────────────────────────────┼
│ ID                   │ ba93cc68-5cb2-49dc-86cf-bccba9392677 │
│ Name                 │ test-none                            │
│ Description          │                                      │
│ Instance Type        │ standard.medium                      │
│ Template             │ Linux Ubuntu 22.04 LTS 64-bit        │
│ Zone                 │ ch-gva-2                             │
│ Anti-Affinity Groups │ n/a                                  │
│ Security Groups      │ n/a                                  │
│ Private Networks     │ n/a                                  │
│ Elastic IPs          │ n/a                                  │
│ IPv6                 │ false                                │
+ │ Public IP            │ none                                 │
│ SSH Key              │ -                                    │
│ Size                 │ 2                                    │
│ Disk Size            │ 60 GiB                               │
│ Instance Prefix      │ pool                                 │
│ State                │ scaling-up                           │
│ Labels               │ n/a                                  │
│ Instances            │ pool-ba93c-nciaq                     │
│                      │ pool-ba93c-mvixw                     │
┼──────────────────────┼──────────────────────────────────────┼
$ go run main.go compute instance-pool create test-default --disk-size 60 --size 2
 ✔ Creating Instance Pool "test-default"... 42s
┼──────────────────────┼──────────────────────────────────────┼
│    INSTANCE POOL     │                                      │
┼──────────────────────┼──────────────────────────────────────┼
│ ID                   │ a5cd3fdc-79d3-4ab6-bd3a-a67e30517db0 │
│ Name                 │ test-default                         │
│ Description          │                                      │
│ Instance Type        │ standard.medium                      │
│ Template             │ Linux Ubuntu 22.04 LTS 64-bit        │
│ Zone                 │ ch-gva-2                             │
│ Anti-Affinity Groups │ n/a                                  │
│ Security Groups      │ n/a                                  │
│ Private Networks     │ n/a                                  │
│ Elastic IPs          │ n/a                                  │
│ IPv6                 │ false                                │
+ │ Public IP            │ inet4                                │
│ SSH Key              │ -                                    │
│ Size                 │ 2                                    │
│ Disk Size            │ 60 GiB                               │
│ Instance Prefix      │ pool                                 │
│ State                │ scaling-up                           │
│ Labels               │ n/a                                  │
│ Instances            │ pool-a5cd3-bejdn                     │
│                      │ pool-a5cd3-swcgp                     │
┼──────────────────────┼──────────────────────────────────────┼
```